### PR TITLE
Add ack handler to process different protocol response.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyExchanger.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyExchanger.java
@@ -75,7 +75,7 @@ public class MQTTProxyExchanger {
         @Override
         public void channelActive(ChannelHandlerContext ctx) throws Exception {
             super.channelActive(ctx);
-            MqttConnectMessage connectMessage = NettyUtils.getConnectMsg(processor.getChannel());
+            MqttConnectMessage connectMessage = processor.getConnection().getConnectMessage();
             ctx.channel().writeAndFlush(connectMessage);
         }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;
@@ -59,6 +60,7 @@ public class MQTTProxyProtocolMethodProcessor implements ProtocolMethodProcessor
 
     private final MQTTProxyService proxyService;
     private final Channel channel;
+    @Getter
     private Connection connection;
     private final LookupHandler lookupHandler;
     private final MQTTProxyConfiguration proxyConfig;
@@ -115,20 +117,16 @@ public class MQTTProxyProtocolMethodProcessor implements ProtocolMethodProcessor
                 return;
             }
         }
-        NettyUtils.setConnectMsg(channel, connectMessage);
-        NettyUtils.setKeepAliveTime(channel, MqttMessageUtils.getKeepAliveTime(msg));
-        NettyUtils.addIdleStateHandler(channel, MqttMessageUtils.getKeepAliveTime(msg));
-
         connection = Connection.builder()
                 .protocolVersion(protocolVersion)
                 .clientId(clientId)
                 .cleanSession(msg.variableHeader().isCleanSession())
+                .connectMessage(connectMessage)
+                .keepAliveTime(msg.variableHeader().keepAliveTimeSeconds())
                 .channel(channel)
                 .connectionManager(connectionManager)
                 .serverReceivePubMaximum(proxyConfig.getReceiveMaximum())
                 .build();
-        connectionManager.addConnection(connection);
-        NettyUtils.setConnection(channel, connection);
         connection.sendConnAck();
     }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/handler/AbstractAckHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/handler/AbstractAckHandler.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.support.handler;
+
+import static io.streamnative.pulsar.handlers.mqtt.Connection.ConnectionState.CONNECT_ACK;
+import static io.streamnative.pulsar.handlers.mqtt.Connection.ConnectionState.DISCONNECTED;
+import static io.streamnative.pulsar.handlers.mqtt.Connection.ConnectionState.ESTABLISHED;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.streamnative.pulsar.handlers.mqtt.Connection;
+import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt3.Mqtt3ConnReasonCode;
+import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5ConnReasonCode;
+import io.streamnative.pulsar.handlers.mqtt.messages.factory.MqttConnAckMessageHelper;
+import io.streamnative.pulsar.handlers.mqtt.utils.MqttUtils;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Abstract ack handler.
+ */
+@Slf4j
+public abstract class AbstractAckHandler implements AckHandler {
+
+    abstract MqttMessage getConnAckMessage(Connection connection);
+
+    @Override
+    public void sendConnAck(Connection connection) {
+        String clientId = connection.getClientId();
+        boolean ret = connection.assignState(DISCONNECTED, CONNECT_ACK);
+        if (!ret) {
+            int protocolVersion = connection.getProtocolVersion();
+            log.warn("Unable to assign the state from : {} to : {} for CId={}, close channel",
+                    DISCONNECTED, CONNECT_ACK, clientId);
+            MqttMessage mqttConnAckMessage = MqttUtils.isMqtt5(protocolVersion)
+                    ? MqttConnAckMessageHelper.createMqtt5(Mqtt5ConnReasonCode.SERVER_UNAVAILABLE,
+                    String.format("Unable to assign the state from : %s to : %s for CId=%s, close channel"
+                            , DISCONNECTED, CONNECT_ACK, clientId)) :
+                    MqttConnAckMessageHelper.createConnAck(Mqtt3ConnReasonCode.CONNECTION_REFUSED_SERVER_UNAVAILABLE);
+            connection.sendThenClose(mqttConnAckMessage);
+            return;
+        }
+        MqttMessage ackOkMessage = getConnAckMessage(connection);
+        connection.send(ackOkMessage).addListener(future -> {
+            if (future.isSuccess()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("The CONNECT message has been processed. CId={}", clientId);
+                }
+                connection.assignState(CONNECT_ACK, ESTABLISHED);
+                log.info("current connection state : {}", connection.getConnectionState(connection));
+            }
+        });
+    }
+}

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/handler/AckHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/handler/AckHandler.java
@@ -11,20 +11,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamnative.pulsar.handlers.mqtt;
+package io.streamnative.pulsar.handlers.mqtt.support.handler;
+
+import io.streamnative.pulsar.handlers.mqtt.Connection;
 
 /**
- * Server constants keeper.
+ * Ack handler.
  */
-public final class Constants {
+public interface AckHandler {
 
-    public static final String ATTR_CONNECTION = "Connection";
-    public static final String ATTR_CLIENT_ADDR = "ClientAddr";
-    public static final String AUTH_BASIC = "basic";
-    public static final String AUTH_TOKEN = "token";
-
-    public static final String ATTR_TOPIC_SUBS = "topicSubs";
-
-    private Constants() {
-    }
+    void sendConnAck(Connection connection);
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/handler/AckHandlerFactory.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/handler/AckHandlerFactory.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.support.handler;
+
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Abstract ack handler.
+ */
+@Slf4j
+public enum AckHandlerFactory {
+
+    ACK_HANDLER_V3_1(3, new MqttV3xAckHandler()),
+
+    ACK_HANDLER_V3_1_1(4, new MqttV3xAckHandler()),
+
+    ACK_HANDLER_V5(5, new MqttV5AckHandler());
+
+    @Getter
+    private int protocol;
+
+    @Getter
+    private AckHandler ackHandler;
+
+    AckHandlerFactory(int protocol, AckHandler ackHandler) {
+        this.protocol = protocol;
+        this.ackHandler = ackHandler;
+    }
+
+    public static AckHandlerFactory of(int protocol) {
+        return Arrays.stream(values()).filter(e -> e.protocol == protocol).findFirst()
+                .orElseThrow(() -> new UnsupportedOperationException("invalid protocol :" + protocol));
+    }
+}

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/handler/MqttV3xAckHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/handler/MqttV3xAckHandler.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.support.handler;
+
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttMessageBuilders;
+import io.streamnative.pulsar.handlers.mqtt.Connection;
+import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt3.Mqtt3ConnReasonCode;
+
+/**
+ * Mqtt3x ack handler.
+ */
+public class MqttV3xAckHandler extends AbstractAckHandler {
+
+    @Override
+    MqttMessage getConnAckMessage(Connection connection) {
+        return MqttMessageBuilders.connAck()
+                .returnCode(Mqtt3ConnReasonCode.CONNECTION_ACCEPTED.convertToNettyKlass())
+                .sessionPresent(!connection.isCleanSession())
+                .build();
+    }
+}

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/handler/MqttV5AckHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/handler/MqttV5AckHandler.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.support.handler;
+
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttMessageBuilders;
+import io.netty.handler.codec.mqtt.MqttProperties;
+import io.streamnative.pulsar.handlers.mqtt.Connection;
+import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5ConnReasonCode;
+
+/**
+ * MQTT5 ack handler.
+ */
+public class MqttV5AckHandler extends AbstractAckHandler {
+
+    @Override
+    MqttMessage getConnAckMessage(Connection connection) {
+        MqttProperties properties = new MqttProperties();
+        MqttProperties.IntegerProperty property =
+                new MqttProperties.IntegerProperty(MqttProperties.MqttPropertyType.RECEIVE_MAXIMUM.value(),
+                        connection.getServerReceivePubMaximum());
+        properties.add(property);
+        return MqttMessageBuilders.connAck()
+                .returnCode(Mqtt5ConnReasonCode.SUCCESS.convertToNettyKlass())
+                .sessionPresent(!connection.isCleanSession())
+                .properties(properties)
+                .build();
+    }
+}

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/handler/package-info.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/handler/package-info.java
@@ -11,20 +11,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamnative.pulsar.handlers.mqtt;
 
 /**
- * Server constants keeper.
+ * Package info.
  */
-public final class Constants {
-
-    public static final String ATTR_CONNECTION = "Connection";
-    public static final String ATTR_CLIENT_ADDR = "ClientAddr";
-    public static final String AUTH_BASIC = "basic";
-    public static final String AUTH_TOKEN = "token";
-
-    public static final String ATTR_TOPIC_SUBS = "topicSubs";
-
-    private Constants() {
-    }
-}
+package io.streamnative.pulsar.handlers.mqtt.support.handler;

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MqttMessageUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MqttMessageUtils.java
@@ -78,10 +78,6 @@ public class MqttMessageUtils {
         return new MqttConnectMessage(msg.fixedHeader(), msg.variableHeader(), payload);
     }
 
-    public static int getKeepAliveTime(MqttConnectMessage msg) {
-        return Math.round(msg.variableHeader().keepAliveTimeSeconds() * 1.5f);
-    }
-
     public static List<MqttTopicSubscription> topicSubscriptions(MqttSubscribeMessage msg) {
         List<MqttTopicSubscription> ackTopics = new ArrayList<>();
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/NettyUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/NettyUtils.java
@@ -15,18 +15,12 @@ package io.streamnative.pulsar.handlers.mqtt.utils;
 
 import static io.streamnative.pulsar.handlers.mqtt.Constants.ATTR_CLIENT_ADDR;
 import static io.streamnative.pulsar.handlers.mqtt.Constants.ATTR_CONNECTION;
-import static io.streamnative.pulsar.handlers.mqtt.Constants.ATTR_CONNECT_MSG;
-import static io.streamnative.pulsar.handlers.mqtt.Constants.ATTR_KEEP_ALIVE_TIME;
 import static io.streamnative.pulsar.handlers.mqtt.Constants.ATTR_TOPIC_SUBS;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelPipeline;
-import io.netty.handler.codec.mqtt.MqttConnectMessage;
-import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.AttributeKey;
 import io.streamnative.pulsar.handlers.mqtt.Connection;
 import java.net.InetSocketAddress;
 import java.util.Map;
-import java.util.Optional;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.Subscription;
@@ -37,25 +31,12 @@ import org.apache.pulsar.broker.service.Topic;
  */
 public final class NettyUtils {
 
-    public static final String ATTR_USERNAME = "username";
-
-    private static final AttributeKey<Object> ATTR_KEY_CONNECTION = AttributeKey.valueOf(ATTR_CONNECTION);
-    private static final AttributeKey<Object> ATTR_KEY_KEEP_ALIVE_TIME = AttributeKey.valueOf(ATTR_KEEP_ALIVE_TIME);
-    private static final AttributeKey<Object> ATTR_KEY_USERNAME = AttributeKey.valueOf(ATTR_USERNAME);
-    private static final AttributeKey<Object> ATTR_KEY_CONNECT_MSG = AttributeKey.valueOf(ATTR_CONNECT_MSG);
+    public static final AttributeKey<Object> ATTR_KEY_CONNECTION = AttributeKey.valueOf(ATTR_CONNECTION);
     private static final AttributeKey<Object> ATTR_KEY_TOPIC_SUBS = AttributeKey.valueOf(ATTR_TOPIC_SUBS);
     private static final AttributeKey<Object> ATTR_KEY_CLIENT_ADDR = AttributeKey.valueOf(ATTR_CLIENT_ADDR);
 
-    public static void setConnection(Channel channel, Connection connection) {
-        channel.attr(NettyUtils.ATTR_KEY_CONNECTION).set(connection);
-    }
-
     public static Connection getConnection(Channel channel) {
         return (Connection) channel.attr(NettyUtils.ATTR_KEY_CONNECTION).get();
-    }
-
-    public static void setConnectMsg(Channel channel, MqttConnectMessage connectMessage) {
-        channel.attr(NettyUtils.ATTR_KEY_CONNECT_MSG).set(connectMessage);
     }
 
     public static void setTopicSubscriptions(Channel channel, Map<Topic, Pair<Subscription, Consumer>> topicSubs) {
@@ -64,39 +45,6 @@ public final class NettyUtils {
 
     public static Map<Topic, Pair<Subscription, Consumer>> getTopicSubscriptions(Channel channel) {
         return (Map<Topic, Pair<Subscription, Consumer>>) channel.attr(NettyUtils.ATTR_KEY_TOPIC_SUBS).get();
-    }
-
-    public static Optional<MqttConnectMessage> getAndRemoveConnectMsg(Channel channel) {
-        return Optional.ofNullable(channel.attr(NettyUtils.ATTR_KEY_CONNECT_MSG).getAndSet(null))
-                .map(o -> (MqttConnectMessage) o);
-    }
-
-    public static MqttConnectMessage getConnectMsg(Channel channel) {
-        return (MqttConnectMessage) channel.attr(NettyUtils.ATTR_KEY_CONNECT_MSG).get();
-    }
-
-    public static void userName(Channel channel, String username) {
-        channel.attr(NettyUtils.ATTR_KEY_USERNAME).set(username);
-    }
-
-    public static String userName(Channel channel) {
-        return (String) channel.attr(NettyUtils.ATTR_KEY_USERNAME).get();
-    }
-
-    public static void addIdleStateHandler(Channel channel, int idleTime) {
-        ChannelPipeline pipeline = channel.pipeline();
-        if (pipeline.names().contains("idleStateHandler")) {
-            pipeline.remove("idleStateHandler");
-        }
-        pipeline.addFirst("idleStateHandler", new IdleStateHandler(0, 0, idleTime));
-    }
-
-    public static void setKeepAliveTime(Channel channel, int keepAliveTime) {
-        channel.attr(NettyUtils.ATTR_KEY_KEEP_ALIVE_TIME).set(keepAliveTime);
-    }
-
-    public static int getKeepAliveTime(Channel channel) {
-        return (Integer) channel.attr(NettyUtils.ATTR_KEY_KEEP_ALIVE_TIME).get();
     }
 
     public static String getAndSetAddress(Channel channel) {


### PR DESCRIPTION
## Motivation
For we support mqtt5 protocol, and more properties and features added. Before this pr, we face that in every response, we need to judge if the current protocol is mqtt5 or mqtt3 to decide to return a different response .
So we involved ack handler to resolve this issue. The different protocols will use different ack handlers to process the response and avoid judging the protocol everywhere.

## Modification
- Add ack handler.
- Move some properties to connection.