### PR TITLE
[Proxy] Make MoP proxy connect with MoP broker asynchronously

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/ProxyHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/ProxyHandler.java
@@ -30,6 +30,7 @@ import io.netty.handler.codec.mqtt.MqttMessageType;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
+import java.util.concurrent.CompletableFuture;
 import java.util.List;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -48,6 +49,7 @@ public class ProxyHandler {
     private Channel brokerChannel;
     private State state;
     private List<Object> connectMsgList;
+    private CompletableFuture<Void> brokerFuture = new CompletableFuture<>();
 
     ProxyHandler(ProxyService proxyService, ProxyConnection proxyConnection,
                  String mqttBrokerHost, int mqttBrokerPort, List<Object> connectMsgList) throws Exception {
@@ -70,7 +72,7 @@ public class ProxyHandler {
                 });
         ChannelFuture channelFuture = bootstrap.connect(mqttBrokerHost, mqttBrokerPort);
         brokerChannel = channelFuture.channel();
-        channelFuture.await().addListener(future -> {
+        channelFuture.addListener(future -> {
             if (!future.isSuccess()) {
                 // Close the connection if the connection attempt has failed.
                 clientChannel.close();
@@ -129,6 +131,7 @@ public class ProxyHandler {
                         log.info("The messageType is CONNACK, set the state to Connected.");
                         checkState(msg instanceof MqttConnAckMessage);
                         state = State.Connected;
+                        brokerFuture.complete(null);
                     }
                     break;
                 case Failed:
@@ -146,8 +149,9 @@ public class ProxyHandler {
 
         @Override
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-            cause.printStackTrace();
+            log.error("Failed to create connection with MoP broker.", cause);
             state = State.Failed;
+            brokerFuture.completeExceptionally(cause);
         }
 
         @Override
@@ -167,6 +171,10 @@ public class ProxyHandler {
         Connected,
         Failed,
         Closed
+    }
+
+    public CompletableFuture<Void> brokerFuture() {
+        return this.brokerFuture;
     }
 
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/ProxyHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/ProxyHandler.java
@@ -30,8 +30,8 @@ import io.netty.handler.codec.mqtt.MqttMessageType;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
-import java.util.concurrent.CompletableFuture;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/ProxyInboundHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/ProxyInboundHandler.java
@@ -385,7 +385,7 @@ public class ProxyInboundHandler implements ProtocolMethodProcessor {
             if (proxyHandler.getBrokerChannel().isWritable()) {
                 proxyHandler.getBrokerChannel().writeAndFlush(msg);
             } else {
-                log.error("The broker channel({}:{}) is not writable!", mqttBrokerHost, mqttBrokerPort, throwable);
+                log.error("The broker channel({}:{}) is not writable!", mqttBrokerHost, mqttBrokerPort);
                 channel.close();
                 proxyHandler.close();
             }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/ProxyInboundHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/ProxyInboundHandler.java
@@ -174,27 +174,7 @@ public class ProxyInboundHandler implements ProtocolMethodProcessor {
                 return;
             }
 
-            proxyHandler = proxyHandlerMap.computeIfAbsent
-                    (topicName, key -> {
-                try {
-                    return new ProxyHandler(proxyService,
-                            proxyConnection,
-                            pair.getLeft(),
-                            pair.getRight(),
-                            connectMsgList);
-                } catch (Exception e) {
-                    log.error("[Proxy Publish] Failed to create proxy handler for topic {}",
-                            msg.variableHeader().topicName(), e);
-                    return null;
-                }
-            });
-
-            if (null == proxyHandler) {
-                channel.close();
-                return;
-            }
-
-            proxyHandler.getBrokerChannel().writeAndFlush(msg);
+            writeAndFlush(topicName, pair.getLeft(), pair.getRight(), channel, msg);
         });
     }
 
@@ -299,27 +279,7 @@ public class ProxyInboundHandler implements ProtocolMethodProcessor {
                     return;
                 }
 
-                proxyHandler = proxyHandlerMap.computeIfAbsent(
-                        topicName, key -> {
-                    try {
-                        return new ProxyHandler(proxyService,
-                                proxyConnection,
-                                pair.getLeft(),
-                                pair.getRight(),
-                                connectMsgList);
-                    } catch (Exception e) {
-                        log.error("[Proxy Subscribe] Failed to perform lookup request", e);
-                        return null;
-                    }
-                });
-
-                if (null == proxyHandler) {
-                    channel.close();
-                    return;
-                }
-
-
-                proxyHandler.getBrokerChannel().writeAndFlush(msg);
+                writeAndFlush(topicName, pair.getLeft(), pair.getRight(), channel, msg);
             });
         }
     }
@@ -344,25 +304,8 @@ public class ProxyInboundHandler implements ProtocolMethodProcessor {
                     channel.close();
                     return;
                 }
-                proxyHandler = proxyHandlerMap.computeIfAbsent(topic, key -> {
-                    try {
-                        return new ProxyHandler(proxyService,
-                                proxyConnection,
-                                pair.getLeft(),
-                                pair.getRight(),
-                                connectMsgList);
-                    } catch (Exception e) {
-                        log.error("[Proxy UnSubscribe] Failed to perform lookup request", e);
-                        return null;
-                    }
-                });
 
-                if (null == proxyHandler) {
-                    channel.close();
-                    return;
-                }
-
-                proxyHandler.getBrokerChannel().writeAndFlush(msg);
+                writeAndFlush(topic, pair.getLeft(), pair.getRight(), channel, msg);
             });
         }
     }
@@ -408,6 +351,45 @@ public class ProxyInboundHandler implements ProtocolMethodProcessor {
         }
         // todo remove subscriptions from Pulsar.
         return true;
+    }
+
+    private ProxyHandler getProxyHandler(String topic, String mqttBrokerHost, int mqttBrokerPort) {
+        return proxyHandlerMap.computeIfAbsent(topic, key -> {
+            try {
+                return new ProxyHandler(proxyService,
+                        proxyConnection,
+                        mqttBrokerHost,
+                        mqttBrokerPort,
+                        connectMsgList);
+            } catch (Exception e) {
+                log.error("[Proxy UnSubscribe] Failed to perform lookup request", e);
+                return null;
+            }
+        });
+    }
+
+    private void writeAndFlush(String topic, String mqttBrokerHost, int mqttBrokerPort,
+                               Channel channel, MqttMessage msg) {
+        ProxyHandler proxyHandler = getProxyHandler(topic, mqttBrokerHost, mqttBrokerPort);
+        if (null == proxyHandler) {
+            channel.close();
+            return;
+        }
+        proxyHandler.brokerFuture().whenComplete((ignored, throwable) -> {
+            if (throwable != null) {
+                log.error("[{}] MoP proxy failed to connect with MoP broker({}:{}).",
+                        msg.fixedHeader().messageType(), mqttBrokerHost, mqttBrokerPort, throwable);
+                channel.close();
+                return;
+            }
+            if (proxyHandler.getBrokerChannel().isWritable()) {
+                proxyHandler.getBrokerChannel().writeAndFlush(msg);
+            } else {
+                log.error("The broker channel({}:{}) is not writable!", mqttBrokerHost, mqttBrokerPort, throwable);
+                channel.close();
+                proxyHandler.close();
+            }
+        });
     }
 
 }


### PR DESCRIPTION
# Motication

Currently, the MoP proxy connects with the MoP broker by the method `await()`, this is a block method and it's not recommented, it may cause a deadLock exception.

```
07:17:11.254 [mqtt-redirect-io-32-1:io.streamnative.pulsar.handlers.mqtt.proxy.ProxyInboundHandler@311] ERROR io.streamnative.pulsar.handlers.mqtt.proxy.ProxyInboundHandler - [Proxy Subscribe] Failed to perform lookup request
io.netty.util.concurrent.BlockingOperationException: DefaultChannelPromise@51264ab4(incomplete)
	at io.netty.util.concurrent.DefaultPromise.checkDeadLock(DefaultPromise.java:462) ~[netty-common-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.channel.DefaultChannelPromise.checkDeadLock(DefaultChannelPromise.java:159) ~[netty-transport-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.util.concurrent.DefaultPromise.await(DefaultPromise.java:247) ~[netty-common-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.channel.DefaultChannelPromise.await(DefaultChannelPromise.java:131) ~[netty-transport-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.channel.DefaultChannelPromise.await(DefaultChannelPromise.java:30) ~[netty-transport-4.1.66.Final.jar:4.1.66.Final]
	at io.streamnative.pulsar.handlers.mqtt.proxy.ProxyHandler.<init>(ProxyHandler.java:73) ~[classes/:?]
	at io.streamnative.pulsar.handlers.mqtt.proxy.ProxyInboundHandler.lambda$null$2(ProxyInboundHandler.java:308) ~[classes/:?]
	at java.util.HashMap.computeIfAbsent(HashMap.java:1127) ~[?:1.8.0_302]
	at io.streamnative.pulsar.handlers.mqtt.proxy.ProxyInboundHandler.lambda$processSubscribe$3(ProxyInboundHandler.java:302) ~[classes/:?]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:774) [?:1.8.0_302]
	at java.util.concurrent.CompletableFuture.uniWhenCompleteStage(CompletableFuture.java:792) [?:1.8.0_302]
	at java.util.concurrent.CompletableFuture.whenComplete(CompletableFuture.java:2153) [?:1.8.0_302]
	at io.streamnative.pulsar.handlers.mqtt.proxy.ProxyInboundHandler.processSubscribe(ProxyInboundHandler.java:294) [classes/:?]
	at io.streamnative.pulsar.handlers.mqtt.proxy.ProxyConnection.channelRead(ProxyConnection.java:97) [classes/:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [netty-transport-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [netty-transport-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [netty-transport-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324) [netty-codec-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296) [netty-codec-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [netty-transport-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [netty-transport-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [netty-transport-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286) [netty-handler-4.1.63.Final.jar:4.1.63.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [netty-transport-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [netty-transport-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [netty-transport-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) [netty-transport-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [netty-transport-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [netty-transport-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) [netty-transport-4.1.66.Final.jar:4.1.66.Final]
	at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:795) [netty-transport-native-epoll-4.1.63.Final.jar:4.1.63.Final]
	at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:480) [netty-transport-native-epoll-4.1.63.Final.jar:4.1.63.Final]
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:378) [netty-transport-native-epoll-4.1.63.Final.jar:4.1.63.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) [netty-common-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [netty-common-4.1.67.Final.jar:4.1.67.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-common-4.1.67.Final.jar:4.1.67.Final]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_302]

```

# Modification

Make MoP proxy connect with MoP broker asynchronously.