### PR TITLE
Support set message length.

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,12 @@ MoP will uniformly output its own metrics to Prometheus.
 | mop_received_count| Counter | The total received msg count |
 | mop_received_bytes| Counter | The total received msg in bytes |
 
-MoP also exposes the http interface through `/mop-stats`, and users can obtain mop information in json format through that path.
+MoP can also expose metrics through the http interface. Add below configs first and then restart pulsar broker.
+```
+additionalServlets=mqtt-servlet
+additionalServletDirectory=[protocolHandlerDir]
+```
+Then you can obtain mop information in json format through `/mop-stats`:
 ```
 curl http://pulsar-broker-webservice-address:port/mop-stats/
 {"cluster":"test","subscriptions":{"subs":["/a/b/c"],"count":1},"clients":{"total":1,"maximum":1,"active":0,"active_clients":[]},"namespace":"default","messages":{"received_bytes":57351,"received_count":10,"send_count":20,"send_bytes":60235},"version":"2.9.0-SNAPSHOT","tenant":"public","uptime":"46 seconds"}

--- a/docs/mop-configuration.md
+++ b/docs/mop-configuration.md
@@ -13,6 +13,7 @@
 |defaultTenant | public | Default Pulsar tenant that the MQTT server used |
 |defaultNamespace | default | Default Pulsar namespace that the MQTT server used | 
 |defaultTopicDomain | persistent | Default Pulsar topic domain that the MQTT server used |
+|mqttMessageMaxLength | 8092 | Max length for per message. |
 
 
 ## MoP Proxy

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTChannelInitializer.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTChannelInitializer.java
@@ -104,7 +104,7 @@ public class MQTTChannelInitializer extends ChannelInitializer<SocketChannel> {
         } else if (this.enableTlsPsk) {
             ch.pipeline().addLast(TLS_HANDLER, new SslHandler(PSKUtils.createServerEngine(ch, pskConfiguration)));
         }
-        ch.pipeline().addLast("decoder", new MqttDecoder());
+        ch.pipeline().addLast("decoder", new MqttDecoder(mqttConfig.getMqttMessageMaxLength()));
         ch.pipeline().addLast("encoder", MqttEncoder.INSTANCE);
         ch.pipeline().addLast("handler", new MQTTInboundHandler(mqttService));
     }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTCommonConfiguration.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTCommonConfiguration.java
@@ -298,4 +298,10 @@ public class MQTTCommonConfiguration extends ServiceConfiguration {
             doc = "TLS psk identity with plain text"
     )
     private String tlsPskIdentity = null;
+
+    @FieldContext(
+            category = CATEGORY_MQTT,
+            doc = "Max length for per message."
+    )
+    private int mqttMessageMaxLength = 8192;
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTCommonConfiguration.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTCommonConfiguration.java
@@ -303,5 +303,5 @@ public class MQTTCommonConfiguration extends ServiceConfiguration {
             category = CATEGORY_MQTT,
             doc = "Max length for per message."
     )
-    private int mqttMessageMaxLength = 8192;
+    private int mqttMessageMaxLength = 8092;
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyChannelInitializer.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyChannelInitializer.java
@@ -111,7 +111,7 @@ public class MQTTProxyChannelInitializer extends ChannelInitializer<SocketChanne
         } else if (this.enableTlsPsk) {
             ch.pipeline().addLast(TLS_HANDLER, new SslHandler(PSKUtils.createServerEngine(ch, pskConfiguration)));
         }
-        ch.pipeline().addLast("decoder", new MqttDecoder());
+        ch.pipeline().addLast("decoder", new MqttDecoder(proxyConfig.getMqttMessageMaxLength()));
         ch.pipeline().addLast("encoder", MqttEncoder.INSTANCE);
         ch.pipeline().addLast("handler", new MQTTProxyHandler(proxyService));
     }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyExchanger.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyExchanger.java
@@ -45,7 +45,7 @@ public class MQTTProxyExchanger {
     private CompletableFuture<Void> brokerConnected = new CompletableFuture<>();
     private CompletableFuture<Void> brokerConnectedAck = new CompletableFuture<>();
 
-    MQTTProxyExchanger(MQTTProxyProtocolMethodProcessor processor, InetSocketAddress mqttBroker) {
+    MQTTProxyExchanger(MQTTProxyProtocolMethodProcessor processor, InetSocketAddress mqttBroker, int maxMessageLength) {
         this.processor = processor;
         Bootstrap bootstrap = new Bootstrap();
         bootstrap.group(processor.getChannel().eventLoop())
@@ -53,7 +53,7 @@ public class MQTTProxyExchanger {
                 .handler(new ChannelInitializer<SocketChannel>() {
                     @Override
                     protected void initChannel(SocketChannel ch) throws Exception {
-                        ch.pipeline().addLast("decoder", new MqttDecoder());
+                        ch.pipeline().addLast("decoder", new MqttDecoder(maxMessageLength));
                         ch.pipeline().addLast("encoder", MqttEncoder.INSTANCE);
                         ch.pipeline().addLast("handler", new ExchangerHandler());
                     }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -243,7 +243,7 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
             CompletableFuture<MQTTProxyExchanger> future = new CompletableFuture<>();
             try {
                 MQTTProxyExchanger result = brokerPool.computeIfAbsent(mqttBroker, addr ->
-                        new MQTTProxyExchanger(this, mqttBroker));
+                        new MQTTProxyExchanger(this, mqttBroker, proxyConfig.getMqttMessageMaxLength()));
                 result.connectedAck().thenAccept(__ -> future.complete(result));
             } catch (Exception ex) {
                 future.completeExceptionally(ex);


### PR DESCRIPTION
### Motivation
In netty decoder, default length is 8092.
```
public final class MqttDecoder extends ReplayingDecoder<MqttDecoder.DecoderState> {
    private MqttFixedHeader mqttFixedHeader;
    private Object variableHeader;
    private int bytesRemainingInVariablePart;
    private final int maxBytesInMessage;
    private final int maxClientIdLength;

    public MqttDecoder() {
        this(8092, 23);
    }

    public MqttDecoder(int maxBytesInMessage) {
        this(maxBytesInMessage, 23);
    }
```

In some case, mqtt message length is over limit, there is a error `java.lang.IllegalStateException: too large message: 16422 bytes.`

I think we should allow user to set the max message length.

### Modifications
Support set message length.

### Verifying this change


### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc`