### PR TITLE
Add checkState to log decoder failure instead of swallowing it.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTInboundHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTInboundHandler.java
@@ -15,6 +15,7 @@ package io.streamnative.pulsar.handlers.mqtt;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.netty.handler.codec.mqtt.MqttQoS.AT_MOST_ONCE;
+import static io.streamnative.pulsar.handlers.mqtt.utils.MqttMessageUtils.checkState;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -50,6 +51,7 @@ public class MQTTInboundHandler extends ChannelInboundHandlerAdapter {
             log.debug("Processing MQTT Inbound handler message, type={}", messageType);
         }
         try {
+            checkState(msg);
             switch (messageType) {
                 case CONNECT:
                     checkArgument(msg instanceof MqttConnectMessage);
@@ -98,8 +100,7 @@ public class MQTTInboundHandler extends ChannelInboundHandlerAdapter {
                     break;
             }
         } catch (Throwable ex) {
-            log.error("Exception was caught while processing MQTT message, " + ex.getCause(), ex);
-            ctx.fireExceptionCaught(ex);
+            log.error("Exception was caught while processing MQTT message, ", ex);
             ctx.close();
         }
     }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -40,6 +40,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.naming.AuthenticationException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.authentication.AuthenticationProvider;
@@ -81,7 +82,7 @@ public class MQTTProxyProtocolMethodProcessor implements ProtocolMethodProcessor
         }
 
         // Client must specify the client ID except enable clean session on the connection.
-        if (clientId == null || clientId.length() == 0) {
+        if (StringUtils.isEmpty(clientId)) {
             if (!msg.variableHeader().isCleanSession()) {
                 MqttConnAckMessage badId = connAck(MqttConnectReturnCode.CONNECTION_REFUSED_IDENTIFIER_REJECTED, false);
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
@@ -61,12 +61,12 @@ import java.util.concurrent.CompletableFuture;
 import javax.naming.AuthenticationException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.authentication.AuthenticationProvider;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.common.api.proto.CommandAck;
 import org.apache.pulsar.common.util.FutureUtil;
-
 
 /**
  * Default implementation of protocol method processor.
@@ -289,10 +289,12 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
         if (log.isDebugEnabled()) {
             log.debug("[Connection Lost] channel [{}] ", channel);
         }
-        String clientID = NettyUtils.retrieveClientId(channel);
-        ConnectionDescriptor oldConnDescriptor = new ConnectionDescriptor(clientID, channel, true);
-        ConnectionDescriptorStore.getInstance().removeConnection(oldConnDescriptor);
-        removeSubscriptions(null, clientID);
+        String clientId = NettyUtils.retrieveClientId(channel);
+        if (StringUtils.isNotEmpty(clientId)) {
+            ConnectionDescriptor oldConnDescriptor = new ConnectionDescriptor(clientId, channel, true);
+            ConnectionDescriptorStore.getInstance().removeConnection(oldConnDescriptor);
+            removeSubscriptions(null, clientId);
+        }
     }
 
     @Override

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MqttMessageUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MqttMessageUtils.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.utils;
+
+import io.netty.handler.codec.mqtt.MqttMessage;
+
+public class MqttMessageUtils {
+
+    public static void checkState(MqttMessage msg) {
+        if (!msg.decoderResult().isSuccess()) {
+            throw new IllegalStateException(msg.decoderResult().cause().getMessage());
+        }
+    }
+
+}


### PR DESCRIPTION
## Motivation
If `channelRead` occurs error, eg: clientId is invalid, we will not get the root cause in the stack trace. See below comments.
So we should check the message decoder state before other logics.

## Modification
- Add checkState for the message decoder state.
- Check clientId to avoid NPE.
- Add test cases.