### PR TITLE
Add processPingReq to ProtocolMethodProcessor

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTInboundHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTInboundHandler.java
@@ -14,13 +14,11 @@
 package io.streamnative.pulsar.handlers.mqtt;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.netty.handler.codec.mqtt.MqttQoS.AT_MOST_ONCE;
 import static io.streamnative.pulsar.handlers.mqtt.utils.MqttMessageUtils.checkState;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
-import io.netty.handler.codec.mqtt.MqttFixedHeader;
 import io.netty.handler.codec.mqtt.MqttMessage;
 import io.netty.handler.codec.mqtt.MqttMessageType;
 import io.netty.handler.codec.mqtt.MqttPubAckMessage;
@@ -87,14 +85,7 @@ public class MQTTInboundHandler extends ChannelInboundHandlerAdapter {
                     processor.processPubAck(ctx.channel(), (MqttPubAckMessage) msg);
                     break;
                 case PINGREQ:
-                    MqttFixedHeader pingHeader = new MqttFixedHeader(
-                            MqttMessageType.PINGRESP,
-                            false,
-                            AT_MOST_ONCE,
-                            false,
-                            0);
-                    MqttMessage pingResp = new MqttMessage(pingHeader);
-                    ctx.writeAndFlush(pingResp);
+                    processor.processPingReq(ctx.channel());
                     break;
                 default:
                     log.error("Unknown MessageType:{}", messageType);

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/ProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/ProtocolMethodProcessor.java
@@ -13,6 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.mqtt;
 
+import static io.streamnative.pulsar.handlers.mqtt.utils.MqttMessageUtils.pingResp;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
@@ -50,4 +51,8 @@ public interface ProtocolMethodProcessor {
     void notifyChannelWritable(Channel channel);
 
     void channelActive(ChannelHandlerContext ctx);
+
+    default void processPingReq(Channel channel) {
+        channel.writeAndFlush(pingResp());
+    }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyHandler.java
@@ -14,12 +14,10 @@
 package io.streamnative.pulsar.handlers.mqtt.proxy;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.netty.handler.codec.mqtt.MqttQoS.AT_MOST_ONCE;
 import static io.streamnative.pulsar.handlers.mqtt.utils.MqttMessageUtils.checkState;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
-import io.netty.handler.codec.mqtt.MqttFixedHeader;
 import io.netty.handler.codec.mqtt.MqttMessage;
 import io.netty.handler.codec.mqtt.MqttMessageType;
 import io.netty.handler.codec.mqtt.MqttPubAckMessage;
@@ -30,7 +28,6 @@ import io.streamnative.pulsar.handlers.mqtt.ProtocolMethodProcessor;
 import io.streamnative.pulsar.handlers.mqtt.utils.NettyUtils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.client.api.PulsarClientException;
 
 /**
  * Proxy handler.
@@ -43,7 +40,7 @@ public class MQTTProxyHandler extends ChannelInboundHandlerAdapter{
     @Getter
     private ChannelHandlerContext cnx;
 
-    public MQTTProxyHandler(MQTTProxyService proxyService) throws PulsarClientException {
+    public MQTTProxyHandler(MQTTProxyService proxyService) {
         this.processor = new MQTTProxyProtocolMethodProcessor(proxyService, this);
     }
 
@@ -103,14 +100,7 @@ public class MQTTProxyHandler extends ChannelInboundHandlerAdapter{
                     processor.processPubAck(ctx.channel(), (MqttPubAckMessage) msg);
                     break;
                 case PINGREQ:
-                    MqttFixedHeader pingHeader = new MqttFixedHeader(
-                            MqttMessageType.PINGRESP,
-                            false,
-                            AT_MOST_ONCE,
-                            false,
-                            0);
-                    MqttMessage pingResp = new MqttMessage(pingHeader);
-                    ctx.writeAndFlush(pingResp);
+                    processor.processPingReq(ctx.channel());
                     break;
                 default:
                     log.error("Unknown MessageType:{}", messageType);

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MqttMessageUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MqttMessageUtils.java
@@ -58,6 +58,11 @@ public class MqttMessageUtils {
                 MqttMessageIdVariableHeader.from(packetId));
     }
 
+    public static MqttMessage pingResp() {
+        MqttFixedHeader pingHeader = new MqttFixedHeader(MqttMessageType.PINGRESP, false, AT_MOST_ONCE, false, 0);
+        return new MqttMessage(pingHeader);
+    }
+
     public static String createClientIdentifier(Channel channel) {
         String clientIdentifier;
         if (channel != null && channel.remoteAddress() instanceof InetSocketAddress) {


### PR DESCRIPTION
## Motivation
MQTTProxyHandler and MQTTInboundHandler have the same logic to process ping request. So define a default implementation of processPingReq can reuse the logic.


## Modification
- Add processPingReq to ProtocolMethodProcessor.