### PR TITLE
Support multiple levels topic name

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -12,7 +12,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v1
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/AbstractQosPublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/AbstractQosPublishHandler.java
@@ -42,7 +42,8 @@ public abstract class AbstractQosPublishHandler implements QosPublishHandler {
     }
 
     protected CompletableFuture<Optional<Topic>> getTopicReference(MqttPublishMessage msg) {
-        return PulsarTopicUtils.getTopicReference(pulsarService, msg.variableHeader().topicName());
+        return PulsarTopicUtils.getTopicReference(pulsarService, msg.variableHeader().topicName(),
+                configuration.getDefaultTenant(), configuration.getDefaultNamespace());
     }
 
     protected CompletableFuture<PositionImpl> writeToPulsarTopic(MqttPublishMessage msg) {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTProtocolHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTProtocolHandler.java
@@ -100,7 +100,7 @@ public class MQTTProtocolHandler implements ProtocolHandler {
             proxyConfig.setMqttHeartBeat(mqttConfig.getHeartBeat());
             proxyConfig.setMqttProxyPort(mqttConfig.getMqttProxyPort());
             proxyConfig.setBrokerServiceURL("pulsar://"
-                    + ServiceConfigurationUtils.getAppliedAdvertisedAddress(mqttConfig)
+                    + ServiceConfigurationUtils.getAppliedAdvertisedAddress(mqttConfig, true)
                     + ":" + mqttConfig.getBrokerServicePort().get());
             proxyConfig.setMqttAuthenticationEnabled(mqttConfig.isMqttAuthenticationEnabled());
             proxyConfig.setMqttAuthenticationMethods(mqttConfig.getMqttAuthenticationMethods());

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/ProxyConfiguration.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/ProxyConfiguration.java
@@ -97,9 +97,24 @@ public class ProxyConfiguration {
         doc = "The authentication plugin used by the Pulsar proxy to authenticate with Pulsar brokers"
     )
     private String brokerClientAuthenticationPlugin;
+
     @FieldContext(
         category = CATEGORY_CLIENT_AUTHENTICATION,
         doc = "The authentication parameters used by the Pulsar proxy to authenticate with Pulsar brokers"
     )
     private String brokerClientAuthenticationParameters;
+
+    @FieldContext(
+            category = CATEGORY_MQTT,
+            required = true,
+            doc = "Default Pulsar tenant that the MQTT server used."
+    )
+    private String defaultTenant = "public";
+
+    @FieldContext(
+            category = CATEGORY_MQTT,
+            required = true,
+            doc = "Default Pulsar namespace that the MQTT server used."
+    )
+    private String defaultNamespace = "default";
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/ProxyConnection.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/ProxyConnection.java
@@ -61,7 +61,7 @@ public class ProxyConnection extends ChannelInboundHandlerAdapter{
         this.proxyService = proxyService;
         this.proxyConfig = proxyService.getProxyConfig();
         lookupHandler = proxyService.getLookupHandler();
-        processor = new ProxyInboundHandler(proxyService, this);
+        processor = new ProxyInboundHandler(proxyService, this, proxyConfig);
         state = State.Init;
     }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/ProxyHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/ProxyHandler.java
@@ -30,7 +30,6 @@ import io.netty.handler.codec.mqtt.MqttMessageType;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
-import io.streamnative.pulsar.handlers.mqtt.ProtocolMethodProcessor;
 import java.util.List;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -40,7 +39,6 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class ProxyHandler {
-    private final ProtocolMethodProcessor processor;
     private ProxyService proxyService;
     private ProxyConnection proxyConnection;
     // client -> proxy
@@ -57,7 +55,6 @@ public class ProxyHandler {
         this.proxyConnection = proxyConnection;
         clientChannel = this.proxyConnection.getCnx().channel();
         this.connectMsgList = connectMsgList;
-        processor = new ProxyInboundHandler(proxyService, proxyConnection);
 
         Bootstrap bootstrap = new Bootstrap();
         bootstrap.group(clientChannel.eventLoop())

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTConsumer.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTConsumer.java
@@ -26,12 +26,12 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import org.apache.bookkeeper.mledger.Entry;
-import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.EntryBatchIndexesAcks;
 import org.apache.pulsar.broker.service.EntryBatchSizes;
 import org.apache.pulsar.broker.service.RedeliveryTracker;
 import org.apache.pulsar.broker.service.Subscription;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.common.api.proto.CommandAck;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
 
@@ -57,10 +57,9 @@ public class MQTTConsumer extends Consumer {
 
     public MQTTConsumer(Subscription subscription, String mqttTopicName, String pulsarTopicName, String consumerName,
                         MQTTServerCnx cnx, MqttQoS qos, PacketIdGenerator packetIdGenerator,
-                        OutstandingPacketContainer outstandingPacketContainer)
-            throws BrokerServiceException {
+                        OutstandingPacketContainer outstandingPacketContainer) {
         super(subscription, CommandSubscribe.SubType.Shared, pulsarTopicName, 0, 0, consumerName, 0, cnx,
-                "", null, false, CommandSubscribe.InitialPosition.Latest, null);
+                "", null, false, CommandSubscribe.InitialPosition.Latest, null, MessageId.latest);
         this.pulsarTopicName = pulsarTopicName;
         this.mqttTopicName = mqttTopicName;
         this.cnx = cnx;

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
@@ -13,9 +13,12 @@
  */
 package io.streamnative.pulsar.handlers.mqtt.utils;
 
+import com.google.common.base.Splitter;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.namespace.LookupOptions;
 import org.apache.pulsar.broker.service.BrokerServiceException;
@@ -24,24 +27,36 @@ import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.nonpersistent.NonPersistentSubscription;
 import org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
+import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.util.FutureUtil;
 
 /**
  * Pulsar topic utils.
  */
 public class PulsarTopicUtils {
 
-    public static CompletableFuture<Optional<Topic>> getTopicReference(PulsarService pulsarService, String topicName) {
-        final TopicName topic = TopicName.get(getPulsarTopicName(topicName));
+    public static final String UTF8 = "UTF-8";
+    public static final String PERSISTENT_DOMAIN = TopicDomain.persistent.value() + "://";
+    public static final String NON_PERSISTENT_DOMAIN = TopicDomain.non_persistent.value() + "://";
+
+    public static CompletableFuture<Optional<Topic>> getTopicReference(PulsarService pulsarService, String topicName,
+           String defaultTenant, String defaultNamespace) {
+        final TopicName topic;
+        try {
+            topic = TopicName.get(getPulsarTopicName(topicName, defaultTenant, defaultNamespace));
+        } catch (Exception e) {
+            return FutureUtil.failedFuture(e);
+        }
         return pulsarService.getNamespaceService().getBrokerServiceUrlAsync(topic,
                 LookupOptions.builder().authoritative(false).loadTopicsInBundle(false).build())
                 .thenCompose(lookupOp -> pulsarService.getBrokerService().getTopic(topic.toString(), true));
     }
 
     public static CompletableFuture<Subscription> getOrCreateSubscription(PulsarService pulsarService,
-              String topicName, String subscriptionName) {
+              String topicName, String subscriptionName, String defaultTenant, String defaultNamespace) {
         CompletableFuture<Subscription> promise = new CompletableFuture<>();
-        getTopicReference(pulsarService, topicName).thenAccept(topicOp -> {
+        getTopicReference(pulsarService, topicName, defaultTenant, defaultNamespace).thenAccept(topicOp -> {
             if (!topicOp.isPresent()) {
                 promise.completeExceptionally(new BrokerServiceException.TopicNotFoundException(topicName));
             } else {
@@ -72,7 +87,27 @@ public class PulsarTopicUtils {
         return promise;
     }
 
-    public static String getPulsarTopicName(String mqttTopicName) {
-        return StringUtils.strip(mqttTopicName, "/");
+    public static String getPulsarTopicName(String mqttTopicName, String defaultTenant, String defaultNamespace)
+            throws UnsupportedEncodingException {
+        if (mqttTopicName.startsWith(PERSISTENT_DOMAIN)
+                || mqttTopicName.startsWith(NON_PERSISTENT_DOMAIN)) {
+            List<String> parts = Splitter.on("://").limit(2).splitToList(mqttTopicName);
+            if (parts.size() < 2) {
+                throw new IllegalArgumentException("Invalid topic name: " + mqttTopicName);
+            }
+            String domain = parts.get(0);
+            String rest = parts.get(1);
+            parts = Splitter.on("/").limit(3).splitToList(rest);
+            if (parts.size() < 3) {
+                throw new IllegalArgumentException("Invalid topic name: " + mqttTopicName);
+            }
+            String tenant = parts.get(0);
+            String namespace = parts.get(1);
+            String localName = parts.get(2);
+            return TopicName.get(domain, tenant, namespace, URLEncoder.encode(localName, UTF8)).toString();
+        } else {
+            return TopicName.get(TopicDomain.persistent.value(), defaultTenant, defaultNamespace,
+                    URLEncoder.encode(mqttTopicName, UTF8)).toString();
+        }
     }
 }

--- a/mqtt-impl/src/test/java/io/streamnative/pulsar/handlers/mqtt/untils/PulsarTopicUtilsTest.java
+++ b/mqtt-impl/src/test/java/io/streamnative/pulsar/handlers/mqtt/untils/PulsarTopicUtilsTest.java
@@ -14,6 +14,8 @@
 package io.streamnative.pulsar.handlers.mqtt.untils;
 
 import io.streamnative.pulsar.handlers.mqtt.utils.PulsarTopicUtils;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -23,12 +25,21 @@ import org.testng.annotations.Test;
 public class PulsarTopicUtilsTest {
 
     @Test
-    public void testMqttTopicNameToPulsarTopicName() {
+    public void testMqttTopicNameToPulsarTopicName() throws UnsupportedEncodingException {
         String t0 = "/aaa/bbb/ccc";
-        Assert.assertEquals(PulsarTopicUtils.getPulsarTopicName(t0), "aaa/bbb/ccc");
+        Assert.assertEquals(PulsarTopicUtils.getPulsarTopicName(t0, "public", "default"),
+                "persistent://public/default/" + URLEncoder.encode(t0));
         t0 = "aaa/bbb/ccc/";
-        Assert.assertEquals(PulsarTopicUtils.getPulsarTopicName(t0), "aaa/bbb/ccc");
+        Assert.assertEquals(PulsarTopicUtils.getPulsarTopicName(t0, "public", "default"),
+                "persistent://public/default/" + URLEncoder.encode(t0));
         t0 = "/aaa/bbb/ccc/";
-        Assert.assertEquals(PulsarTopicUtils.getPulsarTopicName(t0), "aaa/bbb/ccc");
+        Assert.assertEquals(PulsarTopicUtils.getPulsarTopicName(t0, "public", "default"),
+                "persistent://public/default/" + URLEncoder.encode(t0));
+        t0 = "persistent://public/default/aaa/bbb/ccc";
+        Assert.assertEquals(PulsarTopicUtils.getPulsarTopicName(t0, "public", "default"),
+                "persistent://public/default/" + URLEncoder.encode("aaa/bbb/ccc"));
+        t0 = "persistent://public/default//aaa/bbb/ccc";
+        Assert.assertEquals(PulsarTopicUtils.getPulsarTopicName(t0, "public", "default"),
+                "persistent://public/default/" + URLEncoder.encode("/aaa/bbb/ccc"));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,8 @@
         <mockito.version>2.22.0</mockito.version>
         <testng.version>6.14.3</testng.version>
         <awaitility.version>4.0.2</awaitility.version>
-        <pulsar.version>2.8.0</pulsar.version>
-        <mqtt.codec.version>4.1.66.Final</mqtt.codec.version>
+        <pulsar.version>2.8.0.10</pulsar.version>
+        <mqtt.codec.version>4.1.67.Final</mqtt.codec.version>
         <log4j2.version>2.13.3</log4j2.version>
         <lombok.version>1.18.4</lombok.version>
         <mqtt.client.version>1.16</mqtt.client.version>
@@ -66,7 +66,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.pulsar</groupId>
+            <groupId>io.streamnative</groupId>
             <artifactId>pulsar-broker</artifactId>
             <version>${pulsar.version}</version>
             <scope>provided</scope>
@@ -271,12 +271,6 @@
     </build>
 
     <repositories>
-        <repository>
-            <id>bintray-streamnative-maven</id>
-            <name>bintray</name>
-            <url>https://dl.bintray.com/streamnative/maven</url>
-        </repository>
-
         <repository>
             <id>central</id>
             <layout>default</layout>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -35,13 +35,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.pulsar</groupId>
+            <groupId>io.streamnative</groupId>
             <artifactId>testmocks</artifactId>
             <version>${pulsar.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.pulsar</groupId>
+            <groupId>io.streamnative</groupId>
             <artifactId>pulsar-broker</artifactId>
             <version>${pulsar.version}</version>
             <type>test-jar</type>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/BasicAuthenticationIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/BasicAuthenticationIntegrationTest.java
@@ -2,9 +2,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/BasicAuthenticationIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/BasicAuthenticationIntegrationTest.java
@@ -2,9 +2,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -42,83 +42,83 @@ import org.testng.annotations.Test;
 @Slf4j
 public class BasicAuthenticationIntegrationTest extends MQTTTestBase {
 
-  @BeforeClass
-  @Override
-  public void setup() throws Exception {
-    System.setProperty("pulsar.auth.basic.conf", "./src/test/resources/htpasswd");
-    String authParams = "{\"userId\":\"superUser\",\"password\":\"supepass\"}";
+    @BeforeClass
+    @Override
+    public void setup() throws Exception {
+        System.setProperty("pulsar.auth.basic.conf", "./src/test/resources/htpasswd");
+        String authParams = "{\"userId\":\"superUser\",\"password\":\"supepass\"}";
 
-    conf.setAuthenticationEnabled(true);
-    conf.setMqttAuthenticationEnabled(true);
-    conf.setMqttAuthenticationMethods(ImmutableList.of("basic"));
-    conf.setSuperUserRoles(ImmutableSet.of("superUser"));
-    conf.setAuthenticationProviders(Sets.newHashSet(AuthenticationProviderBasic.class.getName()));
-    conf.setBrokerClientAuthenticationPlugin(AuthenticationBasic.class.getName());
-    conf.setBrokerClientAuthenticationParameters(authParams);
-    super.init();
+        conf.setAuthenticationEnabled(true);
+        conf.setMqttAuthenticationEnabled(true);
+        conf.setMqttAuthenticationMethods(ImmutableList.of("basic"));
+        conf.setSuperUserRoles(ImmutableSet.of("superUser"));
+        conf.setAuthenticationProviders(Sets.newHashSet(AuthenticationProviderBasic.class.getName()));
+        conf.setBrokerClientAuthenticationPlugin(AuthenticationBasic.class.getName());
+        conf.setBrokerClientAuthenticationParameters(authParams);
+        super.init();
 
-    AuthenticationBasic authPassword = new AuthenticationBasic();
-    authPassword.configure(authParams);
+        AuthenticationBasic authPassword = new AuthenticationBasic();
+        authPassword.configure(authParams);
 
-    pulsarClient = PulsarClient.builder()
-                               .serviceUrl(brokerUrl.toString())
-                               .authentication(authPassword)
-                               .statsInterval(0, TimeUnit.SECONDS)
-                               .build();
-    admin = spy(PulsarAdmin.builder()
-                           .serviceHttpUrl(brokerUrl.toString())
-                           .authentication(authPassword)
-                           .build());
+        pulsarClient = PulsarClient.builder()
+                .serviceUrl(brokerUrl.toString())
+                .authentication(authPassword)
+                .statsInterval(0, TimeUnit.SECONDS)
+                .build();
+        admin = spy(PulsarAdmin.builder()
+                .serviceHttpUrl(brokerUrl.toString())
+                .authentication(authPassword)
+                .build());
 
-    super.setupClusterNamespaces();
-    super.checkPulsarServiceState();
-  }
+        super.setupClusterNamespaces();
+        super.checkPulsarServiceState();
+    }
 
-  @AfterClass(alwaysRun = true)
-  @Override
-  public void cleanup() throws Exception {
-    super.cleanup();
-  }
+    @AfterClass(alwaysRun = true)
+    @Override
+    public void cleanup() throws Exception {
+        super.cleanup();
+    }
 
-  @Override
-  public MQTT createMQTTClient() throws URISyntaxException {
-    MQTT mqtt = super.createMQTTClient();
-    mqtt.setUserName("superUser");
-    mqtt.setPassword("supepass");
-    return mqtt;
-  }
+    @Override
+    public MQTT createMQTTClient() throws URISyntaxException {
+        MQTT mqtt = super.createMQTTClient();
+        mqtt.setUserName("superUser");
+        mqtt.setPassword("supepass");
+        return mqtt;
+    }
 
-  @Test(timeOut = TIMEOUT)
-  public void testAuthenticateAndPublish() throws Exception {
-    MQTT mqtt = createMQTTClient();
-    authenticateAndPublish(mqtt);
-  }
+    @Test(timeOut = TIMEOUT)
+    public void testAuthenticateAndPublish() throws Exception {
+        MQTT mqtt = createMQTTClient();
+        authenticateAndPublish(mqtt);
+    }
 
-  @Test(timeOut = TIMEOUT)
-  public void testAuthenticateAndPublishViaProxy() throws Exception {
-    MQTT mqtt = createMQTTProxyClient();
-    authenticateAndPublish(mqtt);
-  }
+    @Test(timeOut = TIMEOUT)
+    public void testAuthenticateAndPublishViaProxy() throws Exception {
+        MQTT mqtt = createMQTTProxyClient();
+        authenticateAndPublish(mqtt);
+    }
 
-  public void authenticateAndPublish(MQTT mqtt) throws Exception {
-    String topicName = "persistent://public/default/testAuthentication";
-    BlockingConnection connection = mqtt.blockingConnection();
-    connection.connect();
-    Topic[] topics = {new Topic(topicName, QoS.AT_LEAST_ONCE) };
-    connection.subscribe(topics);
-    String message = "Hello MQTT";
-    connection.publish(topicName, message.getBytes(), QoS.AT_LEAST_ONCE, false);
-    Message received = connection.receive();
-    Assert.assertEquals(new String(received.getPayload()), message);
-    received.ack();
-    connection.disconnect();
-  }
+    public void authenticateAndPublish(MQTT mqtt) throws Exception {
+        String topicName = "persistent://public/default/testAuthentication";
+        BlockingConnection connection = mqtt.blockingConnection();
+        connection.connect();
+        Topic[] topics = {new Topic(topicName, QoS.AT_LEAST_ONCE)};
+        connection.subscribe(topics);
+        String message = "Hello MQTT";
+        connection.publish(topicName, message.getBytes(), QoS.AT_LEAST_ONCE, false);
+        Message received = connection.receive();
+        Assert.assertEquals(new String(received.getPayload()), message);
+        received.ack();
+        connection.disconnect();
+    }
 
-  @Test(expectedExceptions = { MQTTException.class }, timeOut = TIMEOUT)
-  public void testInvalidCredentials() throws Exception {
-    MQTT mqtt = createMQTTClient();
-    mqtt.setPassword("invalid");
-    BlockingConnection connection = mqtt.blockingConnection();
-    connection.connect();
-  }
+    @Test(expectedExceptions = {MQTTException.class}, timeOut = TIMEOUT)
+    public void testInvalidCredentials() throws Exception {
+        MQTT mqtt = createMQTTClient();
+        mqtt.setPassword("invalid");
+        BlockingConnection connection = mqtt.blockingConnection();
+        connection.connect();
+    }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/BasicAuthenticationIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/BasicAuthenticationIntegrationTest.java
@@ -41,6 +41,7 @@ import org.testng.annotations.Test;
  */
 @Slf4j
 public class BasicAuthenticationIntegrationTest extends MQTTTestBase {
+
   @BeforeClass
   @Override
   public void setup() throws Exception {
@@ -73,7 +74,7 @@ public class BasicAuthenticationIntegrationTest extends MQTTTestBase {
     super.checkPulsarServiceState();
   }
 
-  @AfterClass
+  @AfterClass(alwaysRun = true)
   @Override
   public void cleanup() throws Exception {
     super.cleanup();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/BasicAuthenticationIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/BasicAuthenticationIntegrationTest.java
@@ -88,13 +88,13 @@ public class BasicAuthenticationIntegrationTest extends MQTTTestBase {
     return mqtt;
   }
 
-  @Test
+  @Test(timeOut = TIMEOUT)
   public void testAuthenticateAndPublish() throws Exception {
     MQTT mqtt = createMQTTClient();
     authenticateAndPublish(mqtt);
   }
 
-  @Test
+  @Test(timeOut = TIMEOUT)
   public void testAuthenticateAndPublishViaProxy() throws Exception {
     MQTT mqtt = createMQTTProxyClient();
     authenticateAndPublish(mqtt);
@@ -114,7 +114,7 @@ public class BasicAuthenticationIntegrationTest extends MQTTTestBase {
     connection.disconnect();
   }
 
-  @Test(expectedExceptions = { MQTTException.class })
+  @Test(expectedExceptions = { MQTTException.class }, timeOut = TIMEOUT)
   public void testInvalidCredentials() throws Exception {
     MQTT mqtt = createMQTTClient();
     mqtt.setPassword("invalid");

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/ProxyTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/ProxyTest.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.streamnative.pulsar.handlers.mqtt;
 
 import io.streamnative.pulsar.handlers.mqtt.base.MQTTTestBase;
@@ -11,6 +25,9 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+/**
+ * Integration tests for MQTT protocol handler with proxy.
+ */
 public class ProxyTest extends MQTTTestBase {
 
     @BeforeClass

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/ProxyTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/ProxyTest.java
@@ -1,0 +1,42 @@
+package io.streamnative.pulsar.handlers.mqtt;
+
+import io.streamnative.pulsar.handlers.mqtt.base.MQTTTestBase;
+import org.fusesource.mqtt.client.BlockingConnection;
+import org.fusesource.mqtt.client.MQTT;
+import org.fusesource.mqtt.client.Message;
+import org.fusesource.mqtt.client.QoS;
+import org.fusesource.mqtt.client.Topic;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class ProxyTest extends MQTTTestBase {
+
+    @BeforeClass
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    public void cleanup() throws Exception {
+        super.cleanup();
+    }
+
+    @Test(dataProvider = "mqttTopicNames", timeOut = TIMEOUT)
+    public void testConnectionViaProxy(String topicName) throws Exception {
+        MQTT mqtt = createMQTTProxyClient();
+        BlockingConnection connection = mqtt.blockingConnection();
+        connection.connect();
+        Topic[] topics = { new Topic(topicName, QoS.AT_MOST_ONCE) };
+        connection.subscribe(topics);
+        String message = "Hello MQTT Proxy";
+        connection.publish(topicName, message.getBytes(), QoS.AT_MOST_ONCE, false);
+        Message received = connection.receive();
+        Assert.assertEquals(new String(received.getPayload()), message);
+        received.ack();
+        connection.disconnect();
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/SimpleIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/SimpleIntegrationTest.java
@@ -59,22 +59,6 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         };
     }
 
-    @DataProvider(name = "mqttTopicNames")
-    public Object[][] mqttTopicNames() {
-        return new Object[][] {
-                { "public/default/t0" },
-                { "/public/default/t0" },
-                { "public/default/t0/" },
-                { "/public/default/t0/" },
-                { "persistent://public/default/t0" },
-                { "persistent://public/default/a/b" },
-                { "persistent://public/default//a/b" },
-                { "non-persistent://public/default/t0" },
-                { "non-persistent://public/default/a/b" },
-                { "non-persistent://public/default//a/b" },
-        };
-    }
-
     @Test(dataProvider = "mqttTopicNames", timeOut = TIMEOUT)
     public void testSimpleMqttPubAndSubQos0(String topicName) throws Exception {
         MQTT mqtt = createMQTTClient();
@@ -313,20 +297,5 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         Assert.assertTrue(connection2.isConnected());
 
         connection2.disconnect();
-    }
-
-    @Test(dataProvider = "mqttTopicNames", timeOut = TIMEOUT)
-    public void testConnectionViaProxy(String topicName) throws Exception {
-        MQTT mqtt = createMQTTProxyClient();
-        BlockingConnection connection = mqtt.blockingConnection();
-        connection.connect();
-        Topic[] topics = { new Topic(topicName, QoS.AT_MOST_ONCE) };
-        connection.subscribe(topics);
-        String message = "Hello MQTT Proxy";
-        connection.publish(topicName, message.getBytes(), QoS.AT_MOST_ONCE, false);
-        Message received = connection.receive();
-        Assert.assertEquals(new String(received.getPayload()), message);
-        received.ack();
-        connection.disconnect();
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/SimpleIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/SimpleIntegrationTest.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.mqtt;
 
 import io.streamnative.pulsar.handlers.mqtt.base.MQTTTestBase;
+import io.streamnative.pulsar.handlers.mqtt.utils.PulsarTopicUtils;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Consumer;
@@ -44,7 +45,7 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         super.setup();
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     @Override
     public void cleanup() throws Exception {
         super.cleanup();
@@ -64,7 +65,13 @@ public class SimpleIntegrationTest extends MQTTTestBase {
                 { "public/default/t0" },
                 { "/public/default/t0" },
                 { "public/default/t0/" },
-                { "/public/default/t0/" }
+                { "/public/default/t0/" },
+                { "persistent://public/default/t0" },
+                { "persistent://public/default/a/b" },
+                { "persistent://public/default//a/b" },
+                { "non-persistent://public/default/t0" },
+                { "non-persistent://public/default/a/b" },
+                { "non-persistent://public/default//a/b" },
         };
     }
 
@@ -98,11 +105,10 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         connection.disconnect();
     }
 
-    @Test
-    public void testSendByMqttAndReceiveByPulsar() throws Exception {
-        final String topic = "persistent://public/default/testReceiveByPulsar";
+    @Test(dataProvider = "mqttTopicNames")
+    public void testSendByMqttAndReceiveByPulsar(String topic) throws Exception {
         Consumer<byte[]> consumer = pulsarClient.newConsumer()
-                .topic(topic)
+                .topic(PulsarTopicUtils.getPulsarTopicName(topic, "public", "default"))
                 .subscriptionName("my-sub")
                 .subscribe();
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/SimpleIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/SimpleIntegrationTest.java
@@ -75,7 +75,7 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         };
     }
 
-    @Test(dataProvider = "mqttTopicNames")
+    @Test(dataProvider = "mqttTopicNames", timeOut = TIMEOUT)
     public void testSimpleMqttPubAndSubQos0(String topicName) throws Exception {
         MQTT mqtt = createMQTTClient();
         BlockingConnection connection = mqtt.blockingConnection();
@@ -90,7 +90,7 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         connection.disconnect();
     }
 
-    @Test(dataProvider = "mqttTopicNames")
+    @Test(dataProvider = "mqttTopicNames", timeOut = TIMEOUT)
     public void testSimpleMqttPubAndSubQos1(String topicName) throws Exception {
         MQTT mqtt = createMQTTClient();
         BlockingConnection connection = mqtt.blockingConnection();
@@ -105,7 +105,7 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         connection.disconnect();
     }
 
-    @Test(dataProvider = "mqttTopicNames")
+    @Test(dataProvider = "mqttTopicNames", timeOut = TIMEOUT)
     public void testSendByMqttAndReceiveByPulsar(String topic) throws Exception {
         Consumer<byte[]> consumer = pulsarClient.newConsumer()
                 .topic(PulsarTopicUtils.getPulsarTopicName(topic, "public", "default"))
@@ -129,7 +129,7 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         connection.disconnect();
     }
 
-    @Test(dataProvider = "batchEnabled")
+    @Test(dataProvider = "batchEnabled", timeOut = TIMEOUT)
     public void testSendByPulsarAndReceiveByMqtt(boolean batchEnabled) throws Exception {
         final String topicName = "persistent://public/default/testSendByPulsarAndReceiveByMqtt";
         MQTT mqtt = createMQTTClient();
@@ -153,7 +153,7 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         producer.close();
     }
 
-    @Test
+    @Test(timeOut = TIMEOUT)
     public void testBacklogShouldBeZeroWithQos0() throws Exception {
         final String topicName = "persistent://public/default/testBacklogShouldBeZeroWithQos0";
         MQTT mqtt = createMQTTClient();
@@ -178,7 +178,7 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         connection.disconnect();
     }
 
-    @Test
+    @Test(timeOut = TIMEOUT)
     public void testBacklogShouldBeZeroWithQos1() throws Exception {
         final String topicName = "persistent://public/default/testBacklogShouldBeZeroWithQos1";
         MQTT mqtt = createMQTTClient();
@@ -205,7 +205,7 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         connection.disconnect();
     }
 
-    @Test
+    @Test(timeOut = TIMEOUT)
     public void testBacklogShouldBeZeroWithQos0AndSendByPulsar() throws Exception {
         final String topicName = "persistent://public/default/testBacklogShouldBeZeroWithQos0AndSendByPulsar-";
         MQTT mqtt = createMQTTClient();
@@ -235,7 +235,7 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         connection.disconnect();
     }
 
-    @Test
+    @Test(timeOut = TIMEOUT)
     public void testBacklogShouldBeZeroWithQos1AndSendByPulsar() throws Exception {
         final String topicName = "persistent://public/default/testBacklogShouldBeZeroWithQos1AndSendByPulsar";
         MQTT mqtt = createMQTTClient();
@@ -267,7 +267,7 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         connection.disconnect();
     }
 
-    @Test
+    @Test(timeOut = TIMEOUT)
     public void testSubscribeRejectionWithSameClientId() throws Exception {
         final String topicName = "persistent://public/default/testSubscribeWithSameClientId";
         MQTT mqtt = createMQTTClient();
@@ -290,7 +290,7 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         }
     }
 
-    @Test
+    @Test(timeOut = TIMEOUT)
     public void testSubscribeWithSameClientId() throws Exception {
         final String topicName = "persistent://public/default/testSubscribeWithSameClientId";
         MQTT mqtt = createMQTTClient();
@@ -315,7 +315,7 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         connection2.disconnect();
     }
 
-    @Test(dataProvider = "mqttTopicNames", timeOut = 120000)
+    @Test(dataProvider = "mqttTopicNames", timeOut = TIMEOUT)
     public void testConnectionViaProxy(String topicName) throws Exception {
         MQTT mqtt = createMQTTProxyClient();
         BlockingConnection connection = mqtt.blockingConnection();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/TokenAuthenticationIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/TokenAuthenticationIntegrationTest.java
@@ -2,9 +2,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/TokenAuthenticationIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/TokenAuthenticationIntegrationTest.java
@@ -84,7 +84,7 @@ public class TokenAuthenticationIntegrationTest extends MQTTTestBase {
     super.checkPulsarServiceState();
   }
 
-  @AfterClass
+  @AfterClass(alwaysRun = true)
   @Override
   public void cleanup() throws Exception {
     super.cleanup();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/TokenAuthenticationIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/TokenAuthenticationIntegrationTest.java
@@ -2,9 +2,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -47,88 +47,88 @@ import org.testng.annotations.Test;
  */
 @Slf4j
 public class TokenAuthenticationIntegrationTest extends MQTTTestBase {
-  private String token;
+    private String token;
 
-  @BeforeClass
-  @Override
-  public void setup() throws Exception {
-    SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
-    Properties properties = new Properties();
-    properties.setProperty("tokenSecretKey", AuthTokenUtils.encodeKeyBase64(secretKey));
-    token = AuthTokenUtils.createToken(secretKey, "superUser", Optional.empty());
+    @BeforeClass
+    @Override
+    public void setup() throws Exception {
+        SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
+        Properties properties = new Properties();
+        properties.setProperty("tokenSecretKey", AuthTokenUtils.encodeKeyBase64(secretKey));
+        token = AuthTokenUtils.createToken(secretKey, "superUser", Optional.empty());
 
-    conf.setAuthenticationEnabled(true);
-    conf.setMqttAuthenticationEnabled(true);
-    conf.setMqttAuthenticationMethods(ImmutableList.of("token"));
-    conf.setSuperUserRoles(ImmutableSet.of("superUser"));
-    conf.setAuthenticationProviders(Sets.newHashSet(AuthenticationProviderToken.class.getName()));
-    conf.setBrokerClientAuthenticationPlugin(AuthenticationToken.class.getName());
-    conf.setBrokerClientAuthenticationParameters("token:" + token);
-    conf.setProperties(properties);
-    super.init();
+        conf.setAuthenticationEnabled(true);
+        conf.setMqttAuthenticationEnabled(true);
+        conf.setMqttAuthenticationMethods(ImmutableList.of("token"));
+        conf.setSuperUserRoles(ImmutableSet.of("superUser"));
+        conf.setAuthenticationProviders(Sets.newHashSet(AuthenticationProviderToken.class.getName()));
+        conf.setBrokerClientAuthenticationPlugin(AuthenticationToken.class.getName());
+        conf.setBrokerClientAuthenticationParameters("token:" + token);
+        conf.setProperties(properties);
+        super.init();
 
-    AuthenticationToken authToken = new AuthenticationToken();
-    authToken.configure("token:" + token);
+        AuthenticationToken authToken = new AuthenticationToken();
+        authToken.configure("token:" + token);
 
-    pulsarClient = PulsarClient.builder()
-                               .serviceUrl(brokerUrl.toString())
-                               .authentication(authToken)
-                               .statsInterval(0, TimeUnit.SECONDS)
-                               .build();
-    admin = spy(PulsarAdmin.builder()
-                           .serviceHttpUrl(brokerUrl.toString())
-                           .authentication(authToken)
-                           .build());
+        pulsarClient = PulsarClient.builder()
+                .serviceUrl(brokerUrl.toString())
+                .authentication(authToken)
+                .statsInterval(0, TimeUnit.SECONDS)
+                .build();
+        admin = spy(PulsarAdmin.builder()
+                .serviceHttpUrl(brokerUrl.toString())
+                .authentication(authToken)
+                .build());
 
-    super.setupClusterNamespaces();
-    super.checkPulsarServiceState();
-  }
+        super.setupClusterNamespaces();
+        super.checkPulsarServiceState();
+    }
 
-  @AfterClass(alwaysRun = true)
-  @Override
-  public void cleanup() throws Exception {
-    super.cleanup();
-  }
+    @AfterClass(alwaysRun = true)
+    @Override
+    public void cleanup() throws Exception {
+        super.cleanup();
+    }
 
-  @Override
-  public MQTT createMQTTClient() throws URISyntaxException {
-    MQTT mqtt = super.createMQTTClient();
-    mqtt.setUserName("superUser");
-    mqtt.setPassword(token);
-    return mqtt;
-  }
+    @Override
+    public MQTT createMQTTClient() throws URISyntaxException {
+        MQTT mqtt = super.createMQTTClient();
+        mqtt.setUserName("superUser");
+        mqtt.setPassword(token);
+        return mqtt;
+    }
 
-  @Test
-  public void testAuthenticateAndPublish() throws Exception {
-    MQTT mqtt = createMQTTClient();
-    authenticateAndPublish(mqtt);
-  }
+    @Test
+    public void testAuthenticateAndPublish() throws Exception {
+        MQTT mqtt = createMQTTClient();
+        authenticateAndPublish(mqtt);
+    }
 
-  @Test
-  public void testAuthenticateAndPublishViaProxy() throws Exception {
-    MQTT mqtt = createMQTTProxyClient();
-    authenticateAndPublish(mqtt);
-  }
+    @Test
+    public void testAuthenticateAndPublishViaProxy() throws Exception {
+        MQTT mqtt = createMQTTProxyClient();
+        authenticateAndPublish(mqtt);
+    }
 
-  public void authenticateAndPublish(MQTT mqtt) throws Exception {
-    String topicName = "persistent://public/default/testAuthentication";
-    BlockingConnection connection = mqtt.blockingConnection();
-    connection.connect();
-    Topic[] topics = {new Topic(topicName, QoS.AT_LEAST_ONCE) };
-    connection.subscribe(topics);
-    String message = "Hello MQTT";
-    connection.publish(topicName, message.getBytes(), QoS.AT_LEAST_ONCE, false);
-    Message received = connection.receive();
-    Assert.assertEquals(new String(received.getPayload()), message);
-    received.ack();
-    connection.disconnect();
-  }
+    public void authenticateAndPublish(MQTT mqtt) throws Exception {
+        String topicName = "persistent://public/default/testAuthentication";
+        BlockingConnection connection = mqtt.blockingConnection();
+        connection.connect();
+        Topic[] topics = {new Topic(topicName, QoS.AT_LEAST_ONCE)};
+        connection.subscribe(topics);
+        String message = "Hello MQTT";
+        connection.publish(topicName, message.getBytes(), QoS.AT_LEAST_ONCE, false);
+        Message received = connection.receive();
+        Assert.assertEquals(new String(received.getPayload()), message);
+        received.ack();
+        connection.disconnect();
+    }
 
-  @Test(expectedExceptions = { MQTTException.class })
-  public void testInvalidCredentials() throws Exception {
-    MQTT mqtt = createMQTTClient();
-    mqtt.setPassword("invalid");
-    BlockingConnection connection = mqtt.blockingConnection();
-    connection.connect();
-  }
+    @Test(expectedExceptions = {MQTTException.class})
+    public void testInvalidCredentials() throws Exception {
+        MQTT mqtt = createMQTTClient();
+        mqtt.setPassword("invalid");
+        BlockingConnection connection = mqtt.blockingConnection();
+        connection.connect();
+    }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTTestBase.java
@@ -35,10 +35,10 @@ public class MQTTTestBase extends MQTTProtocolHandlerTestBase {
     @DataProvider(name = "mqttTopicNames")
     public Object[][] mqttTopicNames() {
         return new Object[][] {
-                { "public/default/t0" },
-                { "/public/default/t0" },
-                { "public/default/t0/" },
-                { "/public/default/t0/" },
+                { "a/b/c" },
+                { "/a/b/c" },
+                { "a/b/c/" },
+                { "/a/b/c/" },
                 { "persistent://public/default/t0" },
                 { "persistent://public/default/a/b" },
                 { "persistent://public/default//a/b" },

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTTestBase.java
@@ -28,6 +28,9 @@ import org.testng.annotations.BeforeClass;
  */
 @Slf4j
 public class MQTTTestBase extends MQTTProtocolHandlerTestBase {
+
+    public static final int TIMEOUT = 60 * 1000;
+
     @BeforeClass
     @Override
     protected void setup() throws Exception {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTTestBase.java
@@ -22,6 +22,7 @@ import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.fusesource.mqtt.client.MQTT;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 
 /**
  * Base test class for MQTT Client.
@@ -30,6 +31,22 @@ import org.testng.annotations.BeforeClass;
 public class MQTTTestBase extends MQTTProtocolHandlerTestBase {
 
     public static final int TIMEOUT = 60 * 1000;
+
+    @DataProvider(name = "mqttTopicNames")
+    public Object[][] mqttTopicNames() {
+        return new Object[][] {
+                { "public/default/t0" },
+                { "/public/default/t0" },
+                { "public/default/t0/" },
+                { "/public/default/t0/" },
+                { "persistent://public/default/t0" },
+                { "persistent://public/default/a/b" },
+                { "persistent://public/default//a/b" },
+                { "non-persistent://public/default/t0" },
+                { "non-persistent://public/default/a/b" },
+                { "non-persistent://public/default//a/b" },
+        };
+    }
 
     @BeforeClass
     @Override


### PR DESCRIPTION
Adding a namespace prefix in the MQTT topic name when sending messages and subscribe to a topic.

```
|  __public/default__/a/b/c     ->      /a/b/c under public/default          |
|  __public/default__a/b/c      ->      a/b/c under public/default           |
|  __public/default__/+/b/c      ->     /+/b/c under public/default          |
|  __public/default__/a/b/#     ->      /a/b/# under public/default          |
```

Or

persistent://public/default//a/b/c It's better for us to support non-persistent topic in the future

```
|  persistent://public/default//a/b/c  ->    /a/b/c under public/default     |
|  persistent://public/default/a/b/c   ->    a/b/c under public/default      |
|  persistent://public/default//+/b/c  ->    /+/b/c under public/default     |
|  persistent://public/default//a/b/#  ->    /a/b/# under public/default     |
```

If the namespace prefix absents, use the default tenant and namespace configuration for the MoP:

```
|  /a/b/c  ->    /a/b/c under <default-tenant>/<default-namespace>     |
|  a/b/c   ->    a/b/c under <default-tenant>/<default-namespace>      |
|  /+/b/c  ->    /+/b/c under <default-tenant>/<default-namespace>     |
|  /a/b/#  ->    /a/b/# under <default-tenant>/<default-namespace>     |
```

This will help migrate the existing MQTT applications to MoP without change the topic name to a specified Apache Pulsar namespace.
So, for this approach, the subscriber can only subscribe topics under a namespace. If we want to support subscribe to topics under multiple namespaces or tenants, we can allow the subscriber with topic name persistent://public/+//+/b/c which will fetch all the topics under the namespaces of public tenant.