### PR TITLE
Fix wrong topicname

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
@@ -218,7 +218,7 @@ public class PulsarTopicUtils {
         if (subTopicFilter.startsWith(TopicDomain.persistent.value())
                 || subTopicFilter.startsWith(TopicDomain.non_persistent.value())) {
             TopicName topicName = TopicName.get(pulsarTopicName);
-            return TopicName.get(topicName.getDomain().value(), topicName.getTenant(), topicName.getNamespace(),
+            return TopicName.get(topicName.getDomain().value(), topicName.getTenant(), topicName.getNamespace().replace(topicName.getTenant()+"/",""),
                     URLDecoder.decode(topicName.getLocalName())).toString();
         } else {
             return URLDecoder.decode(TopicName.get(pulsarTopicName).getLocalName());

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
@@ -218,7 +218,8 @@ public class PulsarTopicUtils {
         if (subTopicFilter.startsWith(TopicDomain.persistent.value())
                 || subTopicFilter.startsWith(TopicDomain.non_persistent.value())) {
             TopicName topicName = TopicName.get(pulsarTopicName);
-            return TopicName.get(topicName.getDomain().value(), topicName.getTenant(), topicName.getNamespace().replace(topicName.getTenant()+"/",""),
+            return TopicName.get(topicName.getDomain().value(), topicName.getTenant(),
+                    topicName.getNamespace().replace(topicName.getTenant() + "/", ""),
                     URLDecoder.decode(topicName.getLocalName())).toString();
         } else {
             return URLDecoder.decode(TopicName.get(pulsarTopicName).getLocalName());

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
@@ -218,8 +218,7 @@ public class PulsarTopicUtils {
         if (subTopicFilter.startsWith(TopicDomain.persistent.value())
                 || subTopicFilter.startsWith(TopicDomain.non_persistent.value())) {
             TopicName topicName = TopicName.get(pulsarTopicName);
-            return TopicName.get(topicName.getDomain().value(), topicName.getTenant(),
-                    topicName.getNamespace().replace(topicName.getTenant() + "/", ""),
+            return TopicName.get(topicName.getDomain().value(), NamespaceName.get(topicName.getNamespace()),
                     URLDecoder.decode(topicName.getLocalName())).toString();
         } else {
             return URLDecoder.decode(TopicName.get(pulsarTopicName).getLocalName());

--- a/mqtt-impl/src/test/java/io/streamnative/pulsar/handlers/mqtt/untils/PulsarTopicUtilsTest.java
+++ b/mqtt-impl/src/test/java/io/streamnative/pulsar/handlers/mqtt/untils/PulsarTopicUtilsTest.java
@@ -60,6 +60,29 @@ public class PulsarTopicUtilsTest {
         Pair<TopicDomain, NamespaceName> pair2 = PulsarTopicUtils.getTopicDomainAndNamespaceFromTopicFilter(
                 "persistent://public/default//a/b/c", "public", "default");
         Assert.assertEquals(pair1, pair2);
+    }
 
+    @Test
+    public void testGetToConsumerTopicName() {
+        String mqttTopicname = "non-persistent://public/default/topicA";
+        String pulsarTopicName = "non-persistent://public/default/topicA";
+        String consumerTopicName1 = PulsarTopicUtils.getToConsumerTopicName(
+                mqttTopicname, pulsarTopicName);
+        Assert.assertEquals(mqttTopicname, consumerTopicName1);
+        mqttTopicname = "topicA";
+        String consumerTopicName2 = PulsarTopicUtils.getToConsumerTopicName(
+                mqttTopicname, pulsarTopicName);
+        Assert.assertEquals(mqttTopicname, consumerTopicName2);
+
+
+        mqttTopicname = "persistent://public/default/topicA";
+        pulsarTopicName = "persistent://public/default/topicA";
+        consumerTopicName1 = PulsarTopicUtils.getToConsumerTopicName(
+                mqttTopicname, pulsarTopicName);
+        Assert.assertEquals(mqttTopicname, consumerTopicName1);
+        mqttTopicname = "topicA";
+        consumerTopicName2 = PulsarTopicUtils.getToConsumerTopicName(
+                mqttTopicname, pulsarTopicName);
+        Assert.assertEquals(mqttTopicname, consumerTopicName2);
     }
 }


### PR DESCRIPTION
This error Affect all topics of `[persistent/non-persistent]/{tenant}/{namespace}/{topic}`,  

Just wrong when i send message to `non-persistent://public/default/topicAAA`

TopicName.getNamespace() return `public/default`, and then the message will be send to `non-persistent://public/public/default/topicAAA` 

@codelipenghui   PTAL, Thanks.