### PR TITLE
Using AtomicReferenceFieldUpdater instead of AtomicReference for channelState in Connection

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
@@ -16,6 +16,7 @@ package io.streamnative.pulsar.handlers.mqtt;
 import static io.streamnative.pulsar.handlers.mqtt.Connection.ConnectionState.CONNECT_ACK;
 import static io.streamnative.pulsar.handlers.mqtt.Connection.ConnectionState.DISCONNECTED;
 import static io.streamnative.pulsar.handlers.mqtt.Connection.ConnectionState.ESTABLISHED;
+import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.*;
 import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttConnAckMessage;
 import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
@@ -23,7 +24,7 @@ import io.streamnative.pulsar.handlers.mqtt.utils.MqttMessageUtils;
 import io.streamnative.pulsar.handlers.mqtt.utils.NettyUtils;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
@@ -46,7 +47,9 @@ public class Connection {
     @Getter
     private final boolean cleanSession;
 
-    private final AtomicReference<ConnectionState> channelState = new AtomicReference<>(DISCONNECTED);
+    volatile ConnectionState connectionState = DISCONNECTED;
+
+    private final AtomicReferenceFieldUpdater<Connection,ConnectionState> channelState = newUpdater(Connection.class, ConnectionState.class,"connectionState");
 
     public Connection(String clientId, Channel channel, boolean cleanSession) {
         this.clientId = clientId;
@@ -64,7 +67,7 @@ public class Connection {
                         log.debug("The CONNECT message has been processed. CId={}", clientId);
                     }
                     assignState(CONNECT_ACK, ESTABLISHED);
-                    log.info("current connection state : {}", channelState.get());
+                    log.info("current connection state : {}", channelState.get(this));
                 }
             });
         } else {
@@ -124,17 +127,17 @@ public class Connection {
                     "Updating state of connection. CId = {}, currentState = {}, "
                             + "expectedState = {}, newState = {}.",
                     clientId,
-                    channelState.get(),
+                    channelState.get(this),
                     expected,
                     newState);
         }
-        boolean ret = channelState.compareAndSet(expected, newState);
+        boolean ret = channelState.compareAndSet(this,expected, newState);
         if (!ret) {
             log.error(
                     "Unable to update state of connection."
                             + " CId = {}, currentState = {}, expectedState = {}, newState = {}.",
                     clientId,
-                    channelState.get(),
+                    channelState.get(this),
                     expected,
                     newState);
         }
@@ -145,7 +148,7 @@ public class Connection {
     public String toString() {
         return "Connection{" + "clientId=" + clientId + ", channel=" + channel
                 + ", cleanSession=" + cleanSession + ", state="
-                + channelState.get() + '}';
+                + channelState.get(this) + '}';
     }
 
     @Override

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
@@ -16,7 +16,7 @@ package io.streamnative.pulsar.handlers.mqtt;
 import static io.streamnative.pulsar.handlers.mqtt.Connection.ConnectionState.CONNECT_ACK;
 import static io.streamnative.pulsar.handlers.mqtt.Connection.ConnectionState.DISCONNECTED;
 import static io.streamnative.pulsar.handlers.mqtt.Connection.ConnectionState.ESTABLISHED;
-import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.*;
+import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttConnAckMessage;
 import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
@@ -49,7 +49,8 @@ public class Connection {
 
     volatile ConnectionState connectionState = DISCONNECTED;
 
-    private final AtomicReferenceFieldUpdater<Connection,ConnectionState> channelState = newUpdater(Connection.class, ConnectionState.class,"connectionState");
+    private final AtomicReferenceFieldUpdater<Connection, ConnectionState> channelState =
+            newUpdater(Connection.class, ConnectionState.class, "connectionState");
 
     public Connection(String clientId, Channel channel, boolean cleanSession) {
         this.clientId = clientId;
@@ -131,7 +132,7 @@ public class Connection {
                     expected,
                     newState);
         }
-        boolean ret = channelState.compareAndSet(this,expected, newState);
+        boolean ret = channelState.compareAndSet(this, expected, newState);
         if (!ret) {
             log.error(
                     "Unable to update state of connection."


### PR DESCRIPTION
#236 
Using AtomicReferenceFieldUpdater instead of AtomicReference for channelState in Connection.