### PR TITLE
Update TLS PSK default configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,9 +264,16 @@ mqttProxyTlsPskPort=5684
 // any string can be specified
 tlsPskIdentityHint=alpha
 // identity is semicolon list of string with identity:secret format
-tlsPskIdentity=mqtt:mqtt123      
+tlsPskIdentity=mqtt:mqtt123
 ...
 ```
+Optional configs
+
+|  Config key   | Comment  |
+|  :---------:  | -------- |
+|  tlsPskIdentityFile | When you want identities in a single file with many pairs, you can config this. Identities will load from both `tlsPskIdentity` and `tlsPskIdentityFile`  |
+|  tlsProtocols  | TLS PSK protocols, default is [TLSv1.2], and only support TLSv1.2 currently.  |
+|  tlsCiphers | TLS PSK ciphers, default are [TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA, TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA, TLS_PSK_WITH_AES_128_CBC_SHA, TLS_PSK_WITH_AES_256_CBC_SHA] |
 
 2. As current known mqtt Java client does not support TLS-PSK, it's better to verify this by `mosquitto cli`
 ```cli

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/psk/PSKConfiguration.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/psk/PSKConfiguration.java
@@ -45,13 +45,13 @@ public class PSKConfiguration {
         defaultApplicationProtocols.add(ApplicationProtocolNames.SPDY_3);
         defaultApplicationProtocols.add(ApplicationProtocolNames.SPDY_3_1);
 
-        defaultCiphers.add("PSK-AES128-CBC-SHA");
+        defaultCiphers.add("TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256");
+        defaultCiphers.add("TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA");
+        defaultCiphers.add("TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA");
+        defaultCiphers.add("TLS_PSK_WITH_AES_128_CBC_SHA");
+        defaultCiphers.add("TLS_PSK_WITH_AES_256_CBC_SHA");
 
         defaultProtocols.add("TLSv1.2");
-        defaultProtocols.add("TLSv1.1");
-        defaultProtocols.add("TLSv1");
-        defaultProtocols.add("SSLv3");
-
     }
 
     static ApplicationProtocolConfig defaultProtocolConfig = new ApplicationProtocolConfig(


### PR DESCRIPTION
## Motivation
After the test,  TLS PSK is only supported in TLSv1.2 currently, So update the default configuration and relative doc.

## Modification
- Remove unsupported protocols.
- Add more default supported ciphers.
- Update relative doc.