### PR TITLE
Use ``msg.release()`` to instead of  `` ReferenceCountUtil.safeRelease(msg)``

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -110,7 +110,7 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
         lookupResult
                 .thenCompose(brokerAddress -> writeToBroker(brokerAddress, pulsarTopicName, msg))
                 .exceptionally(ex -> {
-                    ReferenceCountUtil.safeRelease(msg);
+                    msg.release();
                     log.error("[Proxy Publish] Failed to publish for topic : {}, CId : {}",
                             msg.variableHeader().topicName(), connection.getClientId(), ex);
                     MopExceptionHelper.handle(MqttMessageType.PUBLISH, packetId, channel, ex);

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -24,7 +24,6 @@ import io.netty.handler.codec.mqtt.MqttMessageType;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
 import io.netty.handler.codec.mqtt.MqttUnsubscribeMessage;
-import io.netty.util.ReferenceCountUtil;
 import io.streamnative.pulsar.handlers.mqtt.Connection;
 import io.streamnative.pulsar.handlers.mqtt.MQTTConnectionManager;
 import io.streamnative.pulsar.handlers.mqtt.exception.handler.MopExceptionHelper;

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
@@ -29,7 +29,6 @@ import io.netty.handler.codec.mqtt.MqttReasonCodeAndPropertiesVariableHeader;
 import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
 import io.netty.handler.codec.mqtt.MqttTopicSubscription;
 import io.netty.handler.codec.mqtt.MqttUnsubscribeMessage;
-import io.netty.util.ReferenceCountUtil;
 import io.streamnative.pulsar.handlers.mqtt.Connection;
 import io.streamnative.pulsar.handlers.mqtt.MQTTConnectionManager;
 import io.streamnative.pulsar.handlers.mqtt.MQTTServerConfiguration;

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
@@ -165,10 +165,10 @@ public class DefaultProtocolMethodProcessorImpl extends AbstractCommonProtocolMe
                             connection.getUserRole(), new AuthenticationDataCommand(connection.getUserRole()))
                     .thenCompose(authorized -> authorized ? doPublish(msg) : doUnauthorized(msg));
         }
-        result.thenAccept(__ -> ReferenceCountUtil.safeRelease(msg))
+        result.thenAccept(__ -> msg.release())
               .exceptionally(ex -> {
                     log.error("[{}] Write {} to Pulsar topic failed.", msg.variableHeader().topicName(), msg, ex);
-                    ReferenceCountUtil.safeRelease(msg);
+                    msg.release();
                     return null;
                 });
     }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MessagePublishContext.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MessagePublishContext.java
@@ -17,7 +17,6 @@ import static io.streamnative.pulsar.handlers.mqtt.utils.PulsarMessageConverter.
 import io.netty.buffer.ByteBuf;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
-import io.netty.util.ReferenceCountUtil;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MessagePublishContext.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MessagePublishContext.java
@@ -93,8 +93,7 @@ public final class MessagePublishContext implements PublishContext {
         ByteBuf headerAndPayload = messageToByteBuf(message);
         topic.publishMessage(headerAndPayload,
                 MessagePublishContext.get(future, topic, System.nanoTime()));
-
-        ReferenceCountUtil.safeRelease(headerAndPayload);
+        headerAndPayload.release();
         return future;
     }
 }


### PR DESCRIPTION
## Motivation

`` ReferenceCountUtil.safeRelease(msg)`` has many judgement.
Because of we can know who is ``ReferenceCounted``, Then i think we do not need to do redundant judgement.

```java
   public static void safeRelease(Object msg) {
        try {
            release(msg);
        } catch (Throwable var2) {
            logger.warn("Failed to release a message: {}", msg, var2);
        }

    }
```

```java
 public static boolean release(Object msg) {
        return msg instanceof ReferenceCounted ? ((ReferenceCounted)msg).release() : false;
    }
```

## Modification

- Use ``msg.release()`` to instead of  `` ReferenceCountUtil.safeRelease(msg)``