### PR TITLE
Fix IdleHandler readTimeout issue.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Constants.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Constants.java
@@ -20,6 +20,7 @@ public final class Constants {
 
     public static final String ATTR_CLIENT_ID = "ClientID";
     public static final String ATTR_CLEAN_SESSION = "CleanSession";
+    public static final String ATTR_KEEP_ALIVE_TIME = "KeepAliveTime";
     public static final String ATTR_CLIENT_ADDR = "ClientAddr";
     public static final String AUTH_BASIC = "basic";
     public static final String AUTH_TOKEN = "token";

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyExchanger.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyExchanger.java
@@ -56,7 +56,8 @@ public class MQTTProxyExchanger {
                 .handler(new ChannelInitializer<SocketChannel>() {
                     @Override
                     protected void initChannel(SocketChannel ch) throws Exception {
-                        ch.pipeline().addFirst("idleStateHandler", new IdleStateHandler(10, 0, 0));
+                        ch.pipeline().addFirst("idleStateHandler",
+                                new IdleStateHandler(NettyUtils.getKeepAliveTime(processor.clientChannel()), 0, 0));
                         ch.pipeline().addLast("decoder", new MqttDecoder());
                         ch.pipeline().addLast("encoder", MqttEncoder.INSTANCE);
                         ch.pipeline().addLast("handler", new ExchangerHandler());

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -105,6 +105,7 @@ public class MQTTProxyProtocolMethodProcessor implements ProtocolMethodProcessor
 
         NettyUtils.setClientId(channel, clientId);
         NettyUtils.setConnectMsg(channel, connectMessage);
+        NettyUtils.setKeepAliveTime(channel, MqttMessageUtils.getKeepAliveTime(msg));
         NettyUtils.addIdleStateHandler(channel, MqttMessageUtils.getKeepAliveTime(msg));
 
         MqttConnAckMessage ackMessage = MqttMessageUtils.connAck(MqttConnectReturnCode.CONNECTION_ACCEPTED);

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/NettyUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/NettyUtils.java
@@ -17,6 +17,7 @@ import static io.streamnative.pulsar.handlers.mqtt.Constants.ATTR_CLEAN_SESSION;
 import static io.streamnative.pulsar.handlers.mqtt.Constants.ATTR_CLIENT_ADDR;
 import static io.streamnative.pulsar.handlers.mqtt.Constants.ATTR_CLIENT_ID;
 import static io.streamnative.pulsar.handlers.mqtt.Constants.ATTR_CONNECT_MSG;
+import static io.streamnative.pulsar.handlers.mqtt.Constants.ATTR_KEEP_ALIVE_TIME;
 import static io.streamnative.pulsar.handlers.mqtt.Constants.ATTR_TOPIC_SUBS;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
@@ -41,6 +42,7 @@ public final class NettyUtils {
 
     private static final AttributeKey<Object> ATTR_KEY_CLIENT_ID = AttributeKey.valueOf(ATTR_CLIENT_ID);
     private static final AttributeKey<Object> ATTR_KEY_CLEAN_SESSION = AttributeKey.valueOf(ATTR_CLEAN_SESSION);
+    private static final AttributeKey<Object> ATTR_KEY_KEEP_ALIVE_TIME = AttributeKey.valueOf(ATTR_KEEP_ALIVE_TIME);
     private static final AttributeKey<Object> ATTR_KEY_USERNAME = AttributeKey.valueOf(ATTR_USERNAME);
     private static final AttributeKey<Object> ATTR_KEY_USER_ROLE = AttributeKey.valueOf(ATTR_USER_ROLE);
     private static final AttributeKey<Object> ATTR_KEY_CONNECT_MSG = AttributeKey.valueOf(ATTR_CONNECT_MSG);
@@ -102,6 +104,14 @@ public final class NettyUtils {
             pipeline.remove("idleStateHandler");
         }
         pipeline.addFirst("idleStateHandler", new IdleStateHandler(idleTime, 0, 0));
+    }
+
+    public static void setKeepAliveTime(Channel channel, int keepAliveTime) {
+        channel.attr(NettyUtils.ATTR_KEY_KEEP_ALIVE_TIME).set(keepAliveTime);
+    }
+
+    public static int getKeepAliveTime(Channel channel) {
+        return (Integer) channel.attr(NettyUtils.ATTR_KEY_KEEP_ALIVE_TIME).get();
     }
 
     public static String getAndSetAddress(Channel channel) {


### PR DESCRIPTION
## Motivation
We set IdleStateHandler readIdleTimeout to 10, it's not according to user keepAlive time. This will close the proxy to the broker channel and make the proxy write data with `The broker channel is not writable`.

This is also fix #194 .