### PR TITLE
[Build] Fix the dependencies bug caused by pulsar-broker and testmocks

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - master
+      - branch-*
 
 jobs:
   build:

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.pulsar</groupId>
+            <groupId>io.streamnative</groupId>
             <artifactId>pulsar-broker</artifactId>
             <version>${pulsar.version}</version>
             <scope>provided</scope>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -35,13 +35,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.pulsar</groupId>
+            <groupId>io.streamnative</groupId>
             <artifactId>testmocks</artifactId>
             <version>${pulsar.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.pulsar</groupId>
+            <groupId>io.streamnative</groupId>
             <artifactId>pulsar-broker</artifactId>
             <version>${pulsar.version}</version>
             <type>test-jar</type>


### PR DESCRIPTION
The latest artifacts of pulsar-broker and testmocks have been move to Maven Central. This PR fix the dependency bug.