### PR TITLE
Fix MoP http metrics class casting issue.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTServiceServlet.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTServiceServlet.java
@@ -13,23 +13,33 @@
  */
 package io.streamnative.pulsar.handlers.mqtt;
 
-import io.streamnative.pulsar.handlers.mqtt.support.MQTTMetricsCollector;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.protocol.ProtocolHandler;
 import org.eclipse.jetty.http.HttpStatus;
 /**
  * MQTT service servlet handler.
  */
+@Slf4j
 public class MQTTServiceServlet extends HttpServlet {
 
     private static final long serialVersionUID = 1L;
 
     // Define transient by spotbugs
     private final transient PulsarService pulsar;
+
+    private static volatile Pair<Object, Method> metricsCollectorRef;
+
+    private static final Object LOCK = new Object();
 
     public MQTTServiceServlet(PulsarService pulsar) {
         this.pulsar = pulsar;
@@ -40,12 +50,39 @@ public class MQTTServiceServlet extends HttpServlet {
             throws ServletException, IOException {
         response.setStatus(HttpStatus.OK_200);
         response.setContentType("text/plain");
-        response.getOutputStream().write(getMetricsCollector().getJsonStats());
+        response.getOutputStream().write(getJsonStats());
     }
 
-    private MQTTMetricsCollector getMetricsCollector() {
-        return ((MQTTProtocolHandler) pulsar.getProtocolHandlers().protocol("mqtt"))
-                .getMqttService()
-                .getMetricsCollector();
+    private byte[] getJsonStats() {
+        try {
+            Pair<Object, Method> metricsCollector = getMetricsCollector();
+            return (byte[]) metricsCollector.getRight().invoke(metricsCollector.getLeft());
+        } catch (Throwable ex) {
+            return ex.getMessage().getBytes(StandardCharsets.UTF_8);
+        }
+    }
+
+    private Pair<Object, Method> getMetricsCollector() throws IllegalAccessException, InvocationTargetException,
+            NoSuchMethodException {
+        if (metricsCollectorRef == null) {
+            synchronized (LOCK) {
+                if (metricsCollectorRef == null) {
+                    ProtocolHandler protocolHandler = pulsar.getProtocolHandlers().protocol("mqtt");
+                    Method mqttServiceMethod = getMethod(protocolHandler.getClass(), "getMqttService");
+                    Object mqttService = mqttServiceMethod.invoke(protocolHandler);
+                    Method metricsCollectorMethod = getMethod(mqttService.getClass(), "getMetricsCollector");
+                    Object metricsCollector = metricsCollectorMethod.invoke(mqttService);
+                    Method jsonStatsMethod = getMethod(metricsCollector.getClass(), "getJsonStats");
+                    metricsCollectorRef = Pair.of(metricsCollector, jsonStatsMethod);
+                }
+            }
+        }
+        return metricsCollectorRef;
+    }
+
+    private Method getMethod(Class<?> clazz, String methodName) throws NoSuchMethodException {
+        Method method = clazz.getMethod(methodName);
+        method.setAccessible(true);
+        return method;
     }
 }


### PR DESCRIPTION
Fix #352.

## Motivation
Pulsar will load servlet and protocol handler with different NarClassLoader, and cause the issue.
We should call `MetricsCollector` in protocol handler classloader directly, not casting.