### PR TITLE
Fix compatible issue with Pulsar 2.6.0

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTConsumer.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTConsumer.java
@@ -73,8 +73,9 @@ public class MQTTConsumer extends Consumer {
         return sendMessages(entries, batchSizes, null, totalMessages, totalBytes, 0, redeliveryTracker);
     }
 
-    public ChannelPromise sendMessages(List<Entry> entries, EntryBatchSizes batchSizes, EntryBatchIndexesAcks batchIndexesAcks, int totalMessages,
-                                       long totalBytes, long totalChunkedMessages, RedeliveryTracker redeliveryTracker) {
+    public ChannelPromise sendMessages(List<Entry> entries, EntryBatchSizes batchSizes,
+           EntryBatchIndexesAcks batchIndexesAcks, int totalMessages, long totalBytes, long totalChunkedMessages,
+           RedeliveryTracker redeliveryTracker) {
         ChannelPromise promise = cnx.ctx().newPromise();
         MESSAGE_PERMITS_UPDATER.addAndGet(this, -totalMessages);
         for (Entry entry : entries) {


### PR DESCRIPTION
Since there are some features introduce some changes in the Consumer. With this PR, mop can be used on Pulsar 2.5.x and 2.6.0.