### PR TITLE
Fix subscribe with topic filter issues

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTConsumer.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTConsumer.java
@@ -21,6 +21,7 @@ import io.streamnative.pulsar.handlers.mqtt.OutstandingPacket;
 import io.streamnative.pulsar.handlers.mqtt.OutstandingPacketContainer;
 import io.streamnative.pulsar.handlers.mqtt.PacketIdGenerator;
 import io.streamnative.pulsar.handlers.mqtt.utils.PulsarMessageConverter;
+import io.streamnative.pulsar.handlers.mqtt.utils.PulsarTopicUtils;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -83,12 +84,13 @@ public class MQTTConsumer extends Consumer {
                 outstandingPacketContainer.add(new OutstandingPacket(this, packetId, entry.getLedgerId(),
                         entry.getEntryId()));
             }
-            List<MqttPublishMessage> messages = PulsarMessageConverter.toMqttMessages(mqttTopicName, entry,
+            String toConsumerTopicName = PulsarTopicUtils.getToConsumerTopicName(mqttTopicName, pulsarTopicName);
+            List<MqttPublishMessage> messages = PulsarMessageConverter.toMqttMessages(toConsumerTopicName, entry,
                     packetId, qos);
             for (MqttPublishMessage msg : messages) {
                 if (log.isDebugEnabled()) {
-                    log.debug("[{}] [{}] [{}] Send MQTT message to subscriber", pulsarTopicName,
-                            mqttTopicName, super.getSubscription().getName());
+                    log.debug("[{}] [{}] [{}] Send MQTT message {} to subscriber", pulsarTopicName,
+                            mqttTopicName, super.getSubscription().getName(), msg);
                 }
                 cnx.ctx().channel().write(msg);
             }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
@@ -213,4 +213,15 @@ public class PulsarTopicUtils {
                     PulsarTopicUtils.getEncodedPulsarTopicName(topicFilter, defaultTenant, defaultNamespace)));
         }
     }
+
+    public static String getToConsumerTopicName(String subTopicFilter, String pulsarTopicName) {
+        if (subTopicFilter.startsWith(TopicDomain.persistent.value())
+                || subTopicFilter.startsWith(TopicDomain.non_persistent.value())) {
+            TopicName topicName = TopicName.get(pulsarTopicName);
+            return TopicName.get(topicName.getDomain().value(), topicName.getTenant(), topicName.getNamespace(),
+                    URLDecoder.decode(topicName.getLocalName())).toString();
+        } else {
+            return URLDecoder.decode(TopicName.get(pulsarTopicName).getLocalName());
+        }
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,8 @@
         <mqtt.codec.version>4.1.67.Final</mqtt.codec.version>
         <log4j2.version>2.13.3</log4j2.version>
         <lombok.version>1.18.4</lombok.version>
-        <mqtt.client.version>1.16</mqtt.client.version>
+        <fusesource.client.version>1.16</fusesource.client.version>
+        <hivemq.mqtt.client.version>1.2.2</hivemq.mqtt.client.version>
         <javac.target>1.8</javac.target>
         <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -50,7 +50,14 @@
         <dependency>
             <groupId>org.fusesource.mqtt-client</groupId>
             <artifactId>mqtt-client</artifactId>
-            <version>${mqtt.client.version}</version>
+            <version>${fusesource.client.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.hivemq</groupId>
+            <artifactId>hivemq-mqtt-client-shaded</artifactId>
+            <version>${hivemq.mqtt.client.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/SimpleIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/SimpleIntegrationTest.java
@@ -30,7 +30,6 @@ import org.fusesource.mqtt.client.Topic;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -49,14 +48,6 @@ public class SimpleIntegrationTest extends MQTTTestBase {
     @Override
     public void cleanup() throws Exception {
         super.cleanup();
-    }
-
-    @DataProvider(name = "batchEnabled")
-    public Object[][] batchEnabled() {
-        return new Object[][] {
-                { true },
-                { false }
-        };
     }
 
     @Test(dataProvider = "mqttTopicNames", timeOut = TIMEOUT)

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTTestBase.java
@@ -32,6 +32,14 @@ public class MQTTTestBase extends MQTTProtocolHandlerTestBase {
 
     public static final int TIMEOUT = 60 * 1000;
 
+    @DataProvider(name = "batchEnabled")
+    public Object[][] batchEnabled() {
+        return new Object[][] {
+                { true },
+                { false }
+        };
+    }
+
     @DataProvider(name = "mqttTopicNames")
     public Object[][] mqttTopicNames() {
         return new Object[][] {
@@ -45,6 +53,35 @@ public class MQTTTestBase extends MQTTProtocolHandlerTestBase {
                 { "non-persistent://public/default/t0" },
                 { "non-persistent://public/default/a/b" },
                 { "non-persistent://public/default//a/b" },
+        };
+    }
+
+    @DataProvider(name = "mqttPersistentTopicNames")
+    public Object[][] mqttPersistentTopicNames() {
+        return new Object[][] {
+                { "a/b/c" },
+                { "/a/b/c" },
+                { "a/b/c/" },
+                { "/a/b/c/" },
+                { "persistent://public/default/t0" },
+                { "persistent://public/default/a/b" },
+                { "persistent://public/default//a/b" },
+        };
+    }
+
+    @DataProvider(name = "mqttTopicNameAndFilter")
+    public Object[][] mqttTopicNameAndFilter() {
+        return new Object[][] {
+                {"a/b/c", "a/+/c"},
+                {"a/b/c", "+/+/c"},
+                {"a/b/c", "+/+/+"},
+                {"a/b/c", "a/+/+"},
+                {"a/b/c", "a/#"},
+                {"/a/b/c", "/a/+/c"},
+                {"/a/b/c", "/+/+/c"},
+                {"/a/b/c", "/+/+/+"},
+                {"/a/b/c", "/a/+/+"},
+                {"/a/b/c", "/a/#"},
         };
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/hivemq/HiveMQIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/hivemq/HiveMQIntegrationTest.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.hivemq;
+
+import com.hivemq.client.mqtt.MqttGlobalPublishFilter;
+import com.hivemq.client.mqtt.datatypes.MqttQos;
+import com.hivemq.client.mqtt.mqtt3.Mqtt3BlockingClient;
+import com.hivemq.client.mqtt.mqtt3.Mqtt3Client;
+import com.hivemq.client.mqtt.mqtt3.message.publish.Mqtt3Publish;
+import io.streamnative.pulsar.handlers.mqtt.base.MQTTTestBase;
+import lombok.extern.slf4j.Slf4j;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class HiveMQIntegrationTest extends MQTTTestBase {
+
+    @BeforeClass
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    public void cleanup() throws Exception {
+        super.cleanup();
+    }
+
+    @Test(dataProvider = "mqttPersistentTopicNames")
+    public void testBasicPublishAndConsumeWithMQTT(String topic) throws Exception {
+        Thread.sleep(1000000);
+        Mqtt3BlockingClient client = createMqtt3Client();
+        client.connect();
+        client.subscribeWith().topicFilter(topic).qos(MqttQos.AT_LEAST_ONCE).send();
+        byte[] msg = "payload".getBytes();
+        client.publishWith()
+                .topic(topic)
+                .qos(MqttQos.AT_LEAST_ONCE)
+                .payload(msg)
+                .send();
+        try (Mqtt3BlockingClient.Mqtt3Publishes publishes = client.publishes(MqttGlobalPublishFilter.ALL)) {
+            Mqtt3Publish publish = publishes.receive();
+            Assert.assertEquals(publish.getPayloadAsBytes(), msg);
+        }
+        client.disconnect();
+    }
+
+    @Test(dataProvider = "mqttTopicNameAndFilter", timeOut = TIMEOUT)
+    public void testTopicNameFilter(String topic, String filter) throws Exception {
+        Mqtt3BlockingClient client = createMqtt3Client();
+        client.connect();
+        byte[] msg = "payload".getBytes();
+        client.publishWith()
+                .topic(topic)
+                .qos(MqttQos.AT_LEAST_ONCE)
+                .payload(msg)
+                .send();
+        client.subscribeWith().topicFilter(filter).qos(MqttQos.AT_LEAST_ONCE).send();
+        client.publishWith()
+                .topic(topic)
+                .qos(MqttQos.AT_LEAST_ONCE)
+                .payload(msg)
+                .send();
+        try (Mqtt3BlockingClient.Mqtt3Publishes publishes = client.publishes(MqttGlobalPublishFilter.ALL)) {
+            Mqtt3Publish publish = publishes.receive();
+            Assert.assertEquals(publish.getPayloadAsBytes(), msg);
+        }
+        client.unsubscribeWith().topicFilter(filter).send();
+        client.disconnect();
+    }
+
+    private Mqtt3BlockingClient createMqtt3Client() {
+        return Mqtt3Client.builder()
+                .serverHost("127.0.0.1")
+                .serverPort(getMqttBrokerPortList().get(0))
+                .buildBlocking();
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/hivemq/HiveMQIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/hivemq/HiveMQIntegrationTest.java
@@ -40,9 +40,8 @@ public class HiveMQIntegrationTest extends MQTTTestBase {
         super.cleanup();
     }
 
-    @Test(dataProvider = "mqttPersistentTopicNames")
+    @Test(dataProvider = "mqttPersistentTopicNames", timeOut = TIMEOUT)
     public void testBasicPublishAndConsumeWithMQTT(String topic) throws Exception {
-        Thread.sleep(1000000);
         Mqtt3BlockingClient client = createMqtt3Client();
         client.connect();
         client.subscribeWith().topicFilter(topic).qos(MqttQos.AT_LEAST_ONCE).send();


### PR DESCRIPTION
Looks There are some differences between different MQTT client handling the topic name of the message that send to the client.
For the fusesource MQTT client, looks it will not check the topic name of the message, but the mqtt.fx checked.
So all the integration tests passed, but after using mqtt.fx UI tool to verify the topic name filter, the single level
topic name filter does not works.

The fix is return the original topic name to the consumer to avoid differences topic handling between different clients.
And added hiveMQ MQTT client for the integration tests.