### PR TITLE
Support nonpersistent config

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/AbstractQosPublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/AbstractQosPublishHandler.java
@@ -44,7 +44,8 @@ public abstract class AbstractQosPublishHandler implements QosPublishHandler {
 
     protected CompletableFuture<Optional<Topic>> getTopicReference(MqttPublishMessage msg) {
         return PulsarTopicUtils.getTopicReference(pulsarService, msg.variableHeader().topicName(),
-                configuration.getDefaultTenant(), configuration.getDefaultNamespace(), true,configuration.getDefaultTopicDomain());
+                configuration.getDefaultTenant(), configuration.getDefaultNamespace(), true
+                , configuration.getDefaultTopicDomain());
     }
 
     protected CompletableFuture<PositionImpl> writeToPulsarTopic(MqttPublishMessage msg) {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/AbstractQosPublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/AbstractQosPublishHandler.java
@@ -44,7 +44,7 @@ public abstract class AbstractQosPublishHandler implements QosPublishHandler {
 
     protected CompletableFuture<Optional<Topic>> getTopicReference(MqttPublishMessage msg) {
         return PulsarTopicUtils.getTopicReference(pulsarService, msg.variableHeader().topicName(),
-                configuration.getDefaultTenant(), configuration.getDefaultNamespace(), true);
+                configuration.getDefaultTenant(), configuration.getDefaultNamespace(), true,configuration.getDefaultTopicDomain());
     }
 
     protected CompletableFuture<PositionImpl> writeToPulsarTopic(MqttPublishMessage msg) {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTProtocolHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTProtocolHandler.java
@@ -98,6 +98,7 @@ public class MQTTProtocolHandler implements ProtocolHandler {
         if (mqttConfig.isMqttProxyEnable()) {
             MQTTProxyConfiguration proxyConfig = new MQTTProxyConfiguration();
             proxyConfig.setMqttTenant(mqttConfig.getDefaultTenant());
+            proxyConfig.setDefaultTopicDomain(mqttConfig.getDefaultTopicDomain());
             proxyConfig.setMqttMaxNoOfChannels(mqttConfig.getMaxNoOfChannels());
             proxyConfig.setMqttMaxFrameSize(mqttConfig.getMaxFrameSize());
             proxyConfig.setMqttHeartBeat(mqttConfig.getHeartBeat());

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTServerConfiguration.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTServerConfiguration.java
@@ -101,7 +101,7 @@ public class MQTTServerConfiguration extends ServiceConfiguration {
     @FieldContext(
             category = CATEGORY_MQTT,
             required = true,
-            doc = "Default Pulsar topic persistent that the MQTT server used."
+            doc = "Default Pulsar topic that the MQTT server used."
     )
     private String defaultTopicDomain = "persistent";
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTServerConfiguration.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTServerConfiguration.java
@@ -101,7 +101,7 @@ public class MQTTServerConfiguration extends ServiceConfiguration {
     @FieldContext(
             category = CATEGORY_MQTT,
             required = true,
-            doc = "Default Pulsar topic that the MQTT server used."
+            doc = "Default Pulsar topic domain that the MQTT server used."
     )
     private String defaultTopicDomain = "persistent";
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTServerConfiguration.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTServerConfiguration.java
@@ -97,6 +97,14 @@ public class MQTTServerConfiguration extends ServiceConfiguration {
     )
     private String defaultNamespace = "default";
 
+
+    @FieldContext(
+            category = CATEGORY_MQTT,
+            required = true,
+            doc = "Default Pulsar topic persistent that the MQTT server used."
+    )
+    private String defaultTopicDomain = "persistent";
+
     @FieldContext(
             category = CATEGORY_MQTT_PROXY,
             required = false,

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyConfiguration.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyConfiguration.java
@@ -134,7 +134,7 @@ public class MQTTProxyConfiguration {
     @FieldContext(
             category = CATEGORY_MQTT,
             required = true,
-            doc = "Default Pulsar topic persistent that the MQTT server used."
+            doc = "Default Pulsar topic that the MQTT server used."
     )
     private String defaultTopicDomain = "persistent";
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyConfiguration.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyConfiguration.java
@@ -131,6 +131,13 @@ public class MQTTProxyConfiguration {
     )
     private String defaultNamespace = "default";
 
+    @FieldContext(
+            category = CATEGORY_MQTT,
+            required = true,
+            doc = "Default Pulsar topic persistent that the MQTT server used."
+    )
+    private String defaultTopicDomain = "persistent";
+
     private boolean tlsEnabledInProxy = false;
 
     @FieldContext(

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyConfiguration.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyConfiguration.java
@@ -134,7 +134,7 @@ public class MQTTProxyConfiguration {
     @FieldContext(
             category = CATEGORY_MQTT,
             required = true,
-            doc = "Default Pulsar topic that the MQTT server used."
+            doc = "Default Pulsar topic domain that the MQTT server used."
     )
     private String defaultTopicDomain = "persistent";
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -144,7 +144,8 @@ public class MQTTProxyProtocolMethodProcessor implements ProtocolMethodProcessor
 
         CompletableFuture<Pair<String, Integer>> lookupResult = lookupHandler.findBroker(
                 TopicName.get(PulsarTopicUtils.getEncodedPulsarTopicName(msg.variableHeader().topicName(),
-                        proxyConfig.getDefaultTenant(), proxyConfig.getDefaultNamespace(),TopicDomain.getEnum(proxyConfig.getDefaultTopicDomain()))));
+                        proxyConfig.getDefaultTenant(), proxyConfig.getDefaultNamespace(),
+                        TopicDomain.getEnum(proxyConfig.getDefaultTopicDomain()))));
         lookupResult.whenComplete((pair, throwable) -> {
             if (null != throwable) {
                 log.error("[Proxy Publish] Failed to perform lookup request for topic {}",
@@ -155,7 +156,8 @@ public class MQTTProxyProtocolMethodProcessor implements ProtocolMethodProcessor
             final String topicName;
             try {
                 topicName = PulsarTopicUtils.getEncodedPulsarTopicName(msg.variableHeader().topicName(),
-                        proxyConfig.getDefaultTenant(), proxyConfig.getDefaultNamespace(),TopicDomain.getEnum(proxyConfig.getDefaultTopicDomain()));
+                        proxyConfig.getDefaultTenant(), proxyConfig.getDefaultNamespace(),
+                        TopicDomain.getEnum(proxyConfig.getDefaultTopicDomain()));
             } catch (Exception e) {
                 log.error("[Proxy Publish] Failed to get Pulsar topic name for topic {}",
                         msg.variableHeader().topicName(), e);
@@ -212,7 +214,8 @@ public class MQTTProxyProtocolMethodProcessor implements ProtocolMethodProcessor
             log.debug("[Proxy Subscribe] [{}] msg: {}", channel, msg);
         }
         CompletableFuture<List<String>> topicListFuture = PulsarTopicUtils.asyncGetTopicsForSubscribeMsg(msg,
-                proxyConfig.getDefaultTenant(), proxyConfig.getDefaultNamespace(), pulsarService,proxyConfig.getDefaultTopicDomain());
+                proxyConfig.getDefaultTenant(), proxyConfig.getDefaultNamespace(), pulsarService,
+                proxyConfig.getDefaultTopicDomain());
 
         if (topicListFuture == null) {
             channel.close();

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -43,6 +43,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.authentication.AuthenticationProvider;
+import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.FutureUtil;
 
@@ -140,9 +141,10 @@ public class MQTTProxyProtocolMethodProcessor implements ProtocolMethodProcessor
         if (log.isDebugEnabled()) {
             log.debug("[Proxy Publish] [{}] handle processPublish", msg.variableHeader().topicName());
         }
+
         CompletableFuture<Pair<String, Integer>> lookupResult = lookupHandler.findBroker(
                 TopicName.get(PulsarTopicUtils.getEncodedPulsarTopicName(msg.variableHeader().topicName(),
-                        proxyConfig.getDefaultTenant(), proxyConfig.getDefaultNamespace())));
+                        proxyConfig.getDefaultTenant(), proxyConfig.getDefaultNamespace(),TopicDomain.getEnum(proxyConfig.getDefaultTopicDomain()))));
         lookupResult.whenComplete((pair, throwable) -> {
             if (null != throwable) {
                 log.error("[Proxy Publish] Failed to perform lookup request for topic {}",
@@ -153,7 +155,7 @@ public class MQTTProxyProtocolMethodProcessor implements ProtocolMethodProcessor
             final String topicName;
             try {
                 topicName = PulsarTopicUtils.getEncodedPulsarTopicName(msg.variableHeader().topicName(),
-                        proxyConfig.getDefaultTenant(), proxyConfig.getDefaultNamespace());
+                        proxyConfig.getDefaultTenant(), proxyConfig.getDefaultNamespace(),TopicDomain.getEnum(proxyConfig.getDefaultTopicDomain()));
             } catch (Exception e) {
                 log.error("[Proxy Publish] Failed to get Pulsar topic name for topic {}",
                         msg.variableHeader().topicName(), e);
@@ -210,7 +212,7 @@ public class MQTTProxyProtocolMethodProcessor implements ProtocolMethodProcessor
             log.debug("[Proxy Subscribe] [{}] msg: {}", channel, msg);
         }
         CompletableFuture<List<String>> topicListFuture = PulsarTopicUtils.asyncGetTopicsForSubscribeMsg(msg,
-                proxyConfig.getDefaultTenant(), proxyConfig.getDefaultNamespace(), pulsarService);
+                proxyConfig.getDefaultTenant(), proxyConfig.getDefaultNamespace(), pulsarService,proxyConfig.getDefaultTopicDomain());
 
         if (topicListFuture == null) {
             channel.close();

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
@@ -306,13 +306,14 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
         for (MqttTopicSubscription ackTopic : ackTopics) {
             CompletableFuture<List<String>> topicListFuture = PulsarTopicUtils.asyncGetTopicListFromTopicSubscription(
                     ackTopic.topicName(), configuration.getDefaultTenant(), configuration.getDefaultNamespace(),
-                    pulsarService,configuration.getDefaultTopicDomain());
+                    pulsarService, configuration.getDefaultTopicDomain());
             CompletableFuture<Void> completableFuture = topicListFuture.thenCompose(topics -> {
                 List<CompletableFuture<Subscription>> futures = new ArrayList<>();
                 for (String topic : topics) {
                     CompletableFuture<Subscription> future = PulsarTopicUtils
                             .getOrCreateSubscription(pulsarService, topic, clientID,
-                                    configuration.getDefaultTenant(), configuration.getDefaultNamespace(),configuration.getDefaultTopicDomain());
+                                    configuration.getDefaultTenant(), configuration.getDefaultNamespace(),
+                                    configuration.getDefaultTopicDomain());
                     future.thenAccept(sub -> {
                         try {
                             MQTTConsumer consumer = new MQTTConsumer(sub, ackTopic.topicName(),
@@ -350,12 +351,14 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
         List<CompletableFuture<Void>> futureList = new ArrayList<>(topicFilters.size());
         for (String topicFilter : topicFilters) {
             CompletableFuture<List<String>> topicListFuture = PulsarTopicUtils.asyncGetTopicListFromTopicSubscription(
-                    topicFilter, configuration.getDefaultTenant(), configuration.getDefaultNamespace(), pulsarService,configuration.getDefaultTopicDomain());
+                    topicFilter, configuration.getDefaultTenant(), configuration.getDefaultNamespace(), pulsarService,
+                    configuration.getDefaultTopicDomain());
             CompletableFuture<Void> future = topicListFuture.thenCompose(topics -> {
                 List<CompletableFuture<Void>> futures = new ArrayList<>();
                 for (String topic : topics) {
                     PulsarTopicUtils.getTopicReference(pulsarService, topic, configuration.getDefaultTenant(),
-                            configuration.getDefaultNamespace(), false,configuration.getDefaultTopicDomain()).thenAccept(topicOp -> {
+                            configuration.getDefaultNamespace(), false,
+                            configuration.getDefaultTopicDomain()).thenAccept(topicOp -> {
                         if (topicOp.isPresent()) {
                             Subscription subscription = topicOp.get().getSubscription(clientID);
                             if (subscription != null) {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
@@ -306,13 +306,13 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
         for (MqttTopicSubscription ackTopic : ackTopics) {
             CompletableFuture<List<String>> topicListFuture = PulsarTopicUtils.asyncGetTopicListFromTopicSubscription(
                     ackTopic.topicName(), configuration.getDefaultTenant(), configuration.getDefaultNamespace(),
-                    pulsarService);
+                    pulsarService,configuration.getDefaultTopicDomain());
             CompletableFuture<Void> completableFuture = topicListFuture.thenCompose(topics -> {
                 List<CompletableFuture<Subscription>> futures = new ArrayList<>();
                 for (String topic : topics) {
                     CompletableFuture<Subscription> future = PulsarTopicUtils
                             .getOrCreateSubscription(pulsarService, topic, clientID,
-                                    configuration.getDefaultTenant(), configuration.getDefaultNamespace());
+                                    configuration.getDefaultTenant(), configuration.getDefaultNamespace(),configuration.getDefaultTopicDomain());
                     future.thenAccept(sub -> {
                         try {
                             MQTTConsumer consumer = new MQTTConsumer(sub, ackTopic.topicName(),
@@ -350,12 +350,12 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
         List<CompletableFuture<Void>> futureList = new ArrayList<>(topicFilters.size());
         for (String topicFilter : topicFilters) {
             CompletableFuture<List<String>> topicListFuture = PulsarTopicUtils.asyncGetTopicListFromTopicSubscription(
-                    topicFilter, configuration.getDefaultTenant(), configuration.getDefaultNamespace(), pulsarService);
+                    topicFilter, configuration.getDefaultTenant(), configuration.getDefaultNamespace(), pulsarService,configuration.getDefaultTopicDomain());
             CompletableFuture<Void> future = topicListFuture.thenCompose(topics -> {
                 List<CompletableFuture<Void>> futures = new ArrayList<>();
                 for (String topic : topics) {
                     PulsarTopicUtils.getTopicReference(pulsarService, topic, configuration.getDefaultTenant(),
-                            configuration.getDefaultNamespace(), false).thenAccept(topicOp -> {
+                            configuration.getDefaultNamespace(), false,configuration.getDefaultTopicDomain()).thenAccept(topicOp -> {
                         if (topicOp.isPresent()) {
                             Subscription subscription = topicOp.get().getSubscription(clientID);
                             if (subscription != null) {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
@@ -99,11 +99,6 @@ public class PulsarTopicUtils {
         return promise;
     }
 
-//    public static String getEncodedPulsarTopicName(String mqttTopicName, String defaultTenant,
-//                                                   String defaultNamespace) {
-//        return getPulsarTopicName(mqttTopicName, defaultTenant, defaultNamespace, true,topicDomain);
-//    }
-
     public static String getEncodedPulsarTopicName(String mqttTopicName, String defaultTenant,
            String defaultNamespace, TopicDomain topicDomain) {
         return getPulsarTopicName(mqttTopicName, defaultTenant, defaultNamespace, true, topicDomain);

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
@@ -50,10 +50,11 @@ public class PulsarTopicUtils {
     public static final String NON_PERSISTENT_DOMAIN = TopicDomain.non_persistent.value() + "://";
 
     public static CompletableFuture<Optional<Topic>> getTopicReference(PulsarService pulsarService, String topicName,
-           String defaultTenant, String defaultNamespace, boolean encodeTopicName,String defaultTopicDomain) {
+           String defaultTenant, String defaultNamespace, boolean encodeTopicName, String defaultTopicDomain) {
         final TopicName topic;
         try {
-            topic = TopicName.get(getPulsarTopicName(topicName, defaultTenant, defaultNamespace, encodeTopicName,TopicDomain.getEnum(defaultTopicDomain)));
+            topic = TopicName.get(getPulsarTopicName(topicName, defaultTenant, defaultNamespace, encodeTopicName,
+                    TopicDomain.getEnum(defaultTopicDomain)));
         } catch (Exception e) {
             return FutureUtil.failedFuture(e);
         }
@@ -63,9 +64,11 @@ public class PulsarTopicUtils {
     }
 
     public static CompletableFuture<Subscription> getOrCreateSubscription(PulsarService pulsarService,
-              String topicName, String subscriptionName, String defaultTenant, String defaultNamespace,String defaultTopicDomain) {
+              String topicName, String subscriptionName, String defaultTenant, String defaultNamespace,
+                                                                          String defaultTopicDomain) {
         CompletableFuture<Subscription> promise = new CompletableFuture<>();
-        getTopicReference(pulsarService, topicName, defaultTenant, defaultNamespace, false,defaultTopicDomain).thenAccept(topicOp -> {
+        getTopicReference(pulsarService, topicName, defaultTenant, defaultNamespace, false,
+                defaultTopicDomain).thenAccept(topicOp -> {
             if (!topicOp.isPresent()) {
                 promise.completeExceptionally(new BrokerServiceException.TopicNotFoundException(topicName));
             } else {
@@ -102,12 +105,12 @@ public class PulsarTopicUtils {
 //    }
 
     public static String getEncodedPulsarTopicName(String mqttTopicName, String defaultTenant,
-           String defaultNamespace,TopicDomain topicDomain) {
-        return getPulsarTopicName(mqttTopicName, defaultTenant, defaultNamespace, true,topicDomain);
+           String defaultNamespace, TopicDomain topicDomain) {
+        return getPulsarTopicName(mqttTopicName, defaultTenant, defaultNamespace, true, topicDomain);
     }
 
     public static String getPulsarTopicName(String mqttTopicName, String defaultTenant, String defaultNamespace,
-            boolean urlEncoded,TopicDomain topicDomain) {
+            boolean urlEncoded, TopicDomain topicDomain) {
         if (mqttTopicName.startsWith(PERSISTENT_DOMAIN)
                 || mqttTopicName.startsWith(NON_PERSISTENT_DOMAIN)) {
             List<String> parts = Splitter.on("://").limit(2).splitToList(mqttTopicName);
@@ -133,7 +136,7 @@ public class PulsarTopicUtils {
     }
 
     public static Pair<TopicDomain, NamespaceName> getTopicDomainAndNamespaceFromTopicFilter(String mqttTopicFilter,
-            String defaultTenant, String defaultNamespace,String defaultTopicDomain) {
+            String defaultTenant, String defaultNamespace, String defaultTopicDomain) {
         if (mqttTopicFilter.startsWith(PERSISTENT_DOMAIN)
                 || mqttTopicFilter.startsWith(NON_PERSISTENT_DOMAIN)) {
             List<String> parts = Splitter.on("://").limit(2).splitToList(mqttTopicFilter);
@@ -174,13 +177,14 @@ public class PulsarTopicUtils {
     }
 
     public static CompletableFuture<List<String>> asyncGetTopicsForSubscribeMsg(MqttSubscribeMessage msg,
-                 String defaultTenant, String defaultNamespace, PulsarService pulsarService,String defaultTopicDomain) {
+                 String defaultTenant, String defaultNamespace, PulsarService pulsarService,
+                                                                                String defaultTopicDomain) {
         List<CompletableFuture<List<String>>> topicListFuture =
                 new ArrayList<>(msg.payload().topicSubscriptions().size());
 
         for (MqttTopicSubscription req : msg.payload().topicSubscriptions()) {
             topicListFuture.add(asyncGetTopicListFromTopicSubscription(req.topicName(), defaultTenant, defaultNamespace,
-                    pulsarService,defaultTopicDomain));
+                    pulsarService, defaultTopicDomain));
         }
 
         CompletableFuture<List<String>> completeTopicListFuture = null;
@@ -200,14 +204,14 @@ public class PulsarTopicUtils {
     }
 
     public static CompletableFuture<List<String>> asyncGetTopicListFromTopicSubscription(String topicFilter,
-         String defaultTenant, String defaultNamespace, PulsarService pulsarService,String defaultTopicDomain) {
+         String defaultTenant, String defaultNamespace, PulsarService pulsarService, String defaultTopicDomain) {
         if (topicFilter.contains(TopicFilter.SINGLE_LEVEL)
                 || topicFilter.contains(TopicFilter.MULTI_LEVEL)) {
             TopicFilter filter = PulsarTopicUtils.getTopicFilter(topicFilter);
             Pair<TopicDomain, NamespaceName> domainNamespacePair =
                     PulsarTopicUtils
                             .getTopicDomainAndNamespaceFromTopicFilter(topicFilter, defaultTenant,
-                            defaultNamespace,defaultTopicDomain);
+                            defaultNamespace, defaultTopicDomain);
             return pulsarService.getNamespaceService().getListOfTopics(
                     domainNamespacePair.getRight(), domainNamespacePair.getLeft() == TopicDomain.persistent
                             ? CommandGetTopicsOfNamespace.Mode.PERSISTENT
@@ -217,7 +221,8 @@ public class PulsarTopicUtils {
                             .collect(Collectors.toList())));
         } else {
             return CompletableFuture.completedFuture(Collections.singletonList(
-                    PulsarTopicUtils.getEncodedPulsarTopicName(topicFilter, defaultTenant, defaultNamespace,TopicDomain.getEnum(defaultTopicDomain))));
+                    PulsarTopicUtils.getEncodedPulsarTopicName(topicFilter, defaultTenant, defaultNamespace,
+                            TopicDomain.getEnum(defaultTopicDomain))));
         }
     }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
@@ -129,7 +129,6 @@ public class PulsarTopicUtils {
             return TopicName.get(domain, tenant, namespace,
                     urlEncoded ? URLEncoder.encode(localName) : localName).toString();
         } else {
-            //TopicDomain.persistent
             return TopicName.get(topicDomain.value(), defaultTenant, defaultNamespace,
                     URLEncoder.encode(mqttTopicName)).toString();
         }

--- a/mqtt-impl/src/test/java/io/streamnative/pulsar/handlers/mqtt/untils/PulsarTopicUtilsTest.java
+++ b/mqtt-impl/src/test/java/io/streamnative/pulsar/handlers/mqtt/untils/PulsarTopicUtilsTest.java
@@ -16,7 +16,10 @@ package io.streamnative.pulsar.handlers.mqtt.untils;
 import io.streamnative.pulsar.handlers.mqtt.TopicFilter;
 import io.streamnative.pulsar.handlers.mqtt.utils.PulsarTopicUtils;
 import java.net.URLEncoder;
+import java.util.List;
+
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.testng.Assert;
@@ -30,19 +33,19 @@ public class PulsarTopicUtilsTest {
     @Test
     public void testMqttTopicNameToPulsarTopicName() {
         String t0 = "/aaa/bbb/ccc";
-        Assert.assertEquals(PulsarTopicUtils.getEncodedPulsarTopicName(t0, "public", "default"),
+        Assert.assertEquals(PulsarTopicUtils.getEncodedPulsarTopicName(t0, "public", "default", TopicDomain.persistent),
                 "persistent://public/default/" + URLEncoder.encode(t0));
         t0 = "aaa/bbb/ccc/";
-        Assert.assertEquals(PulsarTopicUtils.getEncodedPulsarTopicName(t0, "public", "default"),
+        Assert.assertEquals(PulsarTopicUtils.getEncodedPulsarTopicName(t0, "public", "default", TopicDomain.persistent),
                 "persistent://public/default/" + URLEncoder.encode(t0));
         t0 = "/aaa/bbb/ccc/";
-        Assert.assertEquals(PulsarTopicUtils.getEncodedPulsarTopicName(t0, "public", "default"),
+        Assert.assertEquals(PulsarTopicUtils.getEncodedPulsarTopicName(t0, "public", "default", TopicDomain.persistent),
                 "persistent://public/default/" + URLEncoder.encode(t0));
         t0 = "persistent://public/default/aaa/bbb/ccc";
-        Assert.assertEquals(PulsarTopicUtils.getEncodedPulsarTopicName(t0, "public", "default"),
+        Assert.assertEquals(PulsarTopicUtils.getEncodedPulsarTopicName(t0, "public", "default", TopicDomain.persistent),
                 "persistent://public/default/" + URLEncoder.encode("aaa/bbb/ccc"));
         t0 = "persistent://public/default//aaa/bbb/ccc";
-        Assert.assertEquals(PulsarTopicUtils.getEncodedPulsarTopicName(t0, "public", "default"),
+        Assert.assertEquals(PulsarTopicUtils.getEncodedPulsarTopicName(t0, "public", "default", TopicDomain.persistent),
                 "persistent://public/default/" + URLEncoder.encode("/aaa/bbb/ccc"));
     }
 
@@ -56,10 +59,29 @@ public class PulsarTopicUtilsTest {
     @Test
     public void testGetTopicDomainAndNamespaceFromTopicFilter() {
         Pair<TopicDomain, NamespaceName> pair1 = PulsarTopicUtils.getTopicDomainAndNamespaceFromTopicFilter(
-                "/a/b/c", "public", "default");
+                "/a/b/c", "public", "default",TopicDomain.persistent.value());
         Pair<TopicDomain, NamespaceName> pair2 = PulsarTopicUtils.getTopicDomainAndNamespaceFromTopicFilter(
-                "persistent://public/default//a/b/c", "public", "default");
+                "persistent://public/default//a/b/c", "public", "default",TopicDomain.persistent.value());
         Assert.assertEquals(pair1, pair2);
 
     }
+
+    @Test
+    public void testasyncGetTopicListFromTopicSubscriptionForDefaultTopicDomain() {
+        //test default topic domaon for  non-persistent
+        List<String> topics1 = PulsarTopicUtils.asyncGetTopicListFromTopicSubscription(
+                "/a/b/c", "public", "default", null, "non-persistent").join();
+        List<String> topics2 = PulsarTopicUtils.asyncGetTopicListFromTopicSubscription(
+                "non-persistent://public/default//a/b/c", "public", "default", null, "non-persistent").join();
+        Assert.assertEquals(topics1, topics2);
+
+        //test default topic domaon for persistent
+         topics1 = PulsarTopicUtils.asyncGetTopicListFromTopicSubscription(
+                "/a/b/c", "public", "default", null, "persistent").join();
+         topics2 = PulsarTopicUtils.asyncGetTopicListFromTopicSubscription(
+                "persistent://public/default//a/b/c", "public", "default", null, "non-persistent").join();
+        Assert.assertEquals(topics1, topics2);
+    }
+
+
 }

--- a/mqtt-impl/src/test/java/io/streamnative/pulsar/handlers/mqtt/untils/PulsarTopicUtilsTest.java
+++ b/mqtt-impl/src/test/java/io/streamnative/pulsar/handlers/mqtt/untils/PulsarTopicUtilsTest.java
@@ -66,14 +66,14 @@ public class PulsarTopicUtilsTest {
 
     @Test
     public void testasyncGetTopicListFromTopicSubscriptionForDefaultTopicDomain() {
-        //test default topic domaon for  non-persistent
+        //test default topic domain for  non-persistent
         List<String> topics1 = PulsarTopicUtils.asyncGetTopicListFromTopicSubscription(
                 "/a/b/c", "public", "default", null, "non-persistent").join();
         List<String> topics2 = PulsarTopicUtils.asyncGetTopicListFromTopicSubscription(
                 "non-persistent://public/default//a/b/c", "public", "default", null, "non-persistent").join();
         Assert.assertEquals(topics1, topics2);
 
-        //test default topic domaon for persistent
+        //test default topic domain for persistent
          topics1 = PulsarTopicUtils.asyncGetTopicListFromTopicSubscription(
                 "/a/b/c", "public", "default", null, "persistent").join();
          topics2 = PulsarTopicUtils.asyncGetTopicListFromTopicSubscription(

--- a/mqtt-impl/src/test/java/io/streamnative/pulsar/handlers/mqtt/untils/PulsarTopicUtilsTest.java
+++ b/mqtt-impl/src/test/java/io/streamnative/pulsar/handlers/mqtt/untils/PulsarTopicUtilsTest.java
@@ -17,7 +17,6 @@ import io.streamnative.pulsar.handlers.mqtt.TopicFilter;
 import io.streamnative.pulsar.handlers.mqtt.utils.PulsarTopicUtils;
 import java.net.URLEncoder;
 import java.util.List;
-
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;

--- a/mqtt-impl/src/test/java/io/streamnative/pulsar/handlers/mqtt/untils/PulsarTopicUtilsTest.java
+++ b/mqtt-impl/src/test/java/io/streamnative/pulsar/handlers/mqtt/untils/PulsarTopicUtilsTest.java
@@ -19,7 +19,6 @@ import java.net.URLEncoder;
 import java.util.List;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.testng.Assert;
@@ -59,9 +58,9 @@ public class PulsarTopicUtilsTest {
     @Test
     public void testGetTopicDomainAndNamespaceFromTopicFilter() {
         Pair<TopicDomain, NamespaceName> pair1 = PulsarTopicUtils.getTopicDomainAndNamespaceFromTopicFilter(
-                "/a/b/c", "public", "default",TopicDomain.persistent.value());
+                "/a/b/c", "public", "default", TopicDomain.persistent.value());
         Pair<TopicDomain, NamespaceName> pair2 = PulsarTopicUtils.getTopicDomainAndNamespaceFromTopicFilter(
-                "persistent://public/default//a/b/c", "public", "default",TopicDomain.persistent.value());
+                "persistent://public/default//a/b/c", "public", "default", TopicDomain.persistent.value());
         Assert.assertEquals(pair1, pair2);
 
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/SimpleIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/SimpleIntegrationTest.java
@@ -21,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.naming.TopicDomain;
 import org.awaitility.Awaitility;
 import org.fusesource.mqtt.client.BlockingConnection;
 import org.fusesource.mqtt.client.MQTT;
@@ -83,7 +84,7 @@ public class SimpleIntegrationTest extends MQTTTestBase {
     @Test(dataProvider = "mqttTopicNames", timeOut = TIMEOUT)
     public void testSendByMqttAndReceiveByPulsar(String topic) throws Exception {
         Consumer<byte[]> consumer = pulsarClient.newConsumer()
-                .topic(PulsarTopicUtils.getEncodedPulsarTopicName(topic, "public", "default"))
+                .topic(PulsarTopicUtils.getEncodedPulsarTopicName(topic, "public", "default", TopicDomain.persistent))
                 .subscriptionName("my-sub")
                 .subscribe();
 


### PR DESCRIPTION
 #50 

Support config of non-persistent topic by default.

In my case,  some time i just use non-persistent for mop , i want my user use topic `topicA` not `non-persistent://public/default/topicA`.