### PR TITLE
Remove the signature of `throws Exception` for LookupHandler#findBroker

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/LookupHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/LookupHandler.java
@@ -26,11 +26,9 @@ public interface LookupHandler {
      * Find broker for protocolHandler.
      *
      * @param topicName topic name
-     * @param protocolHandlerName protocolHandler name
      * @return Pair consist of brokerHost and brokerPort
      */
-    CompletableFuture<Pair<String, Integer>> findBroker(TopicName topicName,
-                                                        String protocolHandlerName) throws Exception;
+    CompletableFuture<Pair<String, Integer>> findBroker(TopicName topicName);
 
     /**
      * Close the lookup handler to cleanup the resource.

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/PulsarServiceLookupHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/PulsarServiceLookupHandler.java
@@ -38,6 +38,8 @@ import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 @Slf4j
 public class PulsarServiceLookupHandler implements LookupHandler {
 
+    private final String protocolHandlerName = "mqtt";
+
     private final PulsarClientImpl pulsarClient;
     private final MetadataCache<LocalBrokerData> localBrokerDataCache;
 
@@ -52,8 +54,7 @@ public class PulsarServiceLookupHandler implements LookupHandler {
     }
 
     @Override
-    public CompletableFuture<Pair<String, Integer>> findBroker(TopicName topicName,
-                                                               String protocolHandlerName) throws Exception {
+    public CompletableFuture<Pair<String, Integer>> findBroker(TopicName topicName) {
         CompletableFuture<Pair<String, Integer>> lookupResult = new CompletableFuture<>();
         CompletableFuture<Pair<InetSocketAddress, InetSocketAddress>> lookup =
                 pulsarClient.getLookup().getBroker(topicName);


### PR DESCRIPTION
## Motivation
As we define the return type of method [findBroker] as CompletableFuture which contains `exception` and `result value`.
So it's better to remove the signature of `throws Exception`

## Modification
- Remove the signature of `throws Exception` for LookupHandler#findBroker.