### PR TITLE
[Test] Start multi-broker if proxy enabled.

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/ProxyTLSTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/ProxyTLSTest.java
@@ -17,7 +17,6 @@ package io.streamnative.pulsar.handlers.mqtt;
 import io.streamnative.pulsar.handlers.mqtt.base.MQTTTestBase;
 import java.io.File;
 import java.io.FileInputStream;
-import java.net.URI;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
@@ -49,8 +48,7 @@ public class ProxyTLSTest extends MQTTTestBase {
 
     @Test(dataProvider = "mqttTopicNames", timeOut = TIMEOUT)
     public void testConnectionUsingTLS(String topicName) throws Exception {
-        MQTT mqtt = new MQTT();
-        mqtt.setHost(URI.create("ssl://127.0.0.1:" + getMqttProxyPortList().get(1)));
+        MQTT mqtt = createMQTTProxyTlsClient();
         File crtFile = new File(TLS_SERVER_CERT_FILE_PATH);
         Certificate certificate = CertificateFactory
                 .getInstance("X.509").generateCertificate(new FileInputStream(crtFile));

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/TLSTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/TLSTest.java
@@ -17,7 +17,6 @@ package io.streamnative.pulsar.handlers.mqtt;
 import io.streamnative.pulsar.handlers.mqtt.base.MQTTTestBase;
 import java.io.File;
 import java.io.FileInputStream;
-import java.net.URI;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
@@ -48,9 +47,7 @@ public class TLSTest extends MQTTTestBase {
 
     @Test(dataProvider = "mqttTopicNames")
     public void testSimpleMqttPubAndSubQos0Tls(String topicName) throws Exception {
-        MQTT mqtt = new MQTT();
-        mqtt.setHost(URI.create("ssl://127.0.0.1:" + getMqttBrokerPortList().get(1)));
-
+        MQTT mqtt = createMQTTTlsClient();
         File crtFile = new File(TLS_SERVER_CERT_FILE_PATH);
         Certificate certificate = CertificateFactory
                 .getInstance("X.509").generateCertificate(new FileInputStream(crtFile));

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTTestBase.java
@@ -14,7 +14,10 @@
 package io.streamnative.pulsar.handlers.mqtt.base;
 
 import com.google.common.collect.Sets;
+import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Random;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
@@ -31,6 +34,8 @@ import org.testng.annotations.DataProvider;
 public class MQTTTestBase extends MQTTProtocolHandlerTestBase {
 
     public static final int TIMEOUT = 60 * 1000;
+
+    private final Random random = new Random();
 
     @DataProvider(name = "batchEnabled")
     public Object[][] batchEnabled() {
@@ -128,14 +133,32 @@ public class MQTTTestBase extends MQTTProtocolHandlerTestBase {
     }
 
     public MQTT createMQTTClient() throws URISyntaxException {
+        List<Integer> mqttBrokerPortList = getMqttBrokerPortList();
         MQTT mqtt = new MQTT();
-        mqtt.setHost("127.0.0.1", getMqttBrokerPortList().get(0));
+        mqtt.setHost("127.0.0.1", mqttBrokerPortList.get(random.nextInt(mqttBrokerPortList.size())));
+        return mqtt;
+    }
+
+    public MQTT createMQTTTlsClient() throws URISyntaxException {
+        List<Integer> mqttBrokerPortTlsList = getMqttBrokerPortTlsList();
+        MQTT mqtt = new MQTT();
+        mqtt.setHost(URI.create("ssl://127.0.0.1:"
+                + mqttBrokerPortTlsList.get(random.nextInt(mqttBrokerPortTlsList.size()))));
         return mqtt;
     }
 
     public MQTT createMQTTProxyClient() throws URISyntaxException {
+        List<Integer> mqttProxyPortList = getMqttProxyPortList();
         MQTT mqtt = createMQTTClient();
-        mqtt.setHost("127.0.0.1", getMqttProxyPortList().get(0));
+        mqtt.setHost("127.0.0.1", mqttProxyPortList.get(random.nextInt(mqttProxyPortList.size())));
+        return mqtt;
+    }
+
+    public MQTT createMQTTProxyTlsClient() throws URISyntaxException {
+        List<Integer> mqttProxyPortTlsList = getMqttProxyPortTlsList();
+        MQTT mqtt = createMQTTClient();
+        mqtt.setHost(URI.create("ssl://127.0.0.1:"
+                + mqttProxyPortTlsList.get(random.nextInt(mqttProxyPortTlsList.size()))));
         return mqtt;
     }
 }


### PR DESCRIPTION
## Motivation
When proxy is enabled,  the test case only starts one broker.  It's better to start multi-brokers in a cluster.