### PR TITLE
Refactor mop proxy part

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTChannelInitializer.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTChannelInitializer.java
@@ -21,7 +21,7 @@ import io.netty.handler.codec.mqtt.MqttEncoder;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateHandler;
-import io.streamnative.pulsar.handlers.mqtt.support.ProtocolMethodProcessorImpl;
+import io.streamnative.pulsar.handlers.mqtt.support.DefaultProtocolMethodProcessorImpl;
 import java.util.Map;
 import lombok.Getter;
 import org.apache.pulsar.broker.PulsarService;
@@ -101,6 +101,7 @@ public class MQTTChannelInitializer extends ChannelInitializer<SocketChannel> {
         ch.pipeline().addLast("decoder", new MqttDecoder());
         ch.pipeline().addLast("encoder", MqttEncoder.INSTANCE);
         ch.pipeline().addLast("handler",
-                new MQTTInboundHandler(new ProtocolMethodProcessorImpl(pulsarService, mqttConfig, authProviders)));
+                new MQTTInboundHandler(new DefaultProtocolMethodProcessorImpl(pulsarService, mqttConfig,
+                        authProviders)));
     }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTProtocolHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTProtocolHandler.java
@@ -17,8 +17,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.collect.ImmutableMap;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
-import io.streamnative.pulsar.handlers.mqtt.proxy.ProxyConfiguration;
-import io.streamnative.pulsar.handlers.mqtt.proxy.ProxyService;
+import io.streamnative.pulsar.handlers.mqtt.proxy.MQTTProxyConfiguration;
+import io.streamnative.pulsar.handlers.mqtt.proxy.MQTTProxyService;
 import io.streamnative.pulsar.handlers.mqtt.utils.AuthUtils;
 import io.streamnative.pulsar.handlers.mqtt.utils.ConfigurationUtils;
 import java.net.InetSocketAddress;
@@ -54,7 +54,7 @@ public class MQTTProtocolHandler implements ProtocolHandler {
     @Getter
     private String bindAddress;
 
-    private ProxyService proxyService;
+    private MQTTProxyService proxyService;
 
     @Override
     public String protocolName() {
@@ -96,7 +96,7 @@ public class MQTTProtocolHandler implements ProtocolHandler {
         }
 
         if (mqttConfig.isMqttProxyEnable()) {
-            ProxyConfiguration proxyConfig = new ProxyConfiguration();
+            MQTTProxyConfiguration proxyConfig = new MQTTProxyConfiguration();
             proxyConfig.setMqttTenant(mqttConfig.getDefaultTenant());
             proxyConfig.setMqttMaxNoOfChannels(mqttConfig.getMaxNoOfChannels());
             proxyConfig.setMqttMaxFrameSize(mqttConfig.getMaxFrameSize());
@@ -129,12 +129,12 @@ public class MQTTProtocolHandler implements ProtocolHandler {
             proxyConfig.setTlsKeyStorePassword(mqttConfig.getTlsTrustStorePassword());
             proxyConfig.setTlsKeyFilePath(mqttConfig.getTlsKeyFilePath());
             log.info("proxyConfig broker service URL: {}", proxyConfig.getBrokerServiceURL());
-            proxyService = new ProxyService(proxyConfig, brokerService.getPulsar(), authProviders);
+            proxyService = new MQTTProxyService(proxyConfig, brokerService.getPulsar(), authProviders);
             try {
                 proxyService.start();
                 log.info("Start MQTT proxy service at port: {}", proxyConfig.getMqttProxyPort());
-            } catch (Exception e) {
-                log.error("Failed to start MQTT proxy service.");
+            } catch (Exception ex) {
+                log.error("Failed to start MQTT proxy service.", ex);
             }
         }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/LookupHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/LookupHandler.java
@@ -32,4 +32,8 @@ public interface LookupHandler {
     CompletableFuture<Pair<String, Integer>> findBroker(TopicName topicName,
                                                         String protocolHandlerName) throws Exception;
 
+    /**
+     * Close the lookup handler to cleanup the resource.
+     */
+    void close();
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyChannelInitializer.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyChannelInitializer.java
@@ -29,11 +29,11 @@ import org.apache.pulsar.common.util.keystoretls.NettySSLContextAutoRefreshBuild
 /**
  * Proxy service channel initializer.
  */
-public class ServiceChannelInitializer extends ChannelInitializer<SocketChannel> {
+public class MQTTProxyChannelInitializer extends ChannelInitializer<SocketChannel> {
 
-    private final ProxyService proxyService;
+    private final MQTTProxyService proxyService;
     @Getter
-    private final ProxyConfiguration proxyConfig;
+    private final MQTTProxyConfiguration proxyConfig;
 
     private final boolean enableTls;
     private final boolean tlsEnabledWithKeyStore;
@@ -41,7 +41,8 @@ public class ServiceChannelInitializer extends ChannelInitializer<SocketChannel>
     private SslContextAutoRefreshBuilder<SslContext> serverSslCtxRefresher;
     private NettySSLContextAutoRefreshBuilder serverSSLContextAutoRefreshBuilder;
 
-    public ServiceChannelInitializer(ProxyService proxyService, ProxyConfiguration proxyConfig, boolean enableTls) {
+    public MQTTProxyChannelInitializer(MQTTProxyService proxyService, MQTTProxyConfiguration proxyConfig,
+                                       boolean enableTls) {
         this.proxyService = proxyService;
         this.proxyConfig = proxyConfig;
         this.enableTls = enableTls;
@@ -93,7 +94,7 @@ public class ServiceChannelInitializer extends ChannelInitializer<SocketChannel>
         }
         ch.pipeline().addLast("decoder", new MqttDecoder());
         ch.pipeline().addLast("encoder", MqttEncoder.INSTANCE);
-        ch.pipeline().addLast("handler", new ProxyConnection(proxyService));
+        ch.pipeline().addLast("handler", new MQTTProxyHandler(proxyService));
     }
 
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyConfiguration.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyConfiguration.java
@@ -27,7 +27,7 @@ import org.apache.pulsar.common.configuration.FieldContext;
  */
 @Getter
 @Setter
-public class ProxyConfiguration {
+public class MQTTProxyConfiguration {
 
     @Category
     private static final String CATEGORY_MQTT = "MQTT on Pulsar";

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyException.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyException.java
@@ -16,14 +16,18 @@ package io.streamnative.pulsar.handlers.mqtt.proxy;
 /**
  * Proxy exception.
  */
-public class ProxyException extends Exception {
+public class MQTTProxyException extends Exception {
 
-    public ProxyException() {
+    public MQTTProxyException() {
         super();
     }
 
-    public ProxyException(String message) {
+    public MQTTProxyException(String message) {
         super(message);
+    }
+
+    public MQTTProxyException(Throwable cause) {
+        super(cause);
     }
 
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyService.java
@@ -20,38 +20,30 @@ import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.Map;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.authentication.AuthenticationProvider;
-import org.apache.pulsar.client.api.AuthenticationFactory;
-import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.client.impl.PulsarClientImpl;
-import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
 
 /**
  * This service is used for redirecting MQTT client request to proper MQTT protocol handler Broker.
  */
 @Slf4j
-public class ProxyService implements Closeable {
+public class MQTTProxyService implements Closeable {
 
     @Getter
-    private ProxyConfiguration proxyConfig;
+    private MQTTProxyConfiguration proxyConfig;
     @Getter
     private PulsarService pulsarService;
-    @Getter
-    private PulsarClientImpl pulsarClient;
     @Getter
     private LookupHandler lookupHandler;
 
     private Channel listenChannel;
     private Channel listenChannelTls;
-    private EventLoopGroup acceptorGroup;
-    @Getter
-    private EventLoopGroup workerGroup;
+    private final EventLoopGroup acceptorGroup;
+    private final EventLoopGroup workerGroup;
 
     private DefaultThreadFactory acceptorThreadFactory = new DefaultThreadFactory("mqtt-redirect-acceptor");
     private DefaultThreadFactory workerThreadFactory = new DefaultThreadFactory("mqtt-redirect-io");
@@ -60,9 +52,9 @@ public class ProxyService implements Closeable {
     @Getter
     private Map<String, AuthenticationProvider> authProviders;
 
-    public ProxyService(
-        ProxyConfiguration proxyConfig, PulsarService pulsarService,
-        Map<String, AuthenticationProvider> authProviders) {
+    public MQTTProxyService(
+            MQTTProxyConfiguration proxyConfig, PulsarService pulsarService,
+            Map<String, AuthenticationProvider> authProviders) {
         configValid(proxyConfig);
 
         this.proxyConfig = proxyConfig;
@@ -72,35 +64,39 @@ public class ProxyService implements Closeable {
         workerGroup = EventLoopUtil.newEventLoopGroup(numThreads, false, workerThreadFactory);
     }
 
-    private void configValid(ProxyConfiguration proxyConfig) {
+    private void configValid(MQTTProxyConfiguration proxyConfig) {
         checkNotNull(proxyConfig);
         checkArgument(proxyConfig.getMqttProxyPort() > 0);
         checkNotNull(proxyConfig.getMqttTenant());
         checkNotNull(proxyConfig.getBrokerServiceURL());
     }
 
-    public void start() throws Exception {
+    public void start() throws MQTTProxyException {
         ServerBootstrap serverBootstrap = new ServerBootstrap();
         serverBootstrap.group(acceptorGroup, workerGroup);
         serverBootstrap.channel(EventLoopUtil.getServerSocketChannelClass(workerGroup));
         EventLoopUtil.enableTriggeredMode(serverBootstrap);
-        serverBootstrap.childHandler(new ServiceChannelInitializer(this, proxyConfig, false));
+        serverBootstrap.childHandler(new MQTTProxyChannelInitializer(this, proxyConfig, false));
+
         try {
             listenChannel = serverBootstrap.bind(proxyConfig.getMqttProxyPort()).sync().channel();
             log.info("Started MQTT Proxy on {}", listenChannel.localAddress());
         } catch (InterruptedException e) {
-            throw new IOException("Failed to bind MQTT Proxy on port " + proxyConfig.getMqttProxyPort(), e);
+            throw new MQTTProxyException(e);
         }
 
         if (proxyConfig.isTlsEnabledInProxy()) {
             ServerBootstrap tlsBootstrap = serverBootstrap.clone();
-            tlsBootstrap.childHandler(new ServiceChannelInitializer(this, proxyConfig, true));
-            listenChannelTls = tlsBootstrap.bind(proxyConfig.getMqttProxyTlsPort()).sync().channel();
-            log.info("Started MQTT TLS Proxy on {}", listenChannelTls.localAddress());
+            tlsBootstrap.childHandler(new MQTTProxyChannelInitializer(this, proxyConfig, true));
+            try {
+                listenChannelTls = tlsBootstrap.bind(proxyConfig.getMqttProxyTlsPort()).sync().channel();
+                log.info("Started MQTT TLS Proxy on {}", listenChannelTls.localAddress());
+            } catch (InterruptedException e) {
+                throw new MQTTProxyException(e);
+            }
         }
 
-        this.pulsarClient = new PulsarClientImpl(createClientConfiguration());
-        this.lookupHandler = new PulsarServiceLookupHandler(pulsarService, pulsarClient);
+        this.lookupHandler = new PulsarServiceLookupHandler(pulsarService, proxyConfig);
     }
 
     @Override
@@ -111,26 +107,8 @@ public class ProxyService implements Closeable {
         if (listenChannelTls != null) {
             listenChannelTls.close();
         }
-        if (pulsarClient != null) {
-            try {
-                pulsarClient.close();
-            } catch (PulsarClientException ignore) {
-            }
-        }
+        lookupHandler.close();
         acceptorGroup.shutdownGracefully();
         workerGroup.shutdownGracefully();
-    }
-
-    private ClientConfigurationData createClientConfiguration()
-        throws PulsarClientException.UnsupportedAuthenticationException {
-        ClientConfigurationData clientConf = new ClientConfigurationData();
-        clientConf.setServiceUrl(proxyConfig.getBrokerServiceURL());
-        if (proxyConfig.getBrokerClientAuthenticationPlugin() != null) {
-            clientConf.setAuthentication(AuthenticationFactory.create(
-                proxyConfig.getBrokerClientAuthenticationPlugin(),
-                proxyConfig.getBrokerClientAuthenticationParameters())
-            );
-        }
-        return clientConf;
     }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
@@ -72,7 +72,7 @@ import org.apache.pulsar.common.util.FutureUtil;
  * Default implementation of protocol method processor.
  */
 @Slf4j
-public class ProtocolMethodProcessorImpl implements ProtocolMethodProcessor {
+public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcessor {
     private final PulsarService pulsarService;
     private final QosPublishHandlers qosPublishHandlers;
     private final MQTTServerConfiguration configuration;
@@ -82,7 +82,7 @@ public class ProtocolMethodProcessorImpl implements ProtocolMethodProcessor {
     private final Map<String, AuthenticationProvider> authProviders;
 
 
-    public ProtocolMethodProcessorImpl(
+    public DefaultProtocolMethodProcessorImpl(
         PulsarService pulsarService,
         MQTTServerConfiguration configuration,
         Map<String, AuthenticationProvider> authProviders


### PR DESCRIPTION
## Modification
- Rename ProxyService to MQTTProxyService.
- Rename ProxyConfiguration to MQTTProxyConfiguration.
- Rename ProxyException to MQTTProxyException.
- Rename ProxyHandler to MQTTProxyExchanger.
- Rename ProxyConnection to MQTTProxyHandler.
- Rename ProtocolMethodProcessorImpl to DefaultProtocolMethodProcessorImpl.
- Using HostAndPort instead of string host and int port.
- Add close method for LookupHandler.
- Remove unused fields and methods.
- Throw MQTTProxyException instead of Exception.
- Add print stack trace when start occurs exception. 