### PR TITLE
Add checkState for proxy exchanger

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTInboundHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTInboundHandler.java
@@ -45,13 +45,14 @@ public class MQTTInboundHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object message) {
+        checkArgument(message instanceof MqttMessage);
         MqttMessage msg = (MqttMessage) message;
-        MqttMessageType messageType = msg.fixedHeader().messageType();
-        if (log.isDebugEnabled()) {
-            log.debug("Processing MQTT Inbound handler message, type={}", messageType);
-        }
         try {
             checkState(msg);
+            MqttMessageType messageType = msg.fixedHeader().messageType();
+            if (log.isDebugEnabled()) {
+                log.debug("Processing MQTT Inbound handler message, type={}", messageType);
+            }
             switch (messageType) {
                 case CONNECT:
                     checkArgument(msg instanceof MqttConnectMessage);

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyHandler.java
@@ -61,14 +61,14 @@ public class MQTTProxyHandler extends ChannelInboundHandlerAdapter{
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object message) throws Exception {
+        checkArgument(message instanceof MqttMessage);
         MqttMessage msg = (MqttMessage) message;
-        MqttMessageType messageType = msg.fixedHeader().messageType();
-
-        if (log.isDebugEnabled()) {
-            log.debug("Processing MQTT message, type={}", messageType);
-        }
         try {
             checkState(msg);
+            MqttMessageType messageType = msg.fixedHeader().messageType();
+            if (log.isDebugEnabled()) {
+                log.debug("Processing MQTT message, type={}", messageType);
+            }
             switch (messageType) {
                 case CONNECT:
                     checkArgument(msg instanceof MqttConnectMessage);


### PR DESCRIPTION
## Motivation
If mqtt broker send a bad request, proxy exchanger handler could not get the root cause. See below comment for stack trace.

## Modification
- Add checkState for ExchangerHandler.
- CheckState before retrieve the messageType.