### PR TITLE
Refactor ProtocolMethodProcessor, remove param `channel`.

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Style check
         run: mvn checkstyle:check
 
-      - name: Spotbugs check
-        run: mvn spotbugs:check
+#      - name: Spotbugs check
+#        run: mvn spotbugs:check
 
       - name: test after build
         run: ./scripts/retry.sh mvn -B -ntp test

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Style check
         run: mvn checkstyle:check
 
-#      - name: Spotbugs check
-#        run: mvn spotbugs:check
+      - name: Spotbugs check
+        run: mvn spotbugs:check
 
       - name: test after build
         run: ./scripts/retry.sh mvn -B -ntp test

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
@@ -84,8 +84,8 @@ public class Connection {
         if (ret) {
             MqttMessage mqttConnAckMessage = MqttUtils.isMqtt5(protocolVersion)
                     ? MqttConnAckMessageHelper
-                    .createMqtt(Mqtt5ConnReasonCode.SUCCESS, !cleanSession, serverReceivePubMaximum) :
-                    MqttConnAckMessageHelper.createMqtt(Mqtt3ConnReasonCode.CONNECTION_ACCEPTED, !cleanSession);
+                    .createConnAck(Mqtt5ConnReasonCode.SUCCESS, !cleanSession, serverReceivePubMaximum) :
+                    MqttConnAckMessageHelper.createConnAck(Mqtt3ConnReasonCode.CONNECTION_ACCEPTED, !cleanSession);
             channel.writeAndFlush(mqttConnAckMessage).addListener(future -> {
                 if (future.isSuccess()) {
                     if (log.isDebugEnabled()) {
@@ -102,7 +102,7 @@ public class Connection {
                     ? MqttConnAckMessageHelper.createMqtt5(Mqtt5ConnReasonCode.SERVER_UNAVAILABLE,
                     String.format("Unable to assign the state from : %s to : %s for CId=%s, close channel"
                             , DISCONNECTED, CONNECT_ACK, clientId)) :
-                    MqttConnAckMessageHelper.createMqtt(Mqtt3ConnReasonCode.CONNECTION_REFUSED_SERVER_UNAVAILABLE);
+                    MqttConnAckMessageHelper.createConnAck(Mqtt3ConnReasonCode.CONNECTION_REFUSED_SERVER_UNAVAILABLE);
             channel.writeAndFlush(mqttConnAckMessage);
             channel.close();
         }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTInboundHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTInboundHandler.java
@@ -60,38 +60,38 @@ public class MQTTInboundHandler extends ChannelInboundHandlerAdapter {
             switch (messageType) {
                 case CONNECT:
                     checkArgument(msg instanceof MqttConnectMessage);
-                    processor.processConnect(ctx.channel(), (MqttConnectMessage) msg);
+                    processor.processConnect((MqttConnectMessage) msg);
                     break;
                 case SUBSCRIBE:
                     checkArgument(msg instanceof MqttSubscribeMessage);
-                    processor.processSubscribe(ctx.channel(), (MqttSubscribeMessage) msg);
+                    processor.processSubscribe((MqttSubscribeMessage) msg);
                     break;
                 case UNSUBSCRIBE:
                     checkArgument(msg instanceof MqttUnsubscribeMessage);
-                    processor.processUnSubscribe(ctx.channel(), (MqttUnsubscribeMessage) msg);
+                    processor.processUnSubscribe((MqttUnsubscribeMessage) msg);
                     break;
                 case PUBLISH:
                     checkArgument(msg instanceof MqttPublishMessage);
-                    processor.processPublish(ctx.channel(), (MqttPublishMessage) msg);
+                    processor.processPublish((MqttPublishMessage) msg);
                     break;
                 case PUBREC:
-                    processor.processPubRec(ctx.channel(), msg);
+                    processor.processPubRec(msg);
                     break;
                 case PUBCOMP:
-                    processor.processPubComp(ctx.channel(), msg);
+                    processor.processPubComp(msg);
                     break;
                 case PUBREL:
-                    processor.processPubRel(ctx.channel(), msg);
+                    processor.processPubRel(msg);
                     break;
                 case DISCONNECT:
-                    processor.processDisconnect(ctx.channel(), msg);
+                    processor.processDisconnect(msg);
                     break;
                 case PUBACK:
                     checkArgument(msg instanceof MqttPubAckMessage);
-                    processor.processPubAck(ctx.channel(), (MqttPubAckMessage) msg);
+                    processor.processPubAck((MqttPubAckMessage) msg);
                     break;
                 case PINGREQ:
-                    processor.processPingReq(ctx.channel());
+                    processor.processPingReq();
                     break;
                 default:
                     log.error("Unknown MessageType:{}", messageType);
@@ -111,7 +111,7 @@ public class MQTTInboundHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        processor.processConnectionLost(ctx.channel());
+        processor.processConnectionLost();
     }
 
     @Override

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/ProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/ProtocolMethodProcessor.java
@@ -13,8 +13,6 @@
  */
 package io.streamnative.pulsar.handlers.mqtt;
 
-import static io.streamnative.pulsar.handlers.mqtt.utils.MqttMessageUtils.pingResp;
-import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttMessage;
 import io.netty.handler.codec.mqtt.MqttPubAckMessage;
@@ -27,27 +25,25 @@ import io.netty.handler.codec.mqtt.MqttUnsubscribeMessage;
  */
 public interface ProtocolMethodProcessor {
 
-    void processConnect(Channel channel, MqttConnectMessage msg);
+    void processConnect(MqttConnectMessage msg);
 
-    void processPubAck(Channel channel, MqttPubAckMessage msg);
+    void processPubAck(MqttPubAckMessage msg);
 
-    void processPublish(Channel channel, MqttPublishMessage msg);
+    void processPublish(MqttPublishMessage msg);
 
-    void processPubRel(Channel channel, MqttMessage msg);
+    void processPubRel(MqttMessage msg);
 
-    void processPubRec(Channel channel, MqttMessage msg);
+    void processPubRec(MqttMessage msg);
 
-    void processPubComp(Channel channel, MqttMessage msg);
+    void processPubComp(MqttMessage msg);
 
-    void processDisconnect(Channel channel, MqttMessage msg);
+    void processDisconnect(MqttMessage msg);
 
-    void processConnectionLost(Channel channel);
+    void processConnectionLost();
 
-    void processSubscribe(Channel channel, MqttSubscribeMessage msg);
+    void processSubscribe(MqttSubscribeMessage msg);
 
-    void processUnSubscribe(Channel channel, MqttUnsubscribeMessage msg);
+    void processUnSubscribe(MqttUnsubscribeMessage msg);
 
-    default void processPingReq(Channel channel) {
-        channel.writeAndFlush(pingResp());
-    }
+    void processPingReq();
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/MqttPropertyUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/MqttPropertyUtils.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.mqtt.messages;
 
 import io.netty.handler.codec.mqtt.MqttProperties;
+import io.streamnative.pulsar.handlers.mqtt.utils.MqttUtils;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 
@@ -51,12 +52,12 @@ public class MqttPropertyUtils {
      * @return Integer - expire interval value
      */
     @SuppressWarnings("unchecked")
-    public static Optional<Integer> getReceiveMaximum(MqttProperties properties) {
+    public static Integer getReceiveMaximum(int protocolVersion, MqttProperties properties) {
         MqttProperties.MqttProperty<Integer> property = properties
                 .getProperty(MqttProperties.MqttPropertyType.RECEIVE_MAXIMUM.value());
         if (property == null) {
-            return Optional.empty();
+            return MqttUtils.isMqtt5(protocolVersion) ? MQTT5_DEFAULT_RECEIVE_MAXIMUM : BEFORE_DEFAULT_RECEIVE_MAXIMUM;
         }
-        return Optional.ofNullable(property.value());
+        return property.value();
     }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/factory/MqttConnAckMessageHelper.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/factory/MqttConnAckMessageHelper.java
@@ -116,6 +116,15 @@ public class MqttConnAckMessageHelper {
         return new MqttConnAckMessage(fixedHeader, mqttConnAckVariableHeader);
     }
 
+    public static MqttMessage createQosNotSupportAck() {
+        MqttProperties properties = new MqttProperties();
+        MqttProperties.StringProperty reasonStringProperty =
+                new MqttProperties.StringProperty(MqttProperties.MqttPropertyType.REASON_STRING.value(),
+                        "The server do not support will message that qos is exactly once.");
+        properties.add(reasonStringProperty);
+        return createMqtt5(Mqtt5ConnReasonCode.QOS_NOT_SUPPORTED, false, properties);
+    }
+
     public static MqttMessage createMqtt5(Mqtt5ConnReasonCode conAckReasonCode, String reasonStr) {
         MqttProperties properties = new MqttProperties();
         MqttProperties.StringProperty reasonStringProperty =

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/factory/MqttConnAckMessageHelper.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/factory/MqttConnAckMessageHelper.java
@@ -22,6 +22,7 @@ import io.netty.handler.codec.mqtt.MqttProperties;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt3.Mqtt3ConnReasonCode;
 import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5ConnReasonCode;
+import io.streamnative.pulsar.handlers.mqtt.utils.MqttUtils;
 
 /**
  * Factory pattern, used to create mqtt protocol connection acknowledgement
@@ -31,6 +32,22 @@ import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5ConnReason
  */
 public class MqttConnAckMessageHelper {
 
+    public static MqttMessage createIdentifierInvalidAck(int protocolVersion) {
+        return MqttUtils.isMqtt5(protocolVersion)
+                ? createConnAck(Mqtt5ConnReasonCode.CLIENT_IDENTIFIER_NOT_VALID)
+                : createConnAck(Mqtt3ConnReasonCode.CONNECTION_REFUSED_IDENTIFIER_REJECTED);
+    }
+
+    public static MqttMessage createAuthFailedAck(int protocolVersion) {
+        return MqttUtils.isMqtt5(protocolVersion)
+                ? createConnAck(Mqtt5ConnReasonCode.BAD_USERNAME_OR_PASSWORD)
+                : createConnAck(Mqtt3ConnReasonCode.CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD);
+    }
+
+    public static MqttMessage createUnsupportedVersionAck() {
+        return createConnAck(Mqtt5ConnReasonCode.UNSUPPORTED_PROTOCOL_VERSION);
+    }
+
     /**
      * Create Mqtt 5 connection acknowledgement with no property.
      *
@@ -38,7 +55,7 @@ public class MqttConnAckMessageHelper {
      * @return - MqttMessage
      * @see Mqtt5ConnReasonCode
      */
-    public static MqttMessage createMqtt(Mqtt5ConnReasonCode conAckReasonCode) {
+    public static MqttMessage createConnAck(Mqtt5ConnReasonCode conAckReasonCode) {
         return createMqtt5(conAckReasonCode, false, MqttProperties.NO_PROPERTIES);
     }
 
@@ -49,7 +66,7 @@ public class MqttConnAckMessageHelper {
      * @return - MqttMessage
      * @see Mqtt5ConnReasonCode
      */
-    public static MqttMessage createMqtt(Mqtt5ConnReasonCode conAckReasonCode, boolean sessionPresent) {
+    public static MqttMessage createConnAck(Mqtt5ConnReasonCode conAckReasonCode, boolean sessionPresent) {
         return createMqtt5(conAckReasonCode, sessionPresent, MqttProperties.NO_PROPERTIES);
     }
 
@@ -62,7 +79,7 @@ public class MqttConnAckMessageHelper {
      * @return - MqttMessage
      * @see Mqtt5ConnReasonCode
      */
-    public static MqttMessage createMqtt(Mqtt5ConnReasonCode conAckReasonCode, boolean sessionPresent,
+    public static MqttMessage createConnAck(Mqtt5ConnReasonCode conAckReasonCode, boolean sessionPresent,
                                          Integer serverReceiveMaximum) {
         MqttProperties properties = new MqttProperties();
         MqttProperties.IntegerProperty property =
@@ -80,8 +97,8 @@ public class MqttConnAckMessageHelper {
      * @return - MqttMessage
      * @see Mqtt3ConnReasonCode
      */
-    public static MqttMessage createMqtt(Mqtt3ConnReasonCode connectReturnCode) {
-      return createMqtt(connectReturnCode, false);
+    public static MqttMessage createConnAck(Mqtt3ConnReasonCode connectReturnCode) {
+      return createConnAck(connectReturnCode, false);
     }
 
     /**
@@ -91,7 +108,7 @@ public class MqttConnAckMessageHelper {
      * @return - MqttMessage
      * @see Mqtt3ConnReasonCode
      */
-    public static MqttMessage createMqtt(Mqtt3ConnReasonCode connectReturnCode, boolean sessionPresent) {
+    public static MqttMessage createConnAck(Mqtt3ConnReasonCode connectReturnCode, boolean sessionPresent) {
         MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.CONNACK, false, MqttQoS.AT_MOST_ONCE,
                 false, 0);
         MqttConnAckVariableHeader mqttConnAckVariableHeader =

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -30,9 +30,7 @@ import io.streamnative.pulsar.handlers.mqtt.MQTTAuthenticationService;
 import io.streamnative.pulsar.handlers.mqtt.MQTTConnectionManager;
 import io.streamnative.pulsar.handlers.mqtt.ProtocolMethodProcessor;
 import io.streamnative.pulsar.handlers.mqtt.exception.handler.MopExceptionHelper;
-import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt3.Mqtt3ConnReasonCode;
 import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt3.Mqtt3SubReasonCode;
-import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5ConnReasonCode;
 import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5SubReasonCode;
 import io.streamnative.pulsar.handlers.mqtt.messages.factory.MqttConnAckMessageHelper;
 import io.streamnative.pulsar.handlers.mqtt.messages.factory.MqttSubAckMessageHelper;
@@ -110,11 +108,7 @@ public class MQTTProxyProtocolMethodProcessor implements ProtocolMethodProcessor
         } else {
             MQTTAuthenticationService.AuthenticationResult authResult = authenticationService.authenticate(payload);
             if (authResult.isFailed()) {
-                MqttMessage connAck = MqttUtils.isMqtt5(protocolVersion)
-                        ? MqttConnAckMessageHelper.createMqtt(Mqtt5ConnReasonCode.BAD_USERNAME_OR_PASSWORD) :
-                        MqttConnAckMessageHelper.createMqtt(
-                                Mqtt3ConnReasonCode.CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD);
-                channel.writeAndFlush(connAck);
+                channel.writeAndFlush(MqttConnAckMessageHelper.createAuthFailedAck(protocolVersion));
                 channel.close();
                 log.error("Invalid or incorrect authentication. CId={}, username={}", clientId, payload.userName());
                 return;

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
@@ -133,7 +133,6 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
         if (!MqttUtils.isSupportedVersion(msg.variableHeader().version())) {
             MqttMessage badProto = MqttConnAckMessageHelper.
                     createMqtt(Mqtt5ConnReasonCode.UNSUPPORTED_PROTOCOL_VERSION);
-
             log.error("MQTT protocol version is not valid. CId={}", clientId);
             channel.writeAndFlush(badProto);
             channel.close();

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MqttUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MqttUtils.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.mqtt.utils;
 
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
+import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.handler.codec.mqtt.MqttVersion;
 
 /**
@@ -43,4 +44,9 @@ public class MqttUtils {
         return version == MqttVersion.MQTT_5.protocolLevel();
     }
 
+    public static boolean isQosSupported(MqttConnectMessage msg) {
+        int willQos = msg.variableHeader().willQos();
+        MqttQoS mqttQoS = MqttQoS.valueOf(willQos);
+        return mqttQoS == MqttQoS.AT_LEAST_ONCE || mqttQoS == MqttQoS.AT_MOST_ONCE;
+    }
 }


### PR DESCRIPTION
## Motivation
ProtocolMethodProcessor has defined all the MQTT messages to handle. but every method contains `channel` which is reducant, we can obtain it from the constructor. So decide to remove it.

## Modification
- Remove `channel` from each method in ProtocolMethodProcessor.