### PR TITLE
MIP 2 - Add ``MqttTestClient`` to abstract all different MQTT client.

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTTestBase.java
@@ -36,8 +36,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 
-
-
 /**
  * Base test class for MQTT Client.
  */
@@ -50,44 +48,44 @@ public class MQTTTestBase extends MQTTProtocolHandlerTestBase {
 
     @DataProvider(name = "batchEnabled")
     public Object[][] batchEnabled() {
-        return new Object[][]{
-                {true},
-                {false}
+        return new Object[][] {
+                { true },
+                { false }
         };
     }
 
     @DataProvider(name = "mqttTopicNames")
     public Object[][] mqttTopicNames() {
-        return new Object[][]{
-                {"a/b/c"},
-                {"/a/b/c"},
-                {"a/b/c/"},
-                {"/a/b/c/"},
-                {"persistent://public/default/t0"},
-                {"persistent://public/default/a/b"},
-                {"persistent://public/default//a/b"},
-                {"non-persistent://public/default/t0"},
-                {"non-persistent://public/default/a/b"},
-                {"non-persistent://public/default//a/b"},
+        return new Object[][] {
+                { "a/b/c" },
+                { "/a/b/c" },
+                { "a/b/c/" },
+                { "/a/b/c/" },
+                { "persistent://public/default/t0" },
+                { "persistent://public/default/a/b" },
+                { "persistent://public/default//a/b" },
+                { "non-persistent://public/default/t0" },
+                { "non-persistent://public/default/a/b" },
+                { "non-persistent://public/default//a/b" },
         };
     }
 
     @DataProvider(name = "mqttPersistentTopicNames")
     public Object[][] mqttPersistentTopicNames() {
-        return new Object[][]{
-                {"a/b/c"},
-                {"/a/b/c"},
-                {"a/b/c/"},
-                {"/a/b/c/"},
-                {"persistent://public/default/t0"},
-                {"persistent://public/default/a/b"},
-                {"persistent://public/default//a/b"},
+        return new Object[][] {
+                { "a/b/c" },
+                { "/a/b/c" },
+                { "a/b/c/" },
+                { "/a/b/c/" },
+                { "persistent://public/default/t0" },
+                { "persistent://public/default/a/b" },
+                { "persistent://public/default//a/b" },
         };
     }
 
     @DataProvider(name = "mqttTopicNameAndFilter")
     public Object[][] mqttTopicNameAndFilter() {
-        return new Object[][]{
+        return new Object[][] {
                 {"a/b/c", "a/+/c"},
                 {"a/b/c", "+/+/c"},
                 {"a/b/c", "+/+/+"},

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/provider/ClientToTopic.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/provider/ClientToTopic.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.base.provider;
+
+import io.streamnative.pulsar.handlers.mqtt.client.MqttTestClient;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ClientToTopic {
+    private MqttTestClient client;
+    private String topic;
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/client/MqttTestClient.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/client/MqttTestClient.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.client;
+
+import io.netty.handler.codec.mqtt.MqttConnAckMessage;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttPubAckMessage;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttSubAckMessage;
+import io.netty.handler.codec.mqtt.MqttUnsubAckMessage;
+import io.streamnative.pulsar.handlers.mqtt.client.options.ConnectOptions;
+import io.streamnative.pulsar.handlers.mqtt.client.options.Optional;
+import io.streamnative.pulsar.handlers.mqtt.client.options.PublishOptions;
+import io.streamnative.pulsar.handlers.mqtt.client.options.SubscribeOptions;
+import io.streamnative.pulsar.handlers.mqtt.client.options.UnSubscribeOptions;
+import java.util.concurrent.TimeUnit;
+
+public interface MqttTestClient {
+
+    Optional<MqttConnAckMessage> connect();
+
+    Optional<MqttConnAckMessage> connect(ConnectOptions connectOptions);
+
+    Optional<MqttSubAckMessage> subscribe(SubscribeOptions subscribeOptions);
+
+    Optional<MqttPublishMessage> receive(long time, TimeUnit unit);
+
+    Optional<MqttUnsubAckMessage> unsubscribe(UnSubscribeOptions unSubscribeOptions);
+
+    Optional<MqttPubAckMessage> publish(PublishOptions publishOptions);
+
+    Optional<MqttMessage> disconnect();
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/client/options/BasicAuth.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/client/options/BasicAuth.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.client.options;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class BasicAuth {
+    private String username;
+    private String password;
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/client/options/ClientOptions.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/client/options/ClientOptions.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.client.options;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class ClientOptions {
+    private String clientId;
+    private String serverUrl;
+    private int port;
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/client/options/ConnectOptions.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/client/options/ConnectOptions.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.client.options;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ConnectOptions {
+    @Builder.Default
+    private boolean cleanSession = true;
+    private BasicAuth basicAuth;
+
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/client/options/Optional.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/client/options/Optional.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.client.options;
+
+
+import lombok.Data;
+
+@Data
+public class Optional<T> {
+    private final boolean supported;
+    private final boolean success;
+    private final T body;
+
+    private Optional(boolean supported, boolean success, T body) {
+        this.supported = supported;
+        this.success = success;
+        this.body = body;
+    }
+
+    public static <T> Optional<T> of(T body) {
+        return new Optional<T>(true, true, body);
+    }
+
+    public static <T> Optional<T> fail() {
+        return new Optional<T>(true, false, null);
+    }
+
+    public static <T> Optional<T> unsupported() {
+        return new Optional<T>(false, false, null);
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/client/options/PublishOptions.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/client/options/PublishOptions.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.client.options;
+
+import io.netty.handler.codec.mqtt.MqttQoS;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PublishOptions {
+    private String topic;
+    private MqttQoS qos;
+    private byte[] payload;
+    @Builder.Default
+    private boolean retain = false;
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/client/options/SubscribeOptions.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/client/options/SubscribeOptions.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.client.options;
+
+import io.netty.handler.codec.mqtt.MqttQoS;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SubscribeOptions {
+    private String topicFilters;
+    private MqttQoS qos;
+    @Builder.Default
+    private boolean autoAck = true;
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/client/options/UnSubscribeOptions.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/client/options/UnSubscribeOptions.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.client.options;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UnSubscribeOptions {
+    private String topicFilter;
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/client/v3x/FuseSourceV3TestClient.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/client/v3x/FuseSourceV3TestClient.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.client.v3x;
+
+
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.mqtt.MqttConnAckMessage;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttMessageBuilders;
+import io.netty.handler.codec.mqtt.MqttPubAckMessage;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttSubAckMessage;
+import io.netty.handler.codec.mqtt.MqttUnsubAckMessage;
+import io.streamnative.pulsar.handlers.mqtt.client.MqttTestClient;
+import io.streamnative.pulsar.handlers.mqtt.client.options.ClientOptions;
+import io.streamnative.pulsar.handlers.mqtt.client.options.ConnectOptions;
+import io.streamnative.pulsar.handlers.mqtt.client.options.Optional;
+import io.streamnative.pulsar.handlers.mqtt.client.options.PublishOptions;
+import io.streamnative.pulsar.handlers.mqtt.client.options.SubscribeOptions;
+import io.streamnative.pulsar.handlers.mqtt.client.options.UnSubscribeOptions;
+import java.net.URISyntaxException;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.fusesource.mqtt.client.BlockingConnection;
+import org.fusesource.mqtt.client.MQTT;
+import org.fusesource.mqtt.client.Message;
+import org.fusesource.mqtt.client.QoS;
+import org.fusesource.mqtt.client.Topic;
+
+@Slf4j
+public class FuseSourceV3TestClient implements MqttTestClient {
+
+    private final MQTT mqtt;
+    private BlockingConnection connection;
+    private boolean autoAck;
+
+    public FuseSourceV3TestClient(ClientOptions clientOptions) {
+        this.mqtt = new MQTT();
+        try {
+            mqtt.setHost(clientOptions.getServerUrl(), clientOptions.getPort());
+        } catch (URISyntaxException e) {
+            log.error("init fuse source mqtt client fail!", e);
+            throw new IllegalStateException("init fuse source mqtt client fail!");
+        }
+    }
+
+    @Override
+    public Optional<MqttConnAckMessage> connect() {
+        return connect(ConnectOptions.builder().build());
+    }
+
+    @Override
+    public Optional<MqttConnAckMessage> connect(ConnectOptions connectOptions) {
+        if (connectOptions.getBasicAuth() != null) {
+            mqtt.setUserName(connectOptions.getBasicAuth().getUsername());
+            mqtt.setPassword(connectOptions.getBasicAuth().getPassword());
+        }
+        mqtt.setCleanSession(connectOptions.isCleanSession());
+        this.connection = mqtt.blockingConnection();
+        try {
+            connection.connect();
+        } catch (Exception e) {
+            log.error("fuse source mqtt client connect fail ", e);
+        }
+        return Optional.unsupported();
+    }
+
+    @Override
+    public Optional<MqttSubAckMessage> subscribe(SubscribeOptions subscribeOptions) {
+        this.autoAck = subscribeOptions.isAutoAck();
+        Topic[] topics = {new Topic(subscribeOptions.getTopicFilters(),
+                QoS.valueOf(subscribeOptions.getQos().name()))};
+        try {
+            connection.subscribe(topics);
+        } catch (Exception e) {
+            log.error("fuse source mqtt client subscribe fail ", e);
+        }
+        return Optional.unsupported();
+    }
+
+    @Override
+    public Optional<MqttPublishMessage> receive(long time, TimeUnit unit) {
+        try {
+            Message msg = connection.receive(time, unit);
+            if (autoAck) {
+                msg.ack();
+            }
+            byte[] payload = msg.getPayload();
+            MqttPublishMessage publishMessage = MqttMessageBuilders.publish()
+                    .qos(MqttQoS.FAILURE)
+                    .payload(Unpooled.buffer().writeBytes(payload))
+                    .topicName(msg.getTopic())
+                    .build();
+            return Optional.of(publishMessage);
+        } catch (Exception e) {
+            log.error("fuse source mqtt client receive fail ", e);
+            return Optional.unsupported();
+        }
+    }
+
+    @Override
+    public Optional<MqttUnsubAckMessage> unsubscribe(UnSubscribeOptions unSubscribeOptions) {
+        try {
+            String[] topic = {unSubscribeOptions.getTopicFilter()};
+            connection.unsubscribe(topic);
+        } catch (Exception e) {
+            log.error("fuse source mqtt client unsubscribe fail ", e);
+        }
+        return Optional.unsupported();
+    }
+
+    @Override
+    public Optional<MqttPubAckMessage> publish(PublishOptions publishOptions) {
+        try {
+            connection.publish(publishOptions.getTopic(), publishOptions.getPayload(),
+                    QoS.valueOf(publishOptions.getQos().name()), publishOptions.isRetain());
+        } catch (Exception e) {
+            log.error("fuse source mqtt client publish fail ", e);
+        }
+        return Optional.unsupported();
+    }
+
+    @Override
+    public Optional<MqttMessage> disconnect() {
+        try {
+            connection.disconnect();
+        } catch (Exception e) {
+            log.error("fuse source mqtt client disconnect fail ", e);
+        }
+        return Optional.unsupported();
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/client/v3x/HiveMqV3TestClient.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/client/v3x/HiveMqV3TestClient.java
@@ -1,0 +1,156 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.client.v3x;
+
+import com.hivemq.client.mqtt.MqttGlobalPublishFilter;
+import com.hivemq.client.mqtt.datatypes.MqttQos;
+import com.hivemq.client.mqtt.mqtt3.Mqtt3BlockingClient;
+import com.hivemq.client.mqtt.mqtt3.Mqtt3Client;
+import com.hivemq.client.mqtt.mqtt3.message.connect.Mqtt3ConnectBuilder;
+import com.hivemq.client.mqtt.mqtt3.message.connect.connack.Mqtt3ConnAck;
+import com.hivemq.client.mqtt.mqtt3.message.publish.Mqtt3Publish;
+import com.hivemq.client.mqtt.mqtt3.message.subscribe.suback.Mqtt3SubAck;
+import com.hivemq.client.mqtt.mqtt3.message.subscribe.suback.Mqtt3SubAckReturnCode;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.mqtt.MqttConnAckMessage;
+import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
+import io.netty.handler.codec.mqtt.MqttFixedHeader;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttMessageBuilders;
+import io.netty.handler.codec.mqtt.MqttMessageIdAndPropertiesVariableHeader;
+import io.netty.handler.codec.mqtt.MqttMessageType;
+import io.netty.handler.codec.mqtt.MqttProperties;
+import io.netty.handler.codec.mqtt.MqttPubAckMessage;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttSubAckMessage;
+import io.netty.handler.codec.mqtt.MqttSubAckPayload;
+import io.netty.handler.codec.mqtt.MqttUnsubAckMessage;
+import io.streamnative.pulsar.handlers.mqtt.client.MqttTestClient;
+import io.streamnative.pulsar.handlers.mqtt.client.options.ClientOptions;
+import io.streamnative.pulsar.handlers.mqtt.client.options.ConnectOptions;
+import io.streamnative.pulsar.handlers.mqtt.client.options.Optional;
+import io.streamnative.pulsar.handlers.mqtt.client.options.PublishOptions;
+import io.streamnative.pulsar.handlers.mqtt.client.options.SubscribeOptions;
+import io.streamnative.pulsar.handlers.mqtt.client.options.UnSubscribeOptions;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+
+
+@Slf4j
+public class HiveMqV3TestClient implements MqttTestClient {
+    private final Mqtt3BlockingClient client;
+    private boolean autoAck;
+
+    public HiveMqV3TestClient(ClientOptions clientOptions) {
+        this.client = Mqtt3Client.builder()
+                .serverHost(clientOptions.getServerUrl())
+                .serverPort(clientOptions.getPort())
+                .buildBlocking();
+    }
+
+    @Override
+    public Optional<MqttConnAckMessage> connect() {
+        return connect(ConnectOptions.builder().build());
+    }
+
+    @Override
+    public Optional<MqttConnAckMessage> connect(ConnectOptions connectOptions) {
+        Mqtt3ConnectBuilder.Send<Mqtt3ConnAck> mqtt3ConnBuilder = client.connectWith();
+        if (connectOptions.getBasicAuth() != null){
+            mqtt3ConnBuilder
+                    .simpleAuth()
+                    .username(connectOptions.getBasicAuth().getUsername())
+                    .password(connectOptions.getBasicAuth().getPassword().getBytes(StandardCharsets.UTF_8))
+                    .applySimpleAuth();
+        }
+        Mqtt3ConnAck connAck = mqtt3ConnBuilder
+                .cleanSession(connectOptions.isCleanSession())
+                .send();
+        MqttConnAckMessage connAckMessage = MqttMessageBuilders.connAck()
+                .returnCode(MqttConnectReturnCode.valueOf((byte) connAck.getReturnCode().getCode()))
+                .sessionPresent(connAck.isSessionPresent())
+                .build();
+        return Optional.of(connAckMessage);
+    }
+
+    @Override
+    public Optional<MqttSubAckMessage> subscribe(SubscribeOptions subscribeOptions) {
+        this.autoAck = subscribeOptions.isAutoAck();
+        Mqtt3SubAck ack = client.subscribeWith()
+                .topicFilter(subscribeOptions.getTopicFilters())
+                .qos(MqttQos.valueOf(subscribeOptions.getQos().name()))
+                .send();
+        MqttFixedHeader mqttFixedHeader =
+                new MqttFixedHeader(MqttMessageType.SUBACK, false, MqttQoS.AT_MOST_ONCE, false, 0);
+        MqttMessageIdAndPropertiesVariableHeader mqttSubAckVariableHeader =
+                new MqttMessageIdAndPropertiesVariableHeader(1, MqttProperties.NO_PROPERTIES);
+        int[] codes = ack.getReturnCodes().stream()
+                .mapToInt(Mqtt3SubAckReturnCode::getCode)
+                .toArray();
+        MqttSubAckPayload subAckPayload = new MqttSubAckPayload(codes);
+        return Optional.of(new MqttSubAckMessage(mqttFixedHeader, mqttSubAckVariableHeader, subAckPayload));
+    }
+
+    @Override
+    public Optional<MqttPublishMessage> receive(long time, TimeUnit unit) {
+        try (Mqtt3BlockingClient.Mqtt3Publishes publishes = client.publishes(MqttGlobalPublishFilter.ALL, !autoAck)) {
+            java.util.Optional<Mqtt3Publish> publish = publishes.receive(time, unit);
+            if (!publish.isPresent()) {
+                return Optional.fail();
+            }
+            Mqtt3Publish mqtt3Publish = publish.get();
+            byte[] payloadAsBytes = mqtt3Publish.getPayloadAsBytes();
+            if (payloadAsBytes == null) {
+                return Optional.fail();
+            }
+
+            MqttPublishMessage publishMessage = MqttMessageBuilders
+                    .publish()
+                    .topicName(mqtt3Publish.getTopic().toString())
+                    .messageId(0)
+                    .qos(MqttQoS.valueOf(mqtt3Publish.getQos().getCode()))
+                    .payload(Unpooled.buffer().writeBytes(payloadAsBytes))
+                    .build();
+            return Optional.of(publishMessage);
+        } catch (InterruptedException e) {
+            return Optional.fail();
+        }
+    }
+
+    @Override
+    public Optional<MqttUnsubAckMessage> unsubscribe(UnSubscribeOptions unSubscribeOptions) {
+        client.unsubscribeWith()
+                .topicFilter(unSubscribeOptions.getTopicFilter())
+                .send();
+        return Optional.unsupported();
+    }
+
+    @Override
+    public Optional<MqttPubAckMessage> publish(PublishOptions publishOptions) {
+        client.publishWith()
+                .topic(publishOptions.getTopic())
+                .payload(publishOptions.getPayload())
+                .qos(MqttQos.valueOf(publishOptions.getQos().name()))
+                .send();
+        return Optional.unsupported();
+    }
+
+    @Override
+    public Optional<MqttMessage> disconnect() {
+        client.disconnect();
+        return Optional.unsupported();
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/BasicIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/BasicIntegrationTest.java
@@ -13,11 +13,6 @@
  */
 package io.streamnative.pulsar.handlers.mqtt.mqtt3;
 
-import com.hivemq.client.mqtt.MqttGlobalPublishFilter;
-import com.hivemq.client.mqtt.datatypes.MqttQos;
-import com.hivemq.client.mqtt.mqtt3.Mqtt3BlockingClient;
-import com.hivemq.client.mqtt.mqtt3.Mqtt3Client;
-import com.hivemq.client.mqtt.mqtt3.message.publish.Mqtt3Publish;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.handler.codec.mqtt.MqttQoS;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/BasicIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/BasicIntegrationTest.java
@@ -67,34 +67,4 @@ public class BasicIntegrationTest extends MQTTTestBase {
         client.disconnect();
     }
 
-    @Test(dataProvider = "mqttTopicNameAndFilter", timeOut = TIMEOUT)
-    public void testTopicNameFilter(String topic, String filter) throws Exception {
-        Mqtt3BlockingClient client = createMqtt3Client();
-        client.connect();
-        byte[] msg = "payload".getBytes();
-        client.publishWith()
-                .topic(topic)
-                .qos(MqttQos.AT_LEAST_ONCE)
-                .payload(msg)
-                .send();
-        client.subscribeWith().topicFilter(filter).qos(MqttQos.AT_LEAST_ONCE).send();
-        client.publishWith()
-                .topic(topic)
-                .qos(MqttQos.AT_LEAST_ONCE)
-                .payload(msg)
-                .send();
-        try (Mqtt3BlockingClient.Mqtt3Publishes publishes = client.publishes(MqttGlobalPublishFilter.ALL)) {
-            Mqtt3Publish publish = publishes.receive();
-            Assert.assertEquals(publish.getPayloadAsBytes(), msg);
-        }
-        client.unsubscribeWith().topicFilter(filter).send();
-        client.disconnect();
-    }
-
-    private Mqtt3BlockingClient createMqtt3Client() {
-        return Mqtt3Client.builder()
-                .serverHost("127.0.0.1")
-                .serverPort(getMqttBrokerPortList().get(0))
-                .buildBlocking();
-    }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/BasicIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/BasicIntegrationTest.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.mqtt3;
+
+import com.hivemq.client.mqtt.MqttGlobalPublishFilter;
+import com.hivemq.client.mqtt.datatypes.MqttQos;
+import com.hivemq.client.mqtt.mqtt3.Mqtt3BlockingClient;
+import com.hivemq.client.mqtt.mqtt3.Mqtt3Client;
+import com.hivemq.client.mqtt.mqtt3.message.publish.Mqtt3Publish;
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.streamnative.pulsar.handlers.mqtt.base.MQTTTestBase;
+import io.streamnative.pulsar.handlers.mqtt.base.provider.ClientToTopic;
+import io.streamnative.pulsar.handlers.mqtt.client.MqttTestClient;
+import io.streamnative.pulsar.handlers.mqtt.client.options.Optional;
+import io.streamnative.pulsar.handlers.mqtt.client.options.PublishOptions;
+import io.streamnative.pulsar.handlers.mqtt.client.options.SubscribeOptions;
+import io.streamnative.pulsar.handlers.mqtt.client.options.UnSubscribeOptions;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+@Slf4j
+public class BasicIntegrationTest extends MQTTTestBase {
+
+    @Test(dataProvider = "mqttClientWithPersistentTopicNames", timeOut = TIMEOUT)
+    public void testBasicPublishAndConsumeWithMQTT(ClientToTopic clientToTopic) throws Exception {
+        MqttTestClient client = clientToTopic.getClient();
+        String topic = clientToTopic.getTopic();
+        client.connect();
+        client.subscribe(SubscribeOptions.builder()
+                .topicFilters(topic)
+                .qos(MqttQoS.AT_LEAST_ONCE)
+                .build());
+        byte[] msg = "payload".getBytes();
+        client.publish(PublishOptions.builder()
+                .topic(topic)
+                .payload(msg)
+                .qos(MqttQoS.AT_LEAST_ONCE)
+                .build());
+        Optional<MqttPublishMessage> receive = client.receive(3, TimeUnit.SECONDS);
+        if (!receive.isSuccess()) {
+            Assert.fail("fail");
+        }
+        MqttPublishMessage publishMessage = receive.getBody();
+        byte[] bytes = new byte[publishMessage.payload().readableBytes()];
+        ByteBuf payload = publishMessage.payload();
+        payload.readBytes(bytes);
+        Assert.assertEquals(publishMessage.variableHeader().topicName(), topic);
+        Assert.assertEquals(bytes, msg);
+        client.unsubscribe(UnSubscribeOptions.builder()
+                .topicFilter(topic).build());
+        client.disconnect();
+    }
+
+    @Test(dataProvider = "mqttTopicNameAndFilter", timeOut = TIMEOUT)
+    public void testTopicNameFilter(String topic, String filter) throws Exception {
+        Mqtt3BlockingClient client = createMqtt3Client();
+        client.connect();
+        byte[] msg = "payload".getBytes();
+        client.publishWith()
+                .topic(topic)
+                .qos(MqttQos.AT_LEAST_ONCE)
+                .payload(msg)
+                .send();
+        client.subscribeWith().topicFilter(filter).qos(MqttQos.AT_LEAST_ONCE).send();
+        client.publishWith()
+                .topic(topic)
+                .qos(MqttQos.AT_LEAST_ONCE)
+                .payload(msg)
+                .send();
+        try (Mqtt3BlockingClient.Mqtt3Publishes publishes = client.publishes(MqttGlobalPublishFilter.ALL)) {
+            Mqtt3Publish publish = publishes.receive();
+            Assert.assertEquals(publish.getPayloadAsBytes(), msg);
+        }
+        client.unsubscribeWith().topicFilter(filter).send();
+        client.disconnect();
+    }
+
+    private Mqtt3BlockingClient createMqtt3Client() {
+        return Mqtt3Client.builder()
+                .serverHost("127.0.0.1")
+                .serverPort(getMqttBrokerPortList().get(0))
+                .buildBlocking();
+    }
+}


### PR DESCRIPTION
Master issue #368 

## Motivation

Now, we write test by ``FuseSource`` and ``HiveMQ`` client. in the future, We may need to add more client tests.

that will  cause a lot of repetitive logic code. like ``HiveMQIntegrationTest`` and ``SimpleIntegrationTest``.

Therefore , i want to  abstract ``MqttTestClient`` to use ``TestNG``  data provider to reduce the repetitive logic code. 

## Modification 

- add new test ``BasicIntegrationTest#testBasicPublishAndConsumeWithMQTT`` to show my idea.





