### PR TITLE
[ mop 2.7 ] Bump log4j-core from 2.13.3 to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <pulsar.version>2.6.2.0</pulsar.version>
         <mqtt.codec.version>4.1.49.Final</mqtt.codec.version>
         <commons-lang3.version>3.4</commons-lang3.version>
-        <log4j2.version>2.13.3</log4j2.version>
+        <log4j2.version>2.16.0</log4j2.version>
         <lombok.version>1.18.4</lombok.version>
         <mqtt.client.version>1.16</mqtt.client.version>
         <javac.target>1.8</javac.target>


### PR DESCRIPTION
## Motivation

fixed #322

## Modification

Bump log4j-core from 2.13.3 to 2.16.0
