### PR TITLE
Refactor mqtt inbound handler.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTCommonInboundHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTCommonInboundHandler.java
@@ -11,10 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamnative.pulsar.handlers.mqtt.proxy;
+package io.streamnative.pulsar.handlers.mqtt;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static io.streamnative.pulsar.handlers.mqtt.utils.MqttMessageUtils.checkState;
+import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
@@ -26,45 +25,31 @@ import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
 import io.netty.handler.codec.mqtt.MqttUnsubscribeMessage;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
-import io.streamnative.pulsar.handlers.mqtt.ProtocolMethodProcessor;
 import io.streamnative.pulsar.handlers.mqtt.utils.NettyUtils;
 import lombok.extern.slf4j.Slf4j;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.streamnative.pulsar.handlers.mqtt.utils.MqttMessageUtils.checkState;
 
 /**
- * Proxy handler.
+ * MQTT common in bound handler.
  */
+@Sharable
 @Slf4j
-public class MQTTProxyHandler extends ChannelInboundHandlerAdapter{
+public class MQTTCommonInboundHandler extends ChannelInboundHandlerAdapter {
 
-    private final MQTTProxyService proxyService;
-
-    private ProtocolMethodProcessor processor;
-
-    public MQTTProxyHandler(MQTTProxyService proxyService) {
-        this.proxyService = proxyService;
-    }
+    protected ProtocolMethodProcessor processor;
 
     @Override
-    public void channelActive(ChannelHandlerContext ctx) throws Exception {
-        super.channelActive(ctx);
-        this.processor = new MQTTProxyProtocolMethodProcessor(proxyService, ctx);
-    }
-
-    @Override
-    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        super.channelInactive(ctx);
-        this.processor.processConnectionLost();
-    }
-
-    @Override
-    public void channelRead(ChannelHandlerContext ctx, Object message) throws Exception {
+    public void channelRead(ChannelHandlerContext ctx, Object message) {
         checkArgument(message instanceof MqttMessage);
+        checkNotNull(processor);
         MqttMessage msg = (MqttMessage) message;
         try {
             checkState(msg);
             MqttMessageType messageType = msg.fixedHeader().messageType();
             if (log.isDebugEnabled()) {
-                log.debug("Processing MQTT message, type={}", messageType);
+                log.debug("Processing MQTT Inbound handler message, type={}", messageType);
             }
             switch (messageType) {
                 case CONNECT:
@@ -107,16 +92,26 @@ public class MQTTProxyHandler extends ChannelInboundHandlerAdapter{
                     break;
             }
         } catch (Throwable ex) {
-            log.error("Exception was caught while processing MQTT message", ex);
+            log.error("Exception was caught while processing MQTT message, ", ex);
             ctx.close();
         }
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        super.channelActive(ctx);
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        processor.processConnectionLost();
     }
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         log.warn(
                 "An unexpected exception was caught while processing MQTT message. "
-                        + "Closing Netty channel {}. connection = {}",
+                + "Closing Netty channel {}. connection = {}",
                 ctx.channel(),
                 NettyUtils.getConnection(ctx.channel()),
                 cause);
@@ -128,12 +123,19 @@ public class MQTTProxyHandler extends ChannelInboundHandlerAdapter{
         if (event instanceof IdleStateEvent) {
             IdleStateEvent e = (IdleStateEvent) event;
             if (e.state() == IdleState.ALL_IDLE) {
-                log.warn("proxy close connection : {} due to reached all idle time",
-                        NettyUtils.getConnection(ctx.channel()));
+                log.warn("close connection : {} due to reached all idle time", NettyUtils.getConnection(ctx.channel()));
                 ctx.close();
             }
         } else {
             super.userEventTriggered(ctx, event);
         }
+    }
+
+    @Override
+    public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+        if (ctx.channel().isWritable()) {
+            ctx.channel().flush();
+        }
+        ctx.fireChannelWritabilityChanged();
     }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTCommonInboundHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTCommonInboundHandler.java
@@ -13,6 +13,9 @@
  */
 package io.streamnative.pulsar.handlers.mqtt;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.streamnative.pulsar.handlers.mqtt.utils.MqttMessageUtils.checkState;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -27,9 +30,6 @@ import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.streamnative.pulsar.handlers.mqtt.utils.NettyUtils;
 import lombok.extern.slf4j.Slf4j;
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static io.streamnative.pulsar.handlers.mqtt.utils.MqttMessageUtils.checkState;
 
 /**
  * MQTT common in bound handler.

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyChannelInitializer.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyChannelInitializer.java
@@ -113,7 +113,7 @@ public class MQTTProxyChannelInitializer extends ChannelInitializer<SocketChanne
         }
         ch.pipeline().addLast("decoder", new MqttDecoder(proxyConfig.getMqttMessageMaxLength()));
         ch.pipeline().addLast("encoder", MqttEncoder.INSTANCE);
-        ch.pipeline().addLast("handler", new MQTTProxyHandler(proxyService));
+        ch.pipeline().addLast("handler", new MQTTProxyInboundHandler(proxyService));
     }
 
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyInboundHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyInboundHandler.java
@@ -11,36 +11,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamnative.pulsar.handlers.mqtt;
+package io.streamnative.pulsar.handlers.mqtt.proxy;
 
-import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
-import io.streamnative.pulsar.handlers.mqtt.support.DefaultProtocolMethodProcessorImpl;
-import lombok.Getter;
+import io.streamnative.pulsar.handlers.mqtt.MQTTCommonInboundHandler;
 import lombok.extern.slf4j.Slf4j;
+
 /**
- * MQTT in bound handler.
+ * Proxy handler.
  */
-@Sharable
 @Slf4j
-public class MQTTInboundHandler extends MQTTCommonInboundHandler {
+public class MQTTProxyInboundHandler extends MQTTCommonInboundHandler {
 
-    @Getter
-    private final MQTTService mqttService;
+    private final MQTTProxyService proxyService;
 
-    public MQTTInboundHandler(MQTTService mqttService) {
-        this.mqttService = mqttService;
+    public MQTTProxyInboundHandler(MQTTProxyService proxyService) {
+        this.proxyService = proxyService;
     }
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
         super.channelActive(ctx);
-        processor = new DefaultProtocolMethodProcessorImpl(mqttService, ctx);
+        this.processor = new MQTTProxyProtocolMethodProcessor(proxyService, ctx);
     }
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        processor.processConnectionLost();
+        super.channelInactive(ctx);
+        this.processor.processConnectionLost();
     }
-
 }


### PR DESCRIPTION
## Motivation
As there are some common methods in MQTTProxyHandler and MQTTInboundHandler,  it's better to share them.
So add MQTTCommonInboundHandler

## Modification
- Add MQTTCommonInboundHandler to abstract the common methods.
- Rename `MQTTProxyHandler` to `MQTTProxyInboundHandler`