### PR TITLE
[ mop 2.9 ] Bump log4j-core from 2.13.3 to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <awaitility.version>4.0.2</awaitility.version>
         <pulsar.version>2.9.0-rc-202110221101</pulsar.version>
         <mqtt.codec.version>4.1.67.Final</mqtt.codec.version>
-        <log4j2.version>2.13.3</log4j2.version>
+        <log4j2.version>2.16.0</log4j2.version>
         <lombok.version>1.18.4</lombok.version>
         <fusesource.client.version>1.16</fusesource.client.version>
         <hivemq.mqtt.client.version>1.2.2</hivemq.mqtt.client.version>


### PR DESCRIPTION
## Motivation

fixed #322

## Modification

Bump log4j-core from 2.13.3 to 2.16.0
