### PR TITLE
Change Pulsar dependency to be provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
             <groupId>org.apache.pulsar</groupId>
             <artifactId>pulsar-broker</artifactId>
             <version>${pulsar.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Pulsar classes will be provided at runtime.
Not including them in the NAR reduces the archive size from ~130MB to
~5MB.