### PR TITLE
Close broker channel when client channel lost.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -191,6 +191,10 @@ public class MQTTProxyProtocolMethodProcessor implements ProtocolMethodProcessor
         if (log.isDebugEnabled()) {
             log.debug("[Proxy Connection Lost] [{}] ", NettyUtils.retrieveClientId(channel));
         }
+        proxyExchangerMap.forEach((k, v) -> v.whenComplete((exchanger, error) -> {
+            exchanger.close();
+        }));
+        proxyExchangerMap.clear();
     }
 
     @Override


### PR DESCRIPTION
## Motivation
When the client channel is not active, we should close the proxy with the broker channel.

BTW, If we don't do this, the broker channel will close these zombie channels by IdleHandler, so no memory leak here.