### PR TITLE
Refactor mqtt property part, put these properties to connection.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/AbstractQosPublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/AbstractQosPublishHandler.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.mqtt;
 
 import static io.streamnative.pulsar.handlers.mqtt.utils.PulsarMessageConverter.toPulsarMsg;
+import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.streamnative.pulsar.handlers.mqtt.exception.MQTTNoMatchingSubscriberException;
 import io.streamnative.pulsar.handlers.mqtt.utils.MessagePublishContext;
@@ -34,10 +35,13 @@ public abstract class AbstractQosPublishHandler implements QosPublishHandler {
 
     protected final PulsarService pulsarService;
     protected final MQTTServerConfiguration configuration;
+    protected final Channel channel;
 
-    protected AbstractQosPublishHandler(PulsarService pulsarService, MQTTServerConfiguration configuration) {
+    protected AbstractQosPublishHandler(PulsarService pulsarService, MQTTServerConfiguration configuration,
+                                        Channel channel) {
         this.pulsarService = pulsarService;
         this.configuration = configuration;
+        this.channel = channel;
     }
 
     protected CompletableFuture<Optional<Topic>> getTopicReference(MqttPublishMessage msg) {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
@@ -30,7 +30,6 @@ import io.streamnative.pulsar.handlers.mqtt.utils.NettyUtils;
 import io.streamnative.pulsar.handlers.mqtt.utils.WillMessage;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import lombok.Builder;
@@ -87,8 +86,7 @@ public class Connection {
         this.protocolVersion = builder.protocolVersion;
         this.cleanSession = builder.cleanSession;
         this.willMessage = builder.willMessage;
-        this.sessionExpireInterval = builder.sessionExpireInterval
-                .orElse(SessionExpireInterval.EXPIRE_IMMEDIATELY.getSecondTime());
+        this.sessionExpireInterval = builder.sessionExpireInterval;
         this.clientReceiveMaximum = builder.clientReceiveMaximum;
         this.serverReceivePubMaximum = builder.serverReceivePubMaximum;
         this.userRole = builder.userRole;
@@ -301,7 +299,7 @@ public class Connection {
         private WillMessage willMessage;
         private int clientReceiveMaximum;
         private int serverReceivePubMaximum;
-        private Optional<Integer> sessionExpireInterval = Optional.empty();
+        private int sessionExpireInterval;
         private Channel channel;
         private MQTTConnectionManager connectionManager;
 
@@ -340,7 +338,7 @@ public class Connection {
             return this;
         }
 
-        public ConnectionBuilder sessionExpireInterval(Optional<Integer> sessionExpireInterval) {
+        public ConnectionBuilder sessionExpireInterval(int sessionExpireInterval) {
             this.sessionExpireInterval = sessionExpireInterval;
             return this;
         }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
@@ -82,19 +82,18 @@ public class Connection {
     private static final AtomicIntegerFieldUpdater<Connection> SERVER_CURRENT_RECEIVE_PUB_MAXIMUM_UPDATER =
             AtomicIntegerFieldUpdater.newUpdater(Connection.class, "serverCurrentReceiveCounter");
 
-    Connection(int protocolVersion, String clientId, String userRole, boolean cleanSession,
-               Optional<WillMessage> willMessage, int sessionExpireInterval, int clientReceiveMaximum,
-               int serverReceivePubMaximum, Channel channel, MQTTConnectionManager manager) {
-        this.clientId = clientId;
-        this.protocolVersion = protocolVersion;
-        this.cleanSession = cleanSession;
-        this.willMessage = willMessage;
-        this.sessionExpireInterval = sessionExpireInterval;
-        this.clientReceiveMaximum = clientReceiveMaximum;
-        this.serverReceivePubMaximum = serverReceivePubMaximum;
-        this.userRole = userRole;
-        this.channel = channel;
-        this.manager = manager;
+    Connection(ConnectionBuilder builder) {
+        this.clientId = builder.clientId;
+        this.protocolVersion = builder.protocolVersion;
+        this.cleanSession = builder.cleanSession;
+        this.willMessage = builder.willMessage;
+        this.sessionExpireInterval = builder.sessionExpireInterval
+                .orElse(SessionExpireInterval.EXPIRE_IMMEDIATELY.getSecondTime());
+        this.clientReceiveMaximum = builder.clientReceiveMaximum;
+        this.serverReceivePubMaximum = builder.serverReceivePubMaximum;
+        this.userRole = builder.userRole;
+        this.channel = builder.channel;
+        this.manager = builder.connectionManager;
     }
 
     public void sendConnAck() {
@@ -357,9 +356,7 @@ public class Connection {
         }
 
         public Connection build() {
-            return new Connection(protocolVersion, clientId, userRole, cleanSession, willMessage,
-                    sessionExpireInterval.orElse(SessionExpireInterval.EXPIRE_IMMEDIATELY.getSecondTime()),
-                    clientReceiveMaximum, serverReceivePubMaximum, channel, connectionManager);
+            return new Connection(this);
         }
     }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
@@ -58,7 +58,7 @@ public class Connection {
     @Getter
     private final int protocolVersion;
     @Getter
-    private final Optional<WillMessage> willMessage;
+    private final WillMessage willMessage;
     @Getter
     private volatile int sessionExpireInterval;
     volatile ConnectionState connectionState = DISCONNECTED;
@@ -298,7 +298,7 @@ public class Connection {
         private String clientId;
         private String userRole;
         private boolean cleanSession;
-        private Optional<WillMessage> willMessage = Optional.empty();
+        private WillMessage willMessage;
         private int clientReceiveMaximum;
         private int serverReceivePubMaximum;
         private Optional<Integer> sessionExpireInterval = Optional.empty();
@@ -320,7 +320,7 @@ public class Connection {
             return this;
         }
 
-        public ConnectionBuilder willMessage(Optional<WillMessage> willMessage) {
+        public ConnectionBuilder willMessage(WillMessage willMessage) {
             this.willMessage = willMessage;
             return this;
         }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Constants.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Constants.java
@@ -18,13 +18,9 @@ package io.streamnative.pulsar.handlers.mqtt;
  */
 public final class Constants {
 
-    public static final String ATTR_CLIENT_ID = "ClientID";
     public static final String ATTR_CONNECTION = "Connection";
-    public static final String ATTR_CLEAN_SESSION = "CleanSession";
     public static final String ATTR_KEEP_ALIVE_TIME = "KeepAliveTime";
     public static final String ATTR_CLIENT_ADDR = "ClientAddr";
-    public static final String ATTR_WILL_MESSAGE = "WillMessage";
-    public static final String ATTR_PROTOCOL_VERSION = "ProtocolVersion";
     public static final String AUTH_BASIC = "basic";
     public static final String AUTH_TOKEN = "token";
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTInboundHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTInboundHandler.java
@@ -118,9 +118,9 @@ public class MQTTInboundHandler extends ChannelInboundHandlerAdapter {
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         log.warn(
                 "An unexpected exception was caught while processing MQTT message. "
-                + "Closing Netty channel {}. MqttClientId = {}",
+                + "Closing Netty channel {}. connection = {}",
                 ctx.channel(),
-                NettyUtils.getClientId(ctx.channel()),
+                NettyUtils.getConnection(ctx.channel()),
                 cause);
         ctx.close();
     }
@@ -130,7 +130,7 @@ public class MQTTInboundHandler extends ChannelInboundHandlerAdapter {
         if (event instanceof IdleStateEvent) {
             IdleStateEvent e = (IdleStateEvent) event;
             if (e.state() == IdleState.ALL_IDLE) {
-                log.warn("close channel : {} due to reached all idle time", NettyUtils.getClientId(ctx.channel()));
+                log.warn("close connection : {} due to reached all idle time", NettyUtils.getConnection(ctx.channel()));
                 ctx.close();
             }
         } else {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/QosPublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/QosPublishHandler.java
@@ -13,14 +13,12 @@
  */
 package io.streamnative.pulsar.handlers.mqtt;
 
-import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
-
 
 /**
  * Interface for Qos publish handler.
  */
 public interface QosPublishHandler {
 
-    void publish(Channel channel, MqttPublishMessage msg);
+    void publish(MqttPublishMessage msg);
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/exception/handler/MopExceptionHelper.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/exception/handler/MopExceptionHelper.java
@@ -41,7 +41,7 @@ public class MopExceptionHelper {
             log.error("Could not found exception handler {}", type);
             throw new IllegalArgumentException(String.format("Could not found exception handler %s", type));
         }
-        int protocolVersion = NettyUtils.getProtocolVersion(channel);
+        int protocolVersion = NettyUtils.getConnection(channel).getProtocolVersion();
         if (!MqttUtils.isSupportedVersion(protocolVersion)) {
             log.error("Wrong protocol version present! the protocol version is {}", protocolVersion);
             throw new IllegalArgumentException(

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyExchanger.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyExchanger.java
@@ -75,7 +75,6 @@ public class MQTTProxyExchanger {
         @Override
         public void channelActive(ChannelHandlerContext ctx) throws Exception {
             super.channelActive(ctx);
-            NettyUtils.setClientId(ctx.channel(), NettyUtils.getClientId(processor.getChannel()));
             MqttConnectMessage connectMessage = NettyUtils.getConnectMsg(processor.getChannel());
             ctx.channel().writeAndFlush(connectMessage);
         }
@@ -122,7 +121,7 @@ public class MQTTProxyExchanger {
 
         @Override
         public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-            log.error("proxy to broker channel inactive. Cid = {}", NettyUtils.getClientId(ctx.channel()));
+            log.error("proxy to broker channel inactive. connection = {}", NettyUtils.getConnection(ctx.channel()));
             processor.getChannel().close();
         }
     }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyHandler.java
@@ -116,9 +116,9 @@ public class MQTTProxyHandler extends ChannelInboundHandlerAdapter{
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         log.warn(
                 "An unexpected exception was caught while processing MQTT message. "
-                        + "Closing Netty channel {}. MqttClientId = {}",
+                        + "Closing Netty channel {}. connection = {}",
                 ctx.channel(),
-                NettyUtils.getClientId(ctx.channel()),
+                NettyUtils.getConnection(ctx.channel()),
                 cause);
         ctx.close();
     }
@@ -128,8 +128,8 @@ public class MQTTProxyHandler extends ChannelInboundHandlerAdapter{
         if (event instanceof IdleStateEvent) {
             IdleStateEvent e = (IdleStateEvent) event;
             if (e.state() == IdleState.ALL_IDLE) {
-                log.warn("proxy close channel : {} due to reached all idle time",
-                        NettyUtils.getClientId(ctx.channel()));
+                log.warn("proxy close connection : {} due to reached all idle time",
+                        NettyUtils.getConnection(ctx.channel()));
                 ctx.close();
             }
         } else {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
@@ -366,9 +366,9 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
         connectionManager.removeConnection(connection);
         connection.removeSubscriptions();
         subscriptionManager.removeSubscription(clientId);
-        Optional<WillMessage> willMessage = connection.getWillMessage();
-        if (willMessage.isPresent()) {
-            fireWillMessage(willMessage.get());
+        WillMessage willMessage = connection.getWillMessage();
+        if (willMessage != null) {
+            fireWillMessage(willMessage);
         }
     }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
@@ -101,11 +101,12 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
     private final MQTTConnectionManager connectionManager;
     private final MQTTSubscriptionManager subscriptionManager;
     private final Channel channel;
+    private Connection connection;
 
     public DefaultProtocolMethodProcessorImpl (MQTTService mqttService, ChannelHandlerContext ctx) {
         this.pulsarService = mqttService.getPulsarService();
         this.configuration = mqttService.getServerConfiguration();
-        this.qosPublishHandlers = new QosPublishHandlersImpl(pulsarService, configuration);
+        this.qosPublishHandlers = new QosPublishHandlersImpl(pulsarService, configuration, ctx.channel());
         this.packetIdGenerator = PacketIdGenerator.newNonZeroGenerator();
         this.outstandingPacketContainer = new OutstandingPacketContainerImpl();
         this.authenticationService = mqttService.getAuthenticationService();
@@ -121,8 +122,8 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
     public void processConnect(MqttConnectMessage msg) {
         MqttConnectPayload payload = msg.payload();
         final int protocolVersion = msg.variableHeader().version();
+        final String username = payload.userName();
         String clientId = payload.clientIdentifier();
-        String username = payload.userName();
         if (log.isDebugEnabled()) {
             log.debug("process CONNECT message. CId={}, username={}", clientId, username);
         }
@@ -170,31 +171,23 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
             channel.close();
             return;
         }
-        if (msg.variableHeader().isWillFlag()) {
-            NettyUtils.setWillMessage(channel, createWillMessage(msg));
-        }
-
-        NettyUtils.setClientId(channel, clientId);
-        NettyUtils.setCleanSession(channel, msg.variableHeader().isCleanSession());
-        NettyUtils.setUserRole(channel, userRole);
-        NettyUtils.addIdleStateHandler(channel, MqttMessageUtils.getKeepAliveTime(msg));
-        NettyUtils.setProtocolVersion(channel, protocolVersion);
-        metricsCollector.addClient(NettyUtils.getAndSetAddress(channel));
-        MqttProperties properties = msg.variableHeader().properties();
-        // Get receive maximum number.
-        Integer receiveMaximum = MqttPropertyUtils.getReceiveMaximum(protocolVersion, properties);
-        Connection.ConnectionBuilder connectionBuilder = Connection.builder()
-                .clientId(clientId)
+        connection = Connection.builder()
                 .protocolVersion(protocolVersion)
-                .channel(channel)
-                .manager(connectionManager)
-                .clientReceiveMaximum(receiveMaximum)
+                .clientId(clientId)
+                .userRole(userRole)
+                .willMessage(createWillMessage(msg))
+                .cleanSession(msg.variableHeader().isCleanSession())
+                .sessionExpireInterval(MqttPropertyUtils.getExpireInterval(msg.variableHeader().properties()))
+                .clientReceiveMaximum(MqttPropertyUtils.getReceiveMaximum(protocolVersion,
+                        msg.variableHeader().properties()))
                 .serverReceivePubMaximum(configuration.getReceiveMaximum())
-                .cleanSession(msg.variableHeader().isCleanSession());
-        MqttPropertyUtils.getExpireInterval(properties).ifPresent(connectionBuilder::sessionExpireInterval);
+                .channel(channel)
+                .connectionManager(connectionManager)
+                .build();
 
-        Connection connection = connectionBuilder.build();
         connectionManager.addConnection(connection);
+        metricsCollector.addClient(NettyUtils.getAndSetAddress(channel));
+        NettyUtils.addIdleStateHandler(channel, MqttMessageUtils.getKeepAliveTime(msg));
         NettyUtils.setConnection(channel, connection);
         connection.sendConnAck();
     }
@@ -202,7 +195,7 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
     @Override
     public void processPubAck(MqttPubAckMessage msg) {
         if (log.isDebugEnabled()) {
-            log.debug("[PubAck] [{}] msg: {}", NettyUtils.getClientId(channel), msg);
+            log.debug("[PubAck] [{}] msg: {}", connection.getClientId(), msg);
         }
         int packetId = msg.variableHeader().messageId();
         OutstandingPacket packet = outstandingPacketContainer.remove(packetId);
@@ -218,54 +211,51 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
     @Override
     public void processPublish(MqttPublishMessage msg) {
         if (log.isDebugEnabled()) {
-            log.debug("[Publish] [{}] msg: {}", NettyUtils.getClientId(channel), msg);
+            log.debug("[Publish] [{}] msg: {}", connection.getClientId(), msg);
         }
-
-        String clientID = NettyUtils.getClientId(channel);
-        String userRole = NettyUtils.getUserRole(channel);
-        final int protocolVersion = NettyUtils.getProtocolVersion(channel);
         final int packetId = msg.variableHeader().packetId();
-
         // Authorization the client
         if (!configuration.isMqttAuthorizationEnabled()) {
-            log.info("[Publish] authorization is disabled, allowing client. CId={}, userRole={}", clientID, userRole);
-            doPublish(channel, msg);
+            log.info("[Publish] authorization is disabled, allowing client. CId={}, userRole={}",
+                    connection.getClientId(), connection.getUserRole());
+            doPublish(msg);
         } else {
             this.authorizationService.canProduceAsync(TopicName.get(msg.variableHeader().topicName()),
-                    userRole, new AuthenticationDataCommand(userRole))
+                            connection.getUserRole(), new AuthenticationDataCommand(connection.getUserRole()))
                     .thenAccept((authorized) -> {
                         if (!authorized) {
-                            log.error("[Publish] no authorization to pub topic={}, userRole={}, CId= {}",
-                                    msg.variableHeader().topicName(), userRole, clientID);
+                            log.error("[Publish] not authorized to topic={}, userRole={}, CId= {}",
+                                    msg.variableHeader().topicName(), connection.getUserRole(),
+                                    connection.getClientId());
                             // Support Mqtt 5
-                            if (MqttUtils.isMqtt5(protocolVersion)) {
+                            if (MqttUtils.isMqtt5(connection.getProtocolVersion())) {
                                 MqttMessage mqttPubAckMessage =
                                     MqttPubAckMessageHelper.createMqtt5(packetId, Mqtt5PubReasonCode.NOT_AUTHORIZED,
-                                        String.format("The client %s not authorized.", clientID));
+                                        String.format("The client %s not authorized.", connection.getClientId()));
                                 channel.writeAndFlush(mqttPubAckMessage);
                             }
                             channel.close();
                         } else {
-                            doPublish(channel, msg);
+                            doPublish(msg);
                         }
                     });
         }
     }
 
-    private void doPublish(Channel channel, MqttPublishMessage msg) {
+    private void doPublish(MqttPublishMessage msg) {
         final MqttQoS qos = msg.fixedHeader().qosLevel();
         metricsCollector.addSend(msg.payload().readableBytes());
         switch (qos) {
             case AT_MOST_ONCE:
-                this.qosPublishHandlers.qos0().publish(channel, msg);
+                this.qosPublishHandlers.qos0().publish(msg);
                 break;
             case AT_LEAST_ONCE:
-                checkServerReceivePubMessageAndIncrementCounterIfNeeded(channel, msg);
-                this.qosPublishHandlers.qos1().publish(channel, msg);
+                checkServerReceivePubMessageAndIncrementCounterIfNeeded(msg);
+                this.qosPublishHandlers.qos1().publish(msg);
                 break;
             case EXACTLY_ONCE:
-                checkServerReceivePubMessageAndIncrementCounterIfNeeded(channel, msg);
-                this.qosPublishHandlers.qos2().publish(channel, msg);
+                checkServerReceivePubMessageAndIncrementCounterIfNeeded(msg);
+                this.qosPublishHandlers.qos2().publish(msg);
                 break;
             default:
                 log.error("Unknown QoS-Type:{}", qos);
@@ -274,13 +264,12 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
         }
     }
 
-    private void checkServerReceivePubMessageAndIncrementCounterIfNeeded(Channel channel, MqttPublishMessage msg) {
+    private void checkServerReceivePubMessageAndIncrementCounterIfNeeded(MqttPublishMessage msg) {
         // check mqtt 5.0
-        if (!MqttUtils.isMqtt5(NettyUtils.getProtocolVersion(channel))) {
+        if (!MqttUtils.isMqtt5(connection.getProtocolVersion())) {
             return;
         }
-        Connection connection = NettyUtils.getConnection(channel);
-        if (connection.getServerReceivePubMessage() >= connection.getServerReceivePubMaximum()){
+        if (connection.getServerReceivePubMessage() >= connection.getServerReceivePubMaximum()) {
             log.warn("Client publish exceed server receive maximum , the receive maximum is {}",
                     connection.getServerReceivePubMaximum());
             int packetId = msg.variableHeader().packetId();
@@ -296,28 +285,35 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
     @Override
     public void processPubRel(MqttMessage msg) {
         if (log.isDebugEnabled()) {
-            log.debug("[PubRel] [{}] msg: {}", NettyUtils.getClientId(channel), msg);
+            log.debug("[PubRel] [{}] msg: {}", connection.getClientId(), msg);
         }
     }
 
     @Override
     public void processPubRec(MqttMessage msg) {
         if (log.isDebugEnabled()) {
-            log.debug("[PubRec] [{}] msg: {}", NettyUtils.getClientId(channel), msg);
+            log.debug("[PubRec] [{}] msg: {}", connection.getClientId(), msg);
         }
     }
 
     @Override
     public void processPubComp(MqttMessage msg) {
         if (log.isDebugEnabled()) {
-            log.debug("[PubComp] [{}] msg: {}", NettyUtils.getClientId(channel), msg);
+            log.debug("[PubComp] [{}] msg: {}", connection.getClientId(), msg);
         }
     }
 
     @Override
     public void processDisconnect(MqttMessage msg) {
-        final String clientId = NettyUtils.getClientId(channel);
-        Connection connection = NettyUtils.getConnection(channel);
+        // When login, checkState(msg) failed, connection is null.
+        if (connection == null) {
+            channel.close();
+            return;
+        }
+        final String clientId = connection.getClientId();
+        if (log.isDebugEnabled()) {
+            log.debug("[Disconnect] [{}] ", clientId);
+        }
         // when reset expire interval present, we need to reset session expire interval.
         Object header = msg.variableHeader();
         if (header instanceof MqttReasonCodeAndPropertiesVariableHeader) {
@@ -327,19 +323,10 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
                 return;
             }
         }
-        if (log.isDebugEnabled()) {
-            log.debug("[Disconnect] [{}] ", clientId);
-        }
         metricsCollector.removeClient(NettyUtils.getAddress(channel));
-        // When login, checkState(msg) failed, connection is null.
-        if (connection != null) {
-            connectionManager.removeConnection(connection);
-            connection.removeSubscriptions();
-            connection.close();
-        } else {
-            log.warn("connection is null. close CId={}", clientId);
-            channel.close();
-        }
+        connectionManager.removeConnection(connection);
+        connection.removeSubscriptions();
+        connection.close();
     }
 
     private boolean checkAndUpdateSessionExpireIntervalIfNeed(Channel channel, String clientId,
@@ -367,22 +354,21 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
 
     @Override
     public void processConnectionLost() {
-        String clientId = NettyUtils.getClientId(channel);
+        if (connection == null) {
+            channel.close();
+            return;
+        }
+        String clientId = connection.getClientId();
         if (log.isDebugEnabled()) {
             log.debug("[Connection Lost] [{}] ", clientId);
         }
-        if (StringUtils.isNotEmpty(clientId)) {
-            metricsCollector.removeClient(NettyUtils.getAddress(channel));
-            Connection connection =  NettyUtils.getConnection(channel);
-            if (connection != null) {
-                connectionManager.removeConnection(connection);
-                connection.removeSubscriptions();
-            }
-            subscriptionManager.removeSubscription(clientId);
-            Optional<WillMessage> willMessage = NettyUtils.getWillMessage(channel);
-            if (willMessage.isPresent()) {
-                fireWillMessage(willMessage.get());
-            }
+        metricsCollector.removeClient(NettyUtils.getAddress(channel));
+        connectionManager.removeConnection(connection);
+        connection.removeSubscriptions();
+        subscriptionManager.removeSubscription(clientId);
+        Optional<WillMessage> willMessage = connection.getWillMessage();
+        if (willMessage.isPresent()) {
+            fireWillMessage(willMessage.get());
         }
     }
 
@@ -406,14 +392,14 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
 
     @Override
     public void processSubscribe(MqttSubscribeMessage msg) {
-        String clientID = NettyUtils.getClientId(channel);
-        String userRole = NettyUtils.getUserRole(channel);
-        int protocolVersion = NettyUtils.getProtocolVersion(channel);
+        String clientId = connection.getClientId();
+        String userRole = connection.getUserRole();
+        int protocolVersion = connection.getProtocolVersion();
         if (log.isDebugEnabled()) {
-            log.debug("[Subscribe] [{}] msg: {}", clientID, msg);
+            log.debug("[Subscribe] [{}] msg: {}", clientId, msg);
         }
 
-        if (StringUtils.isEmpty(clientID)) {
+        if (StringUtils.isEmpty(clientId)) {
             log.error("clientId is empty for sub [{}] close channel", msg);
             MqttMessage subAckMessage = MqttUtils.isMqtt5(protocolVersion)
                     ? MqttSubAckMessageHelper.createMqtt5(msg.variableHeader().messageId(),
@@ -426,8 +412,8 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
 
         // Authorization the client
         if (!configuration.isMqttAuthorizationEnabled()) {
-            log.info("[Subscribe] authorization is disabled, allowing client. CId={}, userRole={}", clientID, userRole);
-            doSubscribe(channel, msg, clientID);
+            log.info("[Subscribe] authorization is disabled, allowing client. CId={}, userRole={}", clientId, userRole);
+            doSubscribe(msg, clientId);
         } else {
             List<CompletableFuture<Void>> authorizationFutures = new ArrayList<>();
             AtomicBoolean authorizedFlag = new AtomicBoolean(true);
@@ -437,7 +423,7 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
                             if (!authorized) {
                                 authorizedFlag.set(authorized);
                                 log.warn("[Subscribe] no authorization to sub topic={}, userRole={}, CId= {}",
-                                        topic.topicName(), userRole, clientID);
+                                        topic.topicName(), userRole, clientId);
                             }
                         }));
             }
@@ -446,22 +432,21 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
                     int messageId = msg.variableHeader().messageId();
                     MqttMessage subscribeAckMessage = MqttUtils.isMqtt5(protocolVersion)
                             ? MqttSubAckMessageHelper.createMqtt5(messageId, Mqtt5SubReasonCode.NOT_AUTHORIZED,
-                            String.format("The client %s not authorized.", clientID)) :
+                            String.format("The client %s not authorized.", clientId)) :
                             MqttSubAckMessageHelper.createMqtt(messageId, Mqtt3SubReasonCode.FAILURE);
                     channel.writeAndFlush(subscribeAckMessage);
                     channel.close();
                 } else {
-                    doSubscribe(channel, msg, clientID);
+                    doSubscribe(msg, clientId);
                 }
             });
         }
     }
 
-    private void doSubscribe(Channel channel, MqttSubscribeMessage msg, String clientID) {
+    private void doSubscribe(MqttSubscribeMessage msg, String clientID) {
         int messageID = msg.variableHeader().messageId();
-        Connection connection = NettyUtils.getConnection(channel);
         List<MqttTopicSubscription> subTopics = topicSubscriptions(msg);
-        subscriptionManager.addSubscriptions(NettyUtils.getClientId(channel), subTopics);
+        subscriptionManager.addSubscriptions(connection.getClientId(), subTopics);
         List<CompletableFuture<Void>> futureList = new ArrayList<>(subTopics.size());
         Map<Topic, Pair<Subscription, Consumer>> topicSubscriptions = new ConcurrentHashMap<>();
         for (MqttTopicSubscription subTopic : subTopics) {
@@ -494,7 +479,7 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
             });
             futureList.add(completableFuture);
         }
-        int protocolVersion = NettyUtils.getProtocolVersion(channel);
+        int protocolVersion = connection.getProtocolVersion();
         FutureUtil.waitForAll(futureList).thenAccept(v -> {
             MqttMessage ackMessage =
                     // Support MQTT 5
@@ -518,8 +503,7 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
 
     @Override
     public void processUnSubscribe(MqttUnsubscribeMessage msg) {
-        String clientID = NettyUtils.getClientId(channel);
-        Connection connection = NettyUtils.getConnection(channel);
+        String clientID = connection.getClientId();
         if (log.isDebugEnabled()) {
             log.debug("[Unsubscribe] [{}] msg: {}", clientID, msg);
         }
@@ -570,7 +554,7 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
             futureList.add(future);
         }
         int messageID = msg.variableHeader().messageId();
-        int protocolVersion = NettyUtils.getProtocolVersion(channel);
+        int protocolVersion = connection.getProtocolVersion();
         FutureUtil.waitForAll(futureList).thenAccept(__ -> {
             // ack the client
             MqttMessage ackMessage = MqttUtils.isMqtt5(protocolVersion) ?  // Support Mqtt version 5.0 reason code.

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
@@ -52,6 +52,7 @@ import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5DisConnRea
 import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5PubReasonCode;
 import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5SubReasonCode;
 import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5UnsubReasonCode;
+import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.SessionExpireInterval;
 import io.streamnative.pulsar.handlers.mqtt.messages.factory.MqttConnAckMessageHelper;
 import io.streamnative.pulsar.handlers.mqtt.messages.factory.MqttDisConnAckMessageHelper;
 import io.streamnative.pulsar.handlers.mqtt.messages.factory.MqttPubAckMessageHelper;
@@ -177,7 +178,8 @@ public class DefaultProtocolMethodProcessorImpl implements ProtocolMethodProcess
                 .userRole(userRole)
                 .willMessage(createWillMessage(msg))
                 .cleanSession(msg.variableHeader().isCleanSession())
-                .sessionExpireInterval(MqttPropertyUtils.getExpireInterval(msg.variableHeader().properties()))
+                .sessionExpireInterval(MqttPropertyUtils.getExpireInterval(msg.variableHeader().properties())
+                        .orElse(SessionExpireInterval.EXPIRE_IMMEDIATELY.getSecondTime()))
                 .clientReceiveMaximum(MqttPropertyUtils.getReceiveMaximum(protocolVersion,
                         msg.variableHeader().properties()))
                 .serverReceivePubMaximum(configuration.getReceiveMaximum())

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos0PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos0PublishHandler.java
@@ -25,12 +25,12 @@ import org.apache.pulsar.broker.PulsarService;
 @Slf4j
 public class Qos0PublishHandler extends AbstractQosPublishHandler {
 
-    public Qos0PublishHandler(PulsarService pulsarService, MQTTServerConfiguration configuration) {
-        super(pulsarService, configuration);
+    public Qos0PublishHandler(PulsarService pulsarService, MQTTServerConfiguration configuration, Channel channel) {
+        super(pulsarService, configuration, channel);
     }
 
     @Override
-    public void publish(Channel channel, MqttPublishMessage msg) {
+    public void publish(MqttPublishMessage msg) {
         writeToPulsarTopic(msg).whenComplete((p, e) -> {
             if (e == null) {
                 if (log.isDebugEnabled()) {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
@@ -37,14 +37,14 @@ import org.apache.pulsar.broker.PulsarService;
 @Slf4j
 public class Qos1PublishHandler extends AbstractQosPublishHandler {
 
-    public Qos1PublishHandler(PulsarService pulsarService, MQTTServerConfiguration configuration) {
-        super(pulsarService, configuration);
+    public Qos1PublishHandler(PulsarService pulsarService, MQTTServerConfiguration configuration, Channel channel) {
+        super(pulsarService, configuration, channel);
     }
 
     @Override
-    public void publish(Channel channel, MqttPublishMessage msg) {
+    public void publish(MqttPublishMessage msg) {
         Connection connection = NettyUtils.getConnection(channel);
-        int protocolVersion = NettyUtils.getProtocolVersion(channel);
+        int protocolVersion = connection.getProtocolVersion();
         final boolean isMqtt5 = MqttUtils.isMqtt5(protocolVersion);
         int packetId = msg.variableHeader().packetId();
         final String topic = msg.variableHeader().topicName();
@@ -65,11 +65,11 @@ public class Qos1PublishHandler extends AbstractQosPublishHandler {
                         connection.decrementServerReceivePubMessage();
                         if (log.isDebugEnabled()) {
                             log.debug("[{}] Send Pub Ack {} to {}", topic, msg.variableHeader().packetId(),
-                                    NettyUtils.getClientId(channel));
+                                    connection.getClientId());
                         }
                     } else {
                         log.warn("[{}] Failed to send Pub Ack {} to {}", topic, msg.variableHeader().packetId(),
-                                NettyUtils.getClientId(channel), future.cause());
+                                connection.getClientId(), future.cause());
                     }
                 });
             } else {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos2PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos2PublishHandler.java
@@ -26,12 +26,12 @@ import org.apache.pulsar.broker.PulsarService;
 @Slf4j
 public class Qos2PublishHandler extends AbstractQosPublishHandler {
 
-    public Qos2PublishHandler(PulsarService pulsarService, MQTTServerConfiguration configuration) {
-        super(pulsarService, configuration);
+    public Qos2PublishHandler(PulsarService pulsarService, MQTTServerConfiguration configuration, Channel channel) {
+        super(pulsarService, configuration, channel);
     }
 
     @Override
-    public void publish(Channel channel, MqttPublishMessage msg) {
+    public void publish(MqttPublishMessage msg) {
         log.error("[{}] Failed to write data due to QoS2 does not support.", msg.variableHeader().topicName());
         channel.close();
     }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/QosPublishHandlersImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/QosPublishHandlersImpl.java
@@ -13,6 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.mqtt.support;
 
+import io.netty.channel.Channel;
 import io.streamnative.pulsar.handlers.mqtt.MQTTServerConfiguration;
 import io.streamnative.pulsar.handlers.mqtt.QosPublishHandler;
 import io.streamnative.pulsar.handlers.mqtt.QosPublishHandlers;
@@ -23,18 +24,14 @@ import org.apache.pulsar.broker.PulsarService;
  */
 public class QosPublishHandlersImpl implements QosPublishHandlers {
 
-    private final PulsarService pulsarService;
-    private final MQTTServerConfiguration configuration;
     private final QosPublishHandler qos0Handler;
     private final QosPublishHandler qos1Handler;
     private final QosPublishHandler qos2Handler;
 
-    public QosPublishHandlersImpl(PulsarService pulsarService, MQTTServerConfiguration configuration) {
-        this.pulsarService = pulsarService;
-        this.configuration = configuration;
-        this.qos0Handler = new Qos0PublishHandler(pulsarService, configuration);
-        this.qos1Handler = new Qos1PublishHandler(pulsarService, configuration);
-        this.qos2Handler = new Qos2PublishHandler(pulsarService, configuration);
+    public QosPublishHandlersImpl(PulsarService pulsarService, MQTTServerConfiguration configuration, Channel channel) {
+        this.qos0Handler = new Qos0PublishHandler(pulsarService, configuration, channel);
+        this.qos1Handler = new Qos1PublishHandler(pulsarService, configuration, channel);
+        this.qos2Handler = new Qos2PublishHandler(pulsarService, configuration, channel);
     }
 
     @Override

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MqttMessageUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MqttMessageUtils.java
@@ -93,15 +93,15 @@ public class MqttMessageUtils {
         return ackTopics;
     }
 
-    public static Optional<WillMessage> createWillMessage(MqttConnectMessage msg) {
+    public static WillMessage createWillMessage(MqttConnectMessage msg) {
         if (!msg.variableHeader().isWillFlag()) {
-            return Optional.empty();
+            return null;
         }
         final ByteBuf willPayload = Unpooled.copiedBuffer(msg.payload().willMessageInBytes());
         final String willTopic = msg.payload().willTopic();
         final boolean retained = msg.variableHeader().isWillRetain();
         final MqttQoS qos = MqttQoS.valueOf(msg.variableHeader().willQos());
-        return Optional.of(new WillMessage(willTopic, willPayload, qos, retained));
+        return new WillMessage(willTopic, willPayload, qos, retained);
     }
 
     public static MqttPublishMessage createMqttWillMessage(WillMessage willMessage) {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MqttMessageUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MqttMessageUtils.java
@@ -30,6 +30,7 @@ import io.streamnative.pulsar.handlers.mqtt.support.MessageBuilder;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.apache.commons.codec.binary.Hex;
 
@@ -92,12 +93,15 @@ public class MqttMessageUtils {
         return ackTopics;
     }
 
-    public static WillMessage createWillMessage(MqttConnectMessage msg) {
+    public static Optional<WillMessage> createWillMessage(MqttConnectMessage msg) {
+        if (!msg.variableHeader().isWillFlag()) {
+            return Optional.empty();
+        }
         final ByteBuf willPayload = Unpooled.copiedBuffer(msg.payload().willMessageInBytes());
         final String willTopic = msg.payload().willTopic();
         final boolean retained = msg.variableHeader().isWillRetain();
         final MqttQoS qos = MqttQoS.valueOf(msg.variableHeader().willQos());
-        return new WillMessage(willTopic, willPayload, qos, retained);
+        return Optional.of(new WillMessage(willTopic, willPayload, qos, retained));
     }
 
     public static MqttPublishMessage createMqttWillMessage(WillMessage willMessage) {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MqttMessageUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MqttMessageUtils.java
@@ -30,7 +30,6 @@ import io.streamnative.pulsar.handlers.mqtt.support.MessageBuilder;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.apache.commons.codec.binary.Hex;
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/NettyUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/NettyUtils.java
@@ -13,15 +13,11 @@
  */
 package io.streamnative.pulsar.handlers.mqtt.utils;
 
-import static io.streamnative.pulsar.handlers.mqtt.Constants.ATTR_CLEAN_SESSION;
 import static io.streamnative.pulsar.handlers.mqtt.Constants.ATTR_CLIENT_ADDR;
-import static io.streamnative.pulsar.handlers.mqtt.Constants.ATTR_CLIENT_ID;
 import static io.streamnative.pulsar.handlers.mqtt.Constants.ATTR_CONNECTION;
 import static io.streamnative.pulsar.handlers.mqtt.Constants.ATTR_CONNECT_MSG;
 import static io.streamnative.pulsar.handlers.mqtt.Constants.ATTR_KEEP_ALIVE_TIME;
-import static io.streamnative.pulsar.handlers.mqtt.Constants.ATTR_PROTOCOL_VERSION;
 import static io.streamnative.pulsar.handlers.mqtt.Constants.ATTR_TOPIC_SUBS;
-import static io.streamnative.pulsar.handlers.mqtt.Constants.ATTR_WILL_MESSAGE;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
@@ -42,27 +38,13 @@ import org.apache.pulsar.broker.service.Topic;
 public final class NettyUtils {
 
     public static final String ATTR_USERNAME = "username";
-    public static final String ATTR_USER_ROLE = "userRole";
 
-    private static final AttributeKey<Object> ATTR_KEY_CLIENT_ID = AttributeKey.valueOf(ATTR_CLIENT_ID);
     private static final AttributeKey<Object> ATTR_KEY_CONNECTION = AttributeKey.valueOf(ATTR_CONNECTION);
-    private static final AttributeKey<Object> ATTR_KEY_CLEAN_SESSION = AttributeKey.valueOf(ATTR_CLEAN_SESSION);
     private static final AttributeKey<Object> ATTR_KEY_KEEP_ALIVE_TIME = AttributeKey.valueOf(ATTR_KEEP_ALIVE_TIME);
     private static final AttributeKey<Object> ATTR_KEY_USERNAME = AttributeKey.valueOf(ATTR_USERNAME);
-    private static final AttributeKey<Object> ATTR_KEY_USER_ROLE = AttributeKey.valueOf(ATTR_USER_ROLE);
     private static final AttributeKey<Object> ATTR_KEY_CONNECT_MSG = AttributeKey.valueOf(ATTR_CONNECT_MSG);
     private static final AttributeKey<Object> ATTR_KEY_TOPIC_SUBS = AttributeKey.valueOf(ATTR_TOPIC_SUBS);
     private static final AttributeKey<Object> ATTR_KEY_CLIENT_ADDR = AttributeKey.valueOf(ATTR_CLIENT_ADDR);
-    private static final AttributeKey<Object> ATTR_KEY_WILL_MESSAGE = AttributeKey.valueOf(ATTR_WILL_MESSAGE);
-    private static final AttributeKey<Object> ATTR_KEY_PROTOCOL_VERSION = AttributeKey.valueOf(ATTR_PROTOCOL_VERSION);
-
-    public static void setClientId(Channel channel, String clientId) {
-        channel.attr(NettyUtils.ATTR_KEY_CLIENT_ID).set(clientId);
-    }
-
-    public static String getClientId(Channel channel) {
-        return (String) channel.attr(NettyUtils.ATTR_KEY_CLIENT_ID).get();
-    }
 
     public static void setConnection(Channel channel, Connection connection) {
         channel.attr(NettyUtils.ATTR_KEY_CONNECTION).set(connection);
@@ -70,14 +52,6 @@ public final class NettyUtils {
 
     public static Connection getConnection(Channel channel) {
         return (Connection) channel.attr(NettyUtils.ATTR_KEY_CONNECTION).get();
-    }
-
-    public static void setCleanSession(Channel channel, boolean cleanSession) {
-        channel.attr(NettyUtils.ATTR_KEY_CLEAN_SESSION).set(cleanSession);
-    }
-
-    public static boolean getCleanSession(Channel channel) {
-        return (Boolean) channel.attr(NettyUtils.ATTR_KEY_CLEAN_SESSION).get();
     }
 
     public static void setConnectMsg(Channel channel, MqttConnectMessage connectMessage) {
@@ -103,14 +77,6 @@ public final class NettyUtils {
 
     public static void userName(Channel channel, String username) {
         channel.attr(NettyUtils.ATTR_KEY_USERNAME).set(username);
-    }
-
-    public static String getUserRole(Channel channel) {
-        return (String) channel.attr(NettyUtils.ATTR_KEY_USER_ROLE).get();
-    }
-
-    public static void setUserRole(Channel channel, String authRole) {
-        channel.attr(NettyUtils.ATTR_KEY_USER_ROLE).set(authRole);
     }
 
     public static String userName(Channel channel) {
@@ -146,23 +112,6 @@ public final class NettyUtils {
 
     public static String getAddress(Channel channel) {
         return (String) channel.attr(NettyUtils.ATTR_KEY_CLIENT_ADDR).get();
-    }
-
-    public static void setWillMessage(Channel channel, WillMessage willMessage) {
-        channel.attr(NettyUtils.ATTR_KEY_WILL_MESSAGE).set(willMessage);
-    }
-
-    public static Optional<WillMessage> getWillMessage(Channel channel) {
-        WillMessage willMessage = (WillMessage) channel.attr(NettyUtils.ATTR_KEY_WILL_MESSAGE).get();
-        return Optional.ofNullable(willMessage);
-    }
-
-    public static void setProtocolVersion(Channel channel, int mqttVersion) {
-        channel.attr(NettyUtils.ATTR_KEY_PROTOCOL_VERSION).set(mqttVersion);
-    }
-
-    public static int getProtocolVersion(Channel channel) {
-        return (Integer) channel.attr(NettyUtils.ATTR_KEY_PROTOCOL_VERSION).get();
     }
 
     private NettyUtils() {


### PR DESCRIPTION
## Motivation
As we support MQTT5,  we need to bind more properties to the channel. This is not a good way.  It's better to store these properties to `connection`, and we only bind `connection` to the channel.
Another, we can get the channel at the construct time, so no need to pass the `channel` to any method, like `qos1().publish(channel, msg)`

## Modification
- Move mqtt properties to connection.
- Remove the channel from publish method in qos handler.