### PR TITLE
Handle mqtt topic name with /

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/ProtocolMethodProcessorImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/ProtocolMethodProcessorImpl.java
@@ -413,7 +413,7 @@ public class ProtocolMethodProcessorImpl implements ProtocolMethodProcessor {
 
         for (MqttTopicSubscription req : msg.payload().topicSubscriptions()) {
             MqttQoS qos = req.qualityOfService();
-            ackTopics.add(new MqttTopicSubscription(req.topicName(), qos));
+            ackTopics.add(new MqttTopicSubscription(PulsarTopicUtils.getPulsarTopicName(req.topicName()), qos));
         }
         return ackTopics;
     }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
@@ -15,6 +15,8 @@ package io.streamnative.pulsar.handlers.mqtt.utils;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.namespace.LookupOptions;
 import org.apache.pulsar.broker.service.BrokerServiceException;
@@ -31,7 +33,7 @@ import org.apache.pulsar.common.naming.TopicName;
 public class PulsarTopicUtils {
 
     public static CompletableFuture<Optional<Topic>> getTopicReference(PulsarService pulsarService, String topicName) {
-        final TopicName topic = TopicName.get(topicName);
+        final TopicName topic = TopicName.get(getPulsarTopicName(topicName));
         return pulsarService.getNamespaceService().getBrokerServiceUrlAsync(topic,
                 LookupOptions.builder().authoritative(false).loadTopicsInBundle(false).build())
                 .thenCompose(lookupOp -> pulsarService.getBrokerService().getTopic(topic.toString(), true));
@@ -66,5 +68,9 @@ public class PulsarTopicUtils {
             }
         });
         return promise;
+    }
+
+    public static String getPulsarTopicName(String mqttTopicName) {
+        return StringUtils.strip(mqttTopicName, "/");
     }
 }

--- a/mqtt-impl/src/test/java/io/streamnative/pulsar/handlers/mqtt/untils/PulsarTopicUtilsTest.java
+++ b/mqtt-impl/src/test/java/io/streamnative/pulsar/handlers/mqtt/untils/PulsarTopicUtilsTest.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.untils;
+
+import io.streamnative.pulsar.handlers.mqtt.utils.PulsarTopicUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test for the {@link PulsarTopicUtils}.
+ */
+public class PulsarTopicUtilsTest {
+
+    @Test
+    public void testMqttTopicNameToPulsarTopicName() {
+        String t0 = "/aaa/bbb/ccc";
+        Assert.assertEquals(PulsarTopicUtils.getPulsarTopicName(t0), "aaa/bbb/ccc");
+        t0 = "aaa/bbb/ccc/";
+        Assert.assertEquals(PulsarTopicUtils.getPulsarTopicName(t0), "aaa/bbb/ccc");
+        t0 = "/aaa/bbb/ccc/";
+        Assert.assertEquals(PulsarTopicUtils.getPulsarTopicName(t0), "aaa/bbb/ccc");
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/SimpleIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/SimpleIntegrationTest.java
@@ -59,9 +59,18 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         };
     }
 
-    @Test
-    public void testSimpleMqttPubAndSubQos0() throws Exception {
-        final String topicName = "persistent://public/default/qos0";
+    @DataProvider(name = "mqttTopicNames")
+    public Object[][] mqttTopicNames() {
+        return new Object[][] {
+                { "public/default/t0" },
+                { "/public/default/t0" },
+                { "public/default/t0/" },
+                { "/public/default/t0/" }
+        };
+    }
+
+    @Test(dataProvider = "mqttTopicNames")
+    public void testSimpleMqttPubAndSubQos0(String topicName) throws Exception {
         MQTT mqtt = new MQTT();
         mqtt.setHost("127.0.0.1", getMqttBrokerPortList().get(0));
         BlockingConnection connection = mqtt.blockingConnection();
@@ -76,9 +85,8 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         connection.disconnect();
     }
 
-    @Test
-    public void testSimpleMqttPubAndSubQos1() throws Exception {
-        final String topicName = "persistent://public/default/qos1";
+    @Test(dataProvider = "mqttTopicNames")
+    public void testSimpleMqttPubAndSubQos1(String topicName) throws Exception {
         MQTT mqtt = new MQTT();
         mqtt.setHost("127.0.0.1", getMqttBrokerPortList().get(0));
         BlockingConnection connection = mqtt.blockingConnection();


### PR DESCRIPTION
### Motivation

Strip the mqtt topic name with "/" since the topic name can't used by Pulsar but it's a more common use case in mqtt(topic name start with "/")

### Tests

Add new tests for cover the different topic name cases with "/"