### PR TITLE
Fix subscribe count exists dirty data issue

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyExchanger.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyExchanger.java
@@ -99,8 +99,7 @@ public class MQTTProxyExchanger {
                         break;
                     case SUBACK:
                         MqttSubAckMessage subAckMessage = (MqttSubAckMessage) message;
-                        if (processor.decreaseSubscribeTopicsCount(
-                                subAckMessage.variableHeader().messageId()) == 0) {
+                        if (processor.checkIfSendSubAck(subAckMessage.variableHeader().messageId())) {
                             processor.getChannel().writeAndFlush(message);
                         }
                         break;

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -221,8 +221,12 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
     private CompletableFuture<Void> writeToBroker(MQTTProxyExchanger exchanger, MqttMessage msg) {
         CompletableFuture<Void> result = new CompletableFuture<>();
         if (exchanger.isWritable()) {
-            exchanger.writeAndFlush(msg).addListener(__ -> {
-                result.complete(null);
+            exchanger.writeAndFlush(msg).addListener(future -> {
+                if (future.isSuccess()) {
+                    result.complete(null);
+                } else {
+                    result.completeExceptionally(future.cause());
+                }
             });
         } else {
             log.error("The broker channel({}) is not writable!", exchanger.getMqttBroker());

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -183,6 +183,7 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
                 .exceptionally(ex -> {
                     log.error("[Proxy Subscribe] Failed to process subscribe for {}", clientId, ex);
                     int messageId = msg.variableHeader().messageId();
+                    topicCountForSequenceId.remove(messageId);
                     MqttMessage subAckMessage = MqttUtils.isMqtt5(protocolVersion)
                             ? MqttSubAckMessageHelper.createMqtt5(
                             messageId, Mqtt5SubReasonCode.UNSPECIFIED_ERROR, ex.getCause().getMessage()) :
@@ -251,21 +252,41 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
         return this.channel;
     }
 
-    public boolean increaseSubscribeTopicsCount(int seq, int count) {
-        return topicCountForSequenceId.putIfAbsent(seq, new AtomicInteger(count)) == null;
+    /**
+     *  MQTT support subscribe many topics in one subscribe request.
+     *  We need to record it's subscribe count.
+     * @param seq
+     * @param count
+     */
+    private void increaseSubscribeTopicsCount(int seq, int count) {
+        AtomicInteger subscribeCount = topicCountForSequenceId.putIfAbsent(seq, new AtomicInteger(count));
+        if (subscribeCount != null) {
+            subscribeCount.addAndGet(count);
+        }
     }
 
-    public int decreaseSubscribeTopicsCount(int seq) {
-        if (topicCountForSequenceId.get(seq) == null) {
+    private int decreaseSubscribeTopicsCount(int seq) {
+        AtomicInteger subscribeCount = topicCountForSequenceId.get(seq);
+        if (subscribeCount == null) {
             log.warn("Unexpected subscribe behavior for the proxy, respond seq {} "
                     + "but but the seq does not tracked by the proxy. ", seq);
             return -1;
         } else {
-            int value = topicCountForSequenceId.get(seq).decrementAndGet();
+            int value = subscribeCount.decrementAndGet();
             if (value == 0) {
                 topicCountForSequenceId.remove(seq);
             }
             return value;
         }
+    }
+
+    /**
+     * If one sub-ack succeed, we need to decrease it's sub-count.
+     * As the sub-count return zero, it means the subscribe action succeed.
+     * @param seq
+     * @return
+     */
+    public boolean checkIfSendSubAck(int seq) {
+        return decreaseSubscribeTopicsCount(seq) == 0;
     }
 }


### PR DESCRIPTION
## Motivation
Fix #380 .

Before this pr, if subscribe occurs exception, there may exist dirty data in topicCountForSequenceId. But fortunately,  MQTTProxyProtocolMethodProcessor is connection-based. If subscribe occurs exception, the connection will close, and MQTTProxyProtocolMethodProcessor is destroyed. So dirty data may not expose or cause any problem.  But this implementation is not good and may cause ambiguity. 
So when subscribe occurs exception, remove the msg-id from the topicCountForSequenceId.


# Modification
- Add remove method to remove related msg-id from topicCountForSequenceId when exception.
- Rename topicCountForSequenceId to subscribeTopicsCount