### PR TITLE
Redefine the `processDisconnect` and `processConnectionLost` method.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTInboundHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTInboundHandler.java
@@ -77,7 +77,7 @@ public class MQTTInboundHandler extends ChannelInboundHandlerAdapter {
                     processor.processPubRel(ctx.channel(), msg);
                     break;
                 case DISCONNECT:
-                    processor.processDisconnect(ctx.channel());
+                    processor.processDisconnect(ctx.channel(), msg);
                     break;
                 case PUBACK:
                     checkArgument(msg instanceof MqttPubAckMessage);
@@ -112,11 +112,7 @@ public class MQTTInboundHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        String clientID = NettyUtils.retrieveClientId(ctx.channel());
-        if (clientID != null && !clientID.isEmpty()) {
-            log.info("Notifying connection lost event. MqttClientId = {}.", clientID);
-            processor.processConnectionLost(clientID, ctx.channel());
-        }
+        processor.processConnectionLost(ctx.channel());
         ctx.close();
     }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/ProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/ProtocolMethodProcessor.java
@@ -39,9 +39,9 @@ public interface ProtocolMethodProcessor {
 
     void processPubComp(Channel channel, MqttMessage msg);
 
-    void processDisconnect(Channel channel) throws InterruptedException;
+    void processDisconnect(Channel channel, MqttMessage msg);
 
-    void processConnectionLost(String clientID, Channel channel);
+    void processConnectionLost(Channel channel);
 
     void processSubscribe(Channel channel, MqttSubscribeMessage msg);
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyHandler.java
@@ -99,7 +99,7 @@ public class MQTTProxyHandler extends ChannelInboundHandlerAdapter{
                     processor.processPubRel(ctx.channel(), msg);
                     break;
                 case DISCONNECT:
-                    processor.processDisconnect(ctx.channel());
+                    processor.processDisconnect(ctx.channel(), msg);
                     break;
                 case PUBACK:
                     checkState(msg instanceof MqttPubAckMessage);

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -189,7 +189,7 @@ public class MQTTProxyProtocolMethodProcessor implements ProtocolMethodProcessor
     }
 
     @Override
-    public void processDisconnect(Channel channel) throws InterruptedException {
+    public void processDisconnect(Channel channel, MqttMessage msg) {
         if (log.isDebugEnabled()) {
             log.debug("[Disconnect] [{}] ", channel);
         }
@@ -236,10 +236,13 @@ public class MQTTProxyProtocolMethodProcessor implements ProtocolMethodProcessor
     }
 
     @Override
-    public void processConnectionLost(String clientID, Channel channel) {
-        log.info("[Connection Lost] [{}] clientId: {}", channel, clientID);
-        ConnectionDescriptor oldConnDescr = new ConnectionDescriptor(clientID, channel, true);
-        ConnectionDescriptorStore.getInstance().removeConnection(oldConnDescr);
+    public void processConnectionLost(Channel channel) {
+        if (log.isDebugEnabled()) {
+            log.debug("[Connection Lost] channel [{}] ", channel);
+        }
+        String clientID = NettyUtils.retrieveClientId(channel);
+        ConnectionDescriptor oldConnDescriptor = new ConnectionDescriptor(clientID, channel, true);
+        ConnectionDescriptorStore.getInstance().removeConnection(oldConnDescriptor);
         removeSubscriptions(null, clientID);
     }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
@@ -242,7 +242,7 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
     }
 
     @Override
-    public void processDisconnect(Channel channel) throws InterruptedException {
+    public void processDisconnect(Channel channel, MqttMessage msg) {
         if (log.isDebugEnabled()) {
             log.debug("[Disconnect] [{}] ", channel);
         }
@@ -285,10 +285,13 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
     }
 
     @Override
-    public void processConnectionLost(String clientID, Channel channel) {
-        log.info("[Connection Lost] [{}] clientId: {}", channel, clientID);
-        ConnectionDescriptor oldConnDescr = new ConnectionDescriptor(clientID, channel, true);
-        ConnectionDescriptorStore.getInstance().removeConnection(oldConnDescr);
+    public void processConnectionLost(Channel channel) {
+        if (log.isDebugEnabled()) {
+            log.debug("[Connection Lost] channel [{}] ", channel);
+        }
+        String clientID = NettyUtils.retrieveClientId(channel);
+        ConnectionDescriptor oldConnDescriptor = new ConnectionDescriptor(clientID, channel, true);
+        ConnectionDescriptorStore.getInstance().removeConnection(oldConnDescriptor);
         removeSubscriptions(null, clientID);
     }
 


### PR DESCRIPTION
## Motivation
`processDisconnect` should add `MqttMessage` for proxy to transform it to mqtt broker. 

## Modification
- Add param `MqttMessage` for `processDisconnect`.
- Remove param `String clientID` for `processConnectionLost`.