### PR TITLE
Upgrade pulsar broker version to 2.6.1

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
@@ -16,6 +16,7 @@ package io.streamnative.pulsar.handlers.mqtt.utils;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.namespace.LookupOptions;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.Topic;
@@ -31,7 +32,7 @@ public class PulsarTopicUtils {
 
     public static CompletableFuture<Optional<Topic>> getTopicReference(PulsarService pulsarService, String topicName) {
         final TopicName topic = TopicName.get(topicName);
-        return pulsarService.getNamespaceService().getBrokerServiceUrlAsync(topic, false)
+        return pulsarService.getNamespaceService().getBrokerServiceUrlAsync(topic, LookupOptions.builder().authoritative(false).loadTopicsInBundle(false).build())
                 .thenCompose(lookupOp -> pulsarService.getBrokerService().getTopic(topic.toString(), true));
     }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
@@ -32,7 +32,8 @@ public class PulsarTopicUtils {
 
     public static CompletableFuture<Optional<Topic>> getTopicReference(PulsarService pulsarService, String topicName) {
         final TopicName topic = TopicName.get(topicName);
-        return pulsarService.getNamespaceService().getBrokerServiceUrlAsync(topic, LookupOptions.builder().authoritative(false).loadTopicsInBundle(false).build())
+        return pulsarService.getNamespaceService().getBrokerServiceUrlAsync(topic,
+                LookupOptions.builder().authoritative(false).loadTopicsInBundle(false).build())
                 .thenCompose(lookupOp -> pulsarService.getBrokerService().getTopic(topic.toString(), true));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <lombok.version>1.18.4</lombok.version>
         <mockito.version>2.22.0</mockito.version>
         <testng.version>6.14.3</testng.version>
-        <pulsar.version>2.6.0-sn-4</pulsar.version>
+        <pulsar.version>2.6.1</pulsar.version>
         <mqtt.codec.version>4.1.49.Final</mqtt.codec.version>
         <commons-lang3.version>3.4</commons-lang3.version>
         <log4j2.version>2.10.0</log4j2.version>


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

Fixes: #21 

## Motivation

Currently, mop uses the 2.6.0 version, which causes compatibility problems when users use the 2.6.1 version, resulting in unavailability.

## Modifications

Upgrade pulsar broker version to 2.6.1