### PR TITLE
[ Fixed 352 ] Fixed user can not get mop metrics by http method.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTServiceServlet.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTServiceServlet.java
@@ -62,7 +62,7 @@ public class MQTTServiceServlet extends HttpServlet {
      * Lazy init reference updater.
      */
     private void checkAndInitReflectionReference() {
-        if (JSON_STATS_REFERENCE_UPDATER.get(this) == null) {
+        if (metricsCollectorGetJsonStatsReference == null) {
             try {
                 ProtocolHandler protocolHandler = pulsar.getProtocolHandlers().protocol("mqtt");
                 Method getMqttService = ReflectionUtils.
@@ -73,8 +73,8 @@ public class MQTTServiceServlet extends HttpServlet {
                 Object mqttMetricCollector = getMetricsCollector.invoke(mqttService);
                 Method getJsonStats = ReflectionUtils.
                         reflectAccessibleMethod(mqttMetricCollector.getClass(), "getJsonStats");
-                JSON_STATS_REFERENCE_UPDATER.
-                        set(this, ReflectionUtils.createReference(getJsonStats, mqttMetricCollector));
+                JSON_STATS_REFERENCE_UPDATER
+                        .compareAndSet(this, null, ReflectionUtils.createReference(getJsonStats, mqttMetricCollector));
             } catch (IllegalAccessException | InvocationTargetException e) {
                 log.error("Reflect method got error", e);
                 throw new IllegalStateException(e);

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTServiceServlet.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTServiceServlet.java
@@ -36,7 +36,7 @@ public class MQTTServiceServlet extends HttpServlet {
 
     // Define transient by spotbugs
     private final transient PulsarService pulsar;
-    private volatile ReflectionUtils.Reference metricsCollectorGetJsonStatsReference;
+    private transient volatile ReflectionUtils.Reference metricsCollectorGetJsonStatsReference;
     private static final AtomicReferenceFieldUpdater<MQTTServiceServlet, ReflectionUtils.Reference>
             JSON_STATS_REFERENCE_UPDATER = newUpdater(MQTTServiceServlet.class, ReflectionUtils.Reference.class,
             "metricsCollectorGetJsonStatsReference");

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/ReflectionUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/ReflectionUtils.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.utils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ReflectionUtils {
+
+    public static Method reflectAccessibleMethod(Class<?> objType, String methodName) {
+        try {
+            Method method = objType.getMethod(methodName);
+            method.setAccessible(true);
+            return method;
+        } catch (NoSuchMethodException ex) {
+            log.error("Reflect {} method {} got error,", objType, methodName, ex);
+            throw new IllegalArgumentException(ex);
+        }
+    }
+
+    public static Reference createReference(Method method, Object obj) {
+        return new Reference(method, obj);
+    }
+
+    public static class Reference {
+        private final Method method;
+        private final Object obj;
+
+        public Reference(Method method, Object obj) {
+            this.method = method;
+            this.obj = obj;
+        }
+
+        public Object invoke() {
+            try {
+                return method.invoke(obj);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                log.error("Reflect {} method {} got error,", obj.getClass(), method.getName(), e);
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

original issue #352 

This issue cause by **Apache pulsar** use two different ``NarClassLoader`` to load ''addtionalServelet'' and ''protocolHandler''.

I tried to change the class loader, but to no avail. so, I think we can't cast class across different ``ClassLoader``.

The relative issue on StackOverflow : 

https://stackoverflow.com/questions/2591779/cast-across-classloader
https://stackoverflow.com/questions/7130667/two-classloaders-one-classloader-needs-to-cast-down-an-object-but-other-classlo#comment8548540_7130686

## Modification

- Use reflection to across ``ClassLoader`` limit.
- Cache ``Method`` to improve performance.

## Other 

I think i should to submit issue to ``Apache pulsar``, i don't know if it's a design flaws.
 