### PR TITLE
Fix the issue with same client ID and tests.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/ConnectionDescriptor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/ConnectionDescriptor.java
@@ -81,12 +81,7 @@ public class ConnectionDescriptor {
 
     public void abort() {
         LOG.info("Closing connection descriptor. MqttClientId = {}.", clientID);
-        // try {
-        // this.channel.disconnect().sync();
-        this.channel.close(); // .sync();
-        // } catch (InterruptedException e) {
-        // e.printStackTrace();
-        // }
+        this.channel.close();
     }
 
     public boolean assignState(ConnectionState expected, ConnectionState newState) {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTInboundHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTInboundHandler.java
@@ -124,7 +124,8 @@ public class MQTTInboundHandler extends ChannelInboundHandlerAdapter {
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         log.warn(
                 "An unexpected exception was caught while processing MQTT message. "
-                + "Closing Netty channel. MqttClientId = {}",
+                + "Closing Netty channel {}. MqttClientId = {}",
+                ctx.channel(),
                 NettyUtils.clientID(ctx.channel()),
                 cause);
         ctx.close();

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTInboundHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTInboundHandler.java
@@ -124,10 +124,9 @@ public class MQTTInboundHandler extends ChannelInboundHandlerAdapter {
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         log.warn(
                 "An unexpected exception was caught while processing MQTT message. "
-                + "Closing Netty channel. MqttClientId = {}, cause = {}, errorMessage = {}.",
+                + "Closing Netty channel. MqttClientId = {}",
                 NettyUtils.clientID(ctx.channel()),
-                cause.getCause(),
-                cause.getMessage());
+                cause);
         ctx.close();
     }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/ProtocolMethodProcessorImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/ProtocolMethodProcessorImpl.java
@@ -164,7 +164,7 @@ public class ProtocolMethodProcessorImpl implements ProtocolMethodProcessor {
         if (existing != null) {
             log.info("The client ID is being used in an existing connection. It will be closed. CId={}", clientId);
             existing.abort();
-            sendAck(descriptor, MqttConnectReturnCode.CONNECTION_REFUSED_IDENTIFIER_REJECTED, clientId);
+            sendAck(descriptor, MqttConnectReturnCode.CONNECTION_ACCEPTED, clientId);
             return;
         }
 
@@ -248,7 +248,6 @@ public class ProtocolMethodProcessorImpl implements ProtocolMethodProcessor {
         final String clientID = NettyUtils.clientID(channel);
         log.info("Processing DISCONNECT message. CId={}", clientID);
         channel.flush();
-
         final ConnectionDescriptor existingDescriptor = ConnectionDescriptorStore.getInstance().getConnection(clientID);
         if (existingDescriptor == null) {
             // another client with same ID removed the descriptor, we must exit

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/BasicAuthenticationIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/BasicAuthenticationIntegrationTest.java
@@ -120,5 +120,6 @@ public class BasicAuthenticationIntegrationTest extends MQTTTestBase {
         mqtt.setPassword("invalid");
         BlockingConnection connection = mqtt.blockingConnection();
         connection.connect();
+        connection.disconnect();
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/SimpleIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/SimpleIntegrationTest.java
@@ -251,7 +251,7 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         connection.disconnect();
     }
 
-    @Test(timeOut = TIMEOUT)
+    @Test(timeOut = TIMEOUT, enabled = false)
     public void testSubscribeRejectionWithSameClientId() throws Exception {
         final String topicName = "persistent://public/default/testSubscribeWithSameClientId";
         MQTT mqtt = createMQTTClient();
@@ -272,6 +272,7 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         } catch (MQTTException e){
             Assert.assertTrue(e.getMessage().contains("CONNECTION_REFUSED_IDENTIFIER_REJECTED"));
         }
+        System.out.println("---------------------------");
     }
 
     @Test(timeOut = TIMEOUT)

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/TokenAuthenticationIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/TokenAuthenticationIntegrationTest.java
@@ -130,5 +130,6 @@ public class TokenAuthenticationIntegrationTest extends MQTTTestBase {
         mqtt.setPassword("invalid");
         BlockingConnection connection = mqtt.blockingConnection();
         connection.connect();
+        connection.disconnect();
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/TokenAuthenticationIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/TokenAuthenticationIntegrationTest.java
@@ -98,13 +98,13 @@ public class TokenAuthenticationIntegrationTest extends MQTTTestBase {
         return mqtt;
     }
 
-    @Test
+    @Test(timeOut = TIMEOUT)
     public void testAuthenticateAndPublish() throws Exception {
         MQTT mqtt = createMQTTClient();
         authenticateAndPublish(mqtt);
     }
 
-    @Test
+    @Test(timeOut = TIMEOUT)
     public void testAuthenticateAndPublishViaProxy() throws Exception {
         MQTT mqtt = createMQTTProxyClient();
         authenticateAndPublish(mqtt);


### PR DESCRIPTION
- [MQTT-3.1.4-2]: If the ClientId represents a Client already connected to the Server then the Server MUST disconnect the existing Client.


