### PR TITLE
Correct references to AoP and AMQP -> MoP and MQTT

### DIFF
--- a/.github/workflows/release-note.yml
+++ b/.github/workflows/release-note.yml
@@ -1,4 +1,4 @@
-name: aop Release Notes
+name: MoP Release Notes
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 -->
 
-[![LICENSE](https://img.shields.io/hexpm/l/pulsar.svg)](https://github.com/streamnative/aop/blob/master/LICENSE)
+[![LICENSE](https://img.shields.io/hexpm/l/pulsar.svg)](https://github.com/streamnative/mop/blob/master/LICENSE)
 
 # MQTT on Pulsar (MoP)
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTProtocolHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTProtocolHandler.java
@@ -98,14 +98,14 @@ public class MQTTProtocolHandler implements ProtocolHandler {
             ProxyService proxyService = new ProxyService(proxyConfig, brokerService.getPulsar());
             try {
                 proxyService.start();
-                log.info("Start amqp proxy service at port: {}", proxyConfig.getMqttProxyPort());
+                log.info("Start MQTT proxy service at port: {}", proxyConfig.getMqttProxyPort());
             } catch (Exception e) {
-                log.error("Failed to start amqp proxy service.");
+                log.error("Failed to start MQTT proxy service.");
             }
         }
 
 
-        log.info("Starting AmqpProtocolHandler, aop version is: '{}'", MopVersion.getVersion());
+        log.info("Starting MqttProtocolHandler, MoP version is: '{}'", MopVersion.getVersion());
         log.info("Git Revision {}", MopVersion.getGitSha());
         log.info("Built by {} on {} at {}",
                 MopVersion.getBuildUser(),

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MessagePublishContext.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MessagePublishContext.java
@@ -86,7 +86,7 @@ public final class MessagePublishContext implements PublishContext {
     }
 
     /**
-     * publish amqp message to pulsar topic, no batch.
+     * publish mqtt message to pulsar topic, no batch.
      */
     public static CompletableFuture<PositionImpl> publishMessages(Message<byte[]> message, Topic topic) {
         CompletableFuture<PositionImpl> future = new CompletableFuture<>();


### PR DESCRIPTION
Fix some names that misreference AoP probably left behind when scaffolding the project.