### PR TITLE
Support disconnect session expire interval

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
@@ -144,8 +144,12 @@ public class Connection {
             if (MqttUtils.isMqtt5(protocolVersion)
                     && SESSION_EXPIRE_INTERVAL_UPDATER.get(this)
                     != SessionExpireInterval.NEVER_EXPIRE.getSecondTime()) {
-                manager.newSessionExpireInterval(__ ->
-                        doRemoveSubscriptions(), clientId, SESSION_EXPIRE_INTERVAL_UPDATER.get(this));
+                if (sessionExpireInterval == SessionExpireInterval.EXPIRE_IMMEDIATELY.getSecondTime()) {
+                    doRemoveSubscriptions();
+                } else {
+                    manager.newSessionExpireInterval(__ ->
+                            doRemoveSubscriptions(), clientId, SESSION_EXPIRE_INTERVAL_UPDATER.get(this));
+                }
             }
         }
     }
@@ -234,7 +238,7 @@ public class Connection {
     public boolean checkIsLegalExpireInterval(Integer sessionExpireInterval) {
         int sei = SESSION_EXPIRE_INTERVAL_UPDATER.get(this);
         int zeroSecond = SessionExpireInterval.EXPIRE_IMMEDIATELY.getSecondTime();
-        return sei > zeroSecond && sessionExpireInterval > zeroSecond;
+        return sei > zeroSecond && sessionExpireInterval >= zeroSecond;
     }
 
     /**

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/codes/mqtt5/SessionExpireInterval.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/codes/mqtt5/SessionExpireInterval.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5;
+
+public enum SessionExpireInterval {
+    NEVER_EXPIRE(0xFFFFFFFF),
+    EXPIRE_IMMEDIATELY(0);
+
+    private final int secondTime;
+
+    SessionExpireInterval(int secondTime) {
+        this.secondTime = secondTime;
+    }
+
+    public int getSecondTime() {
+        return secondTime;
+    }
+}

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
@@ -333,7 +333,8 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
         }
     }
 
-    private boolean checkAndUpdateSessionExpireIntervalIfNeed(Channel channel, String clientId, Connection connection, MqttProperties properties) {
+    private boolean checkAndUpdateSessionExpireIntervalIfNeed(Channel channel, String clientId,
+                                                              Connection connection, MqttProperties properties) {
         Optional<Integer> expireInterval = MqttPropertyUtils.getExpireInterval(properties);
         if (expireInterval.isPresent()) {
             Integer sessionExpireInterval = expireInterval.get();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt5/hivemq/base/MQTT5CleanStartTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt5/hivemq/base/MQTT5CleanStartTest.java
@@ -57,6 +57,7 @@ public class MQTT5CleanStartTest extends MQTTTestBase {
         Mqtt5BlockingClient client = MQTT5ClientUtils.createMqtt5Client(getMqttBrokerPortList().get(0));
         Mqtt5ConnAck connect = client.connectWith()
                 .cleanStart(false)
+                .sessionExpiryInterval(0xffffffffL)
                 .send();
         boolean sessionPresent = connect.isSessionPresent();
         Assert.assertTrue(sessionPresent);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt5/hivemq/base/MQTT5SessionExpireIntervalTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt5/hivemq/base/MQTT5SessionExpireIntervalTest.java
@@ -15,7 +15,9 @@ package io.streamnative.pulsar.handlers.mqtt.mqtt5.hivemq.base;
 
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5BlockingClient;
+import com.hivemq.client.mqtt.mqtt5.exceptions.Mqtt5DisconnectException;
 import com.hivemq.client.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAck;
+import com.hivemq.client.mqtt.mqtt5.message.disconnect.Mqtt5DisconnectReasonCode;
 import io.streamnative.pulsar.handlers.mqtt.base.MQTTTestBase;
 import io.streamnative.pulsar.handlers.mqtt.utils.PulsarTopicUtils;
 import java.util.List;
@@ -103,5 +105,80 @@ public class MQTT5SessionExpireIntervalTest extends MQTTTestBase {
                 });
     }
 
+    @Test(timeOut = TIMEOUT)
+    public void testDisconnectSendNewExpireInterval() throws Exception {
+        final String topic = "test-expire-interval-3";
+        Mqtt5BlockingClient client = MQTT5ClientUtils.createMqtt5Client(getMqttBrokerPortList().get(0));
+        client.connectWith()
+                .cleanStart(false)
+                .sessionExpiryInterval(5)
+                .send();
+        client.subscribeWith()
+                .topicFilter(topic)
+                .qos(MqttQos.AT_LEAST_ONCE)
+                .send();
+        String pulsarTopicName = PulsarTopicUtils
+                .getPulsarTopicName(topic, defaultTenant, defaultNamespace, true, defaultTopicDomain);
+        String clientId = Objects.requireNonNull(client.getConfig().getClientIdentifier().orElse(null)).toString();
+        client.disconnectWith()
+                .sessionExpiryInterval(10)
+                .send();
+        Awaitility.await()
+                .pollDelay(8, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    List<String> reconnectSubscriptions = admin.topics().getSubscriptions(pulsarTopicName);
+                    Assert.assertTrue(reconnectSubscriptions.contains(clientId));
+                });
+        Awaitility.await()
+                .untilAsserted(()->{
+                    List<String> reconnectSubscriptions = admin.topics().getSubscriptions(pulsarTopicName);
+                    Assert.assertFalse(reconnectSubscriptions.contains(clientId));
+                });
+    }
+
+
+    @Test(timeOut = TIMEOUT)
+    public void testDisconnectSend0IntervalToCloseSession() throws Exception {
+        final String topic = "test-expire-interval-4";
+        Mqtt5BlockingClient client = MQTT5ClientUtils.createMqtt5Client(getMqttBrokerPortList().get(0));
+        client.connectWith()
+                .cleanStart(false)
+                .sessionExpiryInterval(5)
+                .send();
+        client.subscribeWith()
+                .topicFilter(topic)
+                .qos(MqttQos.AT_LEAST_ONCE)
+                .send();
+        String pulsarTopicName = PulsarTopicUtils
+                .getPulsarTopicName(topic, defaultTenant, defaultNamespace, true, defaultTopicDomain);
+        String clientId = Objects.requireNonNull(client.getConfig().getClientIdentifier().orElse(null)).toString();
+        client.disconnectWith()
+                .sessionExpiryInterval(0)
+                .send();
+        Awaitility.await()
+                .atMost(2, TimeUnit.SECONDS)
+                .untilAsserted(()->{
+                    List<String> reconnectSubscriptions = admin.topics().getSubscriptions(pulsarTopicName);
+                    Assert.assertFalse(reconnectSubscriptions.contains(clientId));
+                });
+    }
+
+
+    @Test(timeOut = TIMEOUT)
+    public void testDisconnectGotProtocolError() throws Exception {
+        Mqtt5BlockingClient client = MQTT5ClientUtils.createMqtt5Client(getMqttBrokerPortList().get(0));
+        client.connectWith()
+                .cleanStart(false)
+                .sessionExpiryInterval(0)
+                .send();
+        try {
+            client.disconnectWith()
+                    .sessionExpiryInterval(10)
+                    .send();
+        } catch (Mqtt5DisconnectException ex){
+            Mqtt5DisconnectReasonCode reasonCode = ex.getMqttMessage().getReasonCode();
+            Assert.assertEquals(reasonCode, Mqtt5DisconnectReasonCode.PROTOCOL_ERROR);
+        }
+    }
 
 }


### PR DESCRIPTION
This feature detail in MQTT5 spec 3.14.2.2.2

- Support disconnect contains session expire interval time to update connect sent value.
- Support disconnect session expire interval value check.
- Support session dose not expire when value is 0xFFFFFFFF (UINT_MAX)