### PR TITLE
Make Netty boss and worker group configurable.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTCommonConfiguration.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTCommonConfiguration.java
@@ -116,6 +116,18 @@ public class MQTTCommonConfiguration extends ServiceConfiguration {
     private boolean mqttProxyTlsEnabled = false;
 
     @FieldContext(
+            category = CATEGORY_MQTT_PROXY,
+            doc = "Number of threads to use for Netty Acceptor. Default is set to `1`"
+    )
+    private int mqttProxyNumAcceptorThreads = 1;
+    @FieldContext(
+            category = CATEGORY_MQTT_PROXY,
+            doc = "Number of threads to use for Netty IO."
+                    + " Default is set to `Runtime.getRuntime().availableProcessors()`"
+    )
+    private int mqttProxyNumIOThreads = Runtime.getRuntime().availableProcessors();
+
+    @FieldContext(
             category = CATEGORY_TLS,
             doc = "Tls cert refresh duration in seconds (set 0 to check on every new connection)"
     )

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTProtocolHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTProtocolHandler.java
@@ -107,6 +107,8 @@ public class MQTTProtocolHandler implements ProtocolHandler {
             proxyConfig.setBrokerServiceURL("pulsar://"
                     + ServiceConfigurationUtils.getAppliedAdvertisedAddress(mqttConfig, true)
                     + ":" + mqttConfig.getBrokerServicePort().get());
+            proxyConfig.setMqttProxyNumAcceptorThreads(mqttConfig.getMqttProxyNumAcceptorThreads());
+            proxyConfig.setMqttProxyNumIOThreads(mqttConfig.getMqttProxyNumIOThreads());
             proxyConfig.setMqttAuthenticationEnabled(mqttConfig.isMqttAuthenticationEnabled());
             proxyConfig.setMqttAuthenticationMethods(mqttConfig.getMqttAuthenticationMethods());
             proxyConfig.setBrokerClientAuthenticationPlugin(mqttConfig.getBrokerClientAuthenticationPlugin());

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyService.java
@@ -47,7 +47,6 @@ public class MQTTProxyService implements Closeable {
 
     private DefaultThreadFactory acceptorThreadFactory = new DefaultThreadFactory("mqtt-redirect-acceptor");
     private DefaultThreadFactory workerThreadFactory = new DefaultThreadFactory("mqtt-redirect-io");
-    private static final int numThreads = Runtime.getRuntime().availableProcessors();
 
     @Getter
     private Map<String, AuthenticationProvider> authProviders;
@@ -60,8 +59,10 @@ public class MQTTProxyService implements Closeable {
         this.proxyConfig = proxyConfig;
         this.pulsarService = pulsarService;
         this.authProviders = authProviders;
-        acceptorGroup = EventLoopUtil.newEventLoopGroup(1, false, acceptorThreadFactory);
-        workerGroup = EventLoopUtil.newEventLoopGroup(numThreads, false, workerThreadFactory);
+        acceptorGroup = EventLoopUtil.newEventLoopGroup(proxyConfig.getMqttProxyNumAcceptorThreads(),
+                false, acceptorThreadFactory);
+        workerGroup = EventLoopUtil.newEventLoopGroup(proxyConfig.getMqttProxyNumIOThreads(),
+                false, workerThreadFactory);
     }
 
     private void configValid(MQTTProxyConfiguration proxyConfig) {


### PR DESCRIPTION
## Motivation
Netty worker group should be configurable, for different scenarios, users may set different worker threads for IO event.