### PR TITLE
Fix authorization execute order issue.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/ConnectionDescriptor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/ConnectionDescriptor.java
@@ -88,8 +88,10 @@ public class ConnectionDescriptor {
 
     public boolean assignState(ConnectionState expected, ConnectionState newState) {
         LOG.debug(
-                "Updating state of connection descriptor. MqttClientId = {}, expectedState = {}, newState = {}.",
+                "Updating state of connection descriptor. MqttClientId = {}, currentState = {}, "
+                        + "expectedState = {}, newState = {}.",
                 clientID,
+                channelState.get(),
                 expected,
                 newState);
         boolean retval = channelState.compareAndSet(expected, newState);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/ProxyTLSTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/ProxyTLSTest.java
@@ -148,7 +148,6 @@ public class ProxyTLSTest extends MQTTTestBase {
 
         connection1.disconnect();
         connection0.disconnect();
-        pulsarServiceList.get(0).getBrokerService().forEachTopic(t -> t.delete().join());
     }
 
     @Test(timeOut = TIMEOUT, priority = 4)

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/ProxyTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/ProxyTest.java
@@ -73,7 +73,6 @@ public class ProxyTest extends MQTTTestBase {
         Assert.assertEquals(new String(received.getPayload()), message);
         received.ack();
         connection.disconnect();
-        pulsarServiceList.get(0).getBrokerService().forEachTopic(t -> t.delete().join());
     }
 
     @Test(expectedExceptions = {EOFException.class, IllegalStateException.class}, priority = 3)


### PR DESCRIPTION
This is related to #173 .

#173 has involved topic authorization, but has a little issue : authorization is async(canConsumeAsync, canProduceAsync) but it may execute after `doSubscribe`/`doPublish`.

## Modification
- Make authorization execute first.
- Fix test.