### PR TITLE
[MIP-3] Add ``Client Restriction`` and ``Server Restriction`` to make the logic clear

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
@@ -129,9 +129,7 @@ public class Connection {
     }
 
     public CompletableFuture<Void> close(boolean force) {
-        if (log.isInfoEnabled()) {
-            log.info("Closing connection. clientId = {}.", clientId);
-        }
+        log.info("Closing connection. clientId = {}.", clientId);
         if (!force) {
             assignState(ESTABLISHED, DISCONNECTED);
         }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
@@ -23,8 +23,10 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttMessage;
 import io.netty.handler.timeout.IdleStateHandler;
+import io.streamnative.pulsar.handlers.mqtt.exception.restrictions.InvalidSessionExpireIntervalException;
 import io.streamnative.pulsar.handlers.mqtt.messages.ack.DisconnectAck;
-import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.SessionExpireInterval;
+import io.streamnative.pulsar.handlers.mqtt.restrictions.ClientRestrictions;
+import io.streamnative.pulsar.handlers.mqtt.restrictions.ServerRestrictions;
 import io.streamnative.pulsar.handlers.mqtt.support.handler.AckHandler;
 import io.streamnative.pulsar.handlers.mqtt.support.handler.AckHandlerFactory;
 import io.streamnative.pulsar.handlers.mqtt.utils.MqttUtils;
@@ -48,22 +50,11 @@ public class Connection {
     @Getter
     private final Channel channel;
     @Getter
-    private final boolean cleanSession;
-    @Getter
     private final int protocolVersion;
     @Getter
     private final WillMessage willMessage;
     @Getter
-    private volatile int sessionExpireInterval;
-    volatile ConnectionState connectionState = DISCONNECTED;
-    @Getter
-    private int clientReceiveMaximum; // mqtt 5.0 specification.
-    @Getter
-    private int serverReceivePubMaximum;
-    @Getter
-    private volatile int serverCurrentReceiveCounter = 0;
-    @Getter
-    private String userRole;
+    private final String userRole;
     @Getter
     private final MQTTConnectionManager manager;
     @Getter
@@ -73,13 +64,15 @@ public class Connection {
     @Getter
     private final AckHandler ackHandler;
     @Getter
-    private final int keepAliveTime;
+    private final ClientRestrictions clientRestrictions;
+    @Getter
+    private final ServerRestrictions serverRestrictions;
+    volatile ConnectionState connectionState = DISCONNECTED;
+    @Getter
+    private volatile int serverCurrentReceiveCounter = 0;
 
     private static final AtomicReferenceFieldUpdater<Connection, ConnectionState> channelState =
             newUpdater(Connection.class, ConnectionState.class, "connectionState");
-
-    private static final AtomicIntegerFieldUpdater<Connection> SESSION_EXPIRE_INTERVAL_UPDATER =
-            AtomicIntegerFieldUpdater.newUpdater(Connection.class, "sessionExpireInterval");
 
     private static final AtomicIntegerFieldUpdater<Connection> SERVER_CURRENT_RECEIVE_PUB_MAXIMUM_UPDATER =
             AtomicIntegerFieldUpdater.newUpdater(Connection.class, "serverCurrentReceiveCounter");
@@ -87,17 +80,14 @@ public class Connection {
     Connection(ConnectionBuilder builder) {
         this.clientId = builder.clientId;
         this.protocolVersion = builder.protocolVersion;
-        this.cleanSession = builder.cleanSession;
         this.willMessage = builder.willMessage;
-        this.sessionExpireInterval = builder.sessionExpireInterval;
-        this.clientReceiveMaximum = builder.clientReceiveMaximum;
-        this.serverReceivePubMaximum = builder.serverReceivePubMaximum;
+        this.clientRestrictions = builder.clientRestrictions;
+        this.serverRestrictions = builder.serverRestrictions;
         this.userRole = builder.userRole;
         this.channel = builder.channel;
         this.manager = builder.connectionManager;
         this.manager.addConnection(this);
         this.connectMessage = builder.connectMessage;
-        this.keepAliveTime = builder.keepAliveTime;
         this.ackHandler = AckHandlerFactory.of(protocolVersion).getAckHandler();
         this.channel.attr(ATTR_KEY_CONNECTION).set(this);
         this.topicSubscriptionManager = new TopicSubscriptionManager();
@@ -110,7 +100,7 @@ public class Connection {
             pipeline.remove("idleStateHandler");
         }
         pipeline.addFirst("idleStateHandler", new IdleStateHandler(0, 0,
-                Math.round(keepAliveTime * 1.5f)));
+                Math.round(clientRestrictions.getKeepAliveTime() * 1.5f)));
     }
 
     public ChannelFuture sendConnAck() {
@@ -150,24 +140,24 @@ public class Connection {
                 .success(true)
                 .build();
         ackHandler.sendDisconnectAck(this, disconnectAck);
-        if (cleanSession) {
+        if (clientRestrictions.isCleanSession()) {
             return topicSubscriptionManager.removeSubscriptions();
         }
         // when use mqtt5.0 we need to use session expire interval to remove session.
         // but mqtt protocol version lower than 5.0 we don't do that.
-        if (MqttUtils.isMqtt5(protocolVersion)
-                && SESSION_EXPIRE_INTERVAL_UPDATER.get(this)
-                != SessionExpireInterval.NEVER_EXPIRE.getSecondTime()) {
-            if (sessionExpireInterval == SessionExpireInterval.EXPIRE_IMMEDIATELY.getSecondTime()) {
+        if (MqttUtils.isMqtt5(protocolVersion) && !clientRestrictions.isSessionNeverExpire()) {
+            if (clientRestrictions.isSessionExpireImmediately()) {
                 return topicSubscriptionManager.removeSubscriptions();
+            } else {
+                manager.newSessionExpireInterval(__ -> topicSubscriptionManager.removeSubscriptions(),
+                        clientId, clientRestrictions.getSessionExpireInterval());
+                return CompletableFuture.completedFuture(null);
             }
-            manager.newSessionExpireInterval(__ -> topicSubscriptionManager.removeSubscriptions(),
-                    clientId, SESSION_EXPIRE_INTERVAL_UPDATER.get(this));
+        } else {
+            // remove subscription consumer if we don't need to clean session.
+            topicSubscriptionManager.removeSubscriptionConsumers();
             return CompletableFuture.completedFuture(null);
         }
-        // remove subscription consumer if we don't need to clean session.
-        topicSubscriptionManager.removeSubscriptionConsumers();
-        return CompletableFuture.completedFuture(null);
     }
 
     public boolean assignState(ConnectionState expected, ConnectionState newState) {
@@ -196,14 +186,14 @@ public class Connection {
         return channelState.get(connection);
     }
 
-    public void updateSessionExpireInterval(int newSessionInterval) {
-        SESSION_EXPIRE_INTERVAL_UPDATER.set(this, newSessionInterval);
+    public void updateSessionExpireInterval(int newSessionInterval) throws InvalidSessionExpireIntervalException {
+       clientRestrictions.updateExpireInterval(newSessionInterval);
     }
 
     @Override
     public String toString() {
         return "Connection{" + "clientId=" + clientId + ", channel=" + channel
-                + ", cleanSession=" + cleanSession + ", state="
+                + ", cleanSession=" + clientRestrictions.isCleanSession() + ", state="
                 + channelState.get(this) + '}';
     }
 
@@ -222,18 +212,6 @@ public class Connection {
     @Override
     public int hashCode() {
         return Objects.hash(clientId, channel);
-    }
-
-    /**
-     * Check the session expire interval is valid.
-     *
-     * @param sessionExpireInterval session expire interval second time
-     * @return whether param is valid.
-     */
-    public boolean checkIsLegalExpireInterval(Integer sessionExpireInterval) {
-        int sei = SESSION_EXPIRE_INTERVAL_UPDATER.get(this);
-        int zeroSecond = SessionExpireInterval.EXPIRE_IMMEDIATELY.getSecondTime();
-        return sei > zeroSecond && sessionExpireInterval >= zeroSecond;
     }
 
     public void incrementServerReceivePubMessage() {
@@ -265,15 +243,12 @@ public class Connection {
         private int protocolVersion;
         private String clientId;
         private String userRole;
-        private boolean cleanSession;
         private WillMessage willMessage;
-        private int clientReceiveMaximum;
-        private int serverReceivePubMaximum;
-        private int sessionExpireInterval;
         private Channel channel;
         private MQTTConnectionManager connectionManager;
         private MqttConnectMessage connectMessage;
-        private int keepAliveTime;
+        private ClientRestrictions clientRestrictions;
+        public ServerRestrictions serverRestrictions;
 
         public ConnectionBuilder protocolVersion(int protocolVersion) {
             this.protocolVersion = protocolVersion;
@@ -295,23 +270,13 @@ public class Connection {
             return this;
         }
 
-        public ConnectionBuilder cleanSession(boolean cleanSession) {
-            this.cleanSession = cleanSession;
+        public ConnectionBuilder clientRestrictions(ClientRestrictions clientRestrictions){
+            this.clientRestrictions = clientRestrictions;
             return this;
         }
 
-        public ConnectionBuilder clientReceiveMaximum(int clientReceiveMaximum) {
-            this.clientReceiveMaximum = clientReceiveMaximum;
-            return this;
-        }
-
-        public ConnectionBuilder serverReceivePubMaximum(int serverReceivePubMaximum) {
-            this.serverReceivePubMaximum = serverReceivePubMaximum;
-            return this;
-        }
-
-        public ConnectionBuilder sessionExpireInterval(int sessionExpireInterval) {
-            this.sessionExpireInterval = sessionExpireInterval;
+        public ConnectionBuilder serverRestrictions(ServerRestrictions serverRestrictions){
+            this.serverRestrictions = serverRestrictions;
             return this;
         }
 
@@ -327,11 +292,6 @@ public class Connection {
 
         public ConnectionBuilder connectMessage(MqttConnectMessage connectMessage) {
             this.connectMessage = connectMessage;
-            return this;
-        }
-
-        public ConnectionBuilder keepAliveTime(int keepAliveTime) {
-            this.keepAliveTime = keepAliveTime;
             return this;
         }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/exception/restrictions/InvalidReceiveMaximumException.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/exception/restrictions/InvalidReceiveMaximumException.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.exception.restrictions;
+
+public class InvalidReceiveMaximumException extends Exception {
+    public InvalidReceiveMaximumException() {
+    }
+
+    public InvalidReceiveMaximumException(String message) {
+        super(message);
+    }
+}

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/exception/restrictions/InvalidSessionExpireIntervalException.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/exception/restrictions/InvalidSessionExpireIntervalException.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.exception.restrictions;
+
+public class InvalidSessionExpireIntervalException extends Exception {
+    public InvalidSessionExpireIntervalException() {
+    }
+
+    public InvalidSessionExpireIntervalException(String message) {
+        super(message);
+    }
+}

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/exception/restrictions/package-info.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/exception/restrictions/package-info.java
@@ -1,0 +1,18 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Package info.
+ */
+package io.streamnative.pulsar.handlers.mqtt.exception.restrictions;

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/MqttPropertyUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/MqttPropertyUtils.java
@@ -73,7 +73,7 @@ public class MqttPropertyUtils {
         if (receiveMaximum.isPresent() && receiveMaximum.get() == 0) {
             throw new InvalidReceiveMaximumException("Not Allow Receive maximum property value zero");
         } else {
-            receiveMaximum.ifPresent(clientRestrictionsBuilder::clientReceiveMaximum);
+            receiveMaximum.ifPresent(clientRestrictionsBuilder::receiveMaximum);
         }
     }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/MqttPropertyUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/MqttPropertyUtils.java
@@ -39,6 +39,9 @@ public class MqttPropertyUtils {
     public static Optional<Integer> getExpireInterval(MqttProperties properties) {
         MqttProperties.MqttProperty<Integer> property = properties
                 .getProperty(MqttProperties.MqttPropertyType.SESSION_EXPIRY_INTERVAL.value());
+        if (property == null) {
+            return Optional.empty();
+        }
         return Optional.ofNullable(property.value());
     }
 
@@ -51,6 +54,9 @@ public class MqttPropertyUtils {
     private static Optional<Integer> getReceiveMaximum(MqttProperties properties) {
         MqttProperties.MqttProperty<Integer> property = properties
                 .getProperty(MqttProperties.MqttPropertyType.RECEIVE_MAXIMUM.value());
+        if (property == null) {
+            return Optional.empty();
+        }
         return Optional.ofNullable(property.value());
     }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/MqttPropertyUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/MqttPropertyUtils.java
@@ -87,9 +87,9 @@ public class MqttPropertyUtils {
     public static Optional<Integer> getUpdateSessionExpireIntervalIfExist(int protocolVersion, MqttMessage msg) {
         if (MqttUtils.isMqtt5(protocolVersion)
                 && msg.variableHeader() instanceof MqttReasonCodeAndPropertiesVariableHeader) {
-            return Optional.ofNullable(MqttPropertyUtils
+            return MqttPropertyUtils
                     .getExpireInterval(((MqttReasonCodeAndPropertiesVariableHeader)
-                            msg.variableHeader()).properties()));
+                            msg.variableHeader()).properties());
         } else {
             return Optional.empty();
         }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/factory/MqttConnectAckHelper.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/factory/MqttConnectAckHelper.java
@@ -78,6 +78,12 @@ public class MqttConnectAckHelper {
             return build();
         }
 
+        public MqttMessage protocolError(int protocolVersion) {
+            this.protocolVersion = protocolVersion;
+            this.errorReason = ErrorReason.PROTOCOL_ERROR;
+            return build();
+        }
+
         public MqttMessage build() {
             MqttMessageBuilders.ConnAckBuilder connAckBuilder = MqttMessageBuilders.connAck()
                     .sessionPresent(false)
@@ -106,7 +112,9 @@ public class MqttConnectAckHelper {
         WILL_QOS_NOT_SUPPORT(Mqtt3ConnReasonCode.CONNECTION_REFUSED_SERVER_UNAVAILABLE,
                 Mqtt5ConnReasonCode.QOS_NOT_SUPPORTED),
         SERVER_UNAVAILABLE(Mqtt3ConnReasonCode.CONNECTION_REFUSED_SERVER_UNAVAILABLE,
-                Mqtt5ConnReasonCode.SERVER_UNAVAILABLE);
+                Mqtt5ConnReasonCode.SERVER_UNAVAILABLE),
+        PROTOCOL_ERROR(Mqtt3ConnReasonCode.CONNECTION_REFUSED_SERVER_UNAVAILABLE,
+                Mqtt5ConnReasonCode.PROTOCOL_ERROR);
 
         private final Mqtt3ConnReasonCode v3ReasonCode;
         private final Mqtt5ConnReasonCode v5ReasonCode;

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -83,7 +83,7 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
     @Override
     public void doProcessConnect(MqttConnectMessage msg, String userRole, ClientRestrictions clientRestrictions) {
         ServerRestrictions serverRestrictions = ServerRestrictions.builder()
-                .serverReceiveMaximum(proxyConfig.getReceiveMaximum())
+                .receiveMaximum(proxyConfig.getReceiveMaximum())
                 .build();
         connection = Connection.builder()
                 .protocolVersion(msg.variableHeader().version())

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -29,6 +29,8 @@ import io.streamnative.pulsar.handlers.mqtt.messages.ack.PublishAck;
 import io.streamnative.pulsar.handlers.mqtt.messages.ack.SubscribeAck;
 import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5PubReasonCode;
 import io.streamnative.pulsar.handlers.mqtt.messages.factory.MqttSubAckMessageHelper;
+import io.streamnative.pulsar.handlers.mqtt.restrictions.ClientRestrictions;
+import io.streamnative.pulsar.handlers.mqtt.restrictions.ServerRestrictions;
 import io.streamnative.pulsar.handlers.mqtt.support.AbstractCommonProtocolMethodProcessor;
 import io.streamnative.pulsar.handlers.mqtt.support.handler.AckHandler;
 import io.streamnative.pulsar.handlers.mqtt.utils.ExceptionUtils;
@@ -79,17 +81,19 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
     }
 
     @Override
-    public void doProcessConnect(MqttConnectMessage msg, String userRole) {
+    public void doProcessConnect(MqttConnectMessage msg, String userRole, ClientRestrictions clientRestrictions) {
+        ServerRestrictions serverRestrictions = ServerRestrictions.builder()
+                .serverReceiveMaximum(proxyConfig.getReceiveMaximum())
+                .build();
         connection = Connection.builder()
                 .protocolVersion(msg.variableHeader().version())
                 .clientId(msg.payload().clientIdentifier())
                 .userRole(userRole)
-                .cleanSession(msg.variableHeader().isCleanSession())
                 .connectMessage(msg)
-                .keepAliveTime(msg.variableHeader().keepAliveTimeSeconds())
+                .clientRestrictions(clientRestrictions)
+                .serverRestrictions(serverRestrictions)
                 .channel(channel)
                 .connectionManager(connectionManager)
-                .serverReceivePubMaximum(proxyConfig.getReceiveMaximum())
                 .build();
         connection.sendConnAck();
     }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/restrictions/ClientRestrictions.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/restrictions/ClientRestrictions.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.restrictions;
+
+import io.streamnative.pulsar.handlers.mqtt.exception.restrictions.InvalidSessionExpireIntervalException;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Builder
+@ToString
+@EqualsAndHashCode
+public class ClientRestrictions {
+    // describe by mqtt 5.0 version
+    private static final int MQTT5_DEFAULT_RECEIVE_MAXIMUM = 65535;
+    public static final int BEFORE_DEFAULT_RECEIVE_MAXIMUM = 1000;
+
+    private Integer sessionExpireInterval;
+    private Integer clientReceiveMaximum;
+    private Integer keepAliveTime;
+    @Getter
+    private boolean cleanSession;
+
+    public int getSessionExpireInterval() {
+        return Optional.ofNullable(sessionExpireInterval)
+                .orElse(SessionExpireInterval.EXPIRE_IMMEDIATELY.getSecondTime());
+    }
+
+    public int getClientReceiveMaximum() {
+        return Optional.ofNullable(clientReceiveMaximum).orElse(MQTT5_DEFAULT_RECEIVE_MAXIMUM);
+    }
+
+    public int getKeepAliveTime() {
+        return Optional.ofNullable(keepAliveTime).orElse(0);
+    }
+
+    public void updateExpireInterval(int newExpireInterval) throws InvalidSessionExpireIntervalException {
+        if (sessionExpireInterval <= SessionExpireInterval.EXPIRE_IMMEDIATELY.getSecondTime()
+                || newExpireInterval < SessionExpireInterval.EXPIRE_IMMEDIATELY.getSecondTime()) {
+            throw new InvalidSessionExpireIntervalException(
+                    String.format("Illegal session expire interval originValue=%s newValue=%s",
+                            sessionExpireInterval, newExpireInterval));
+        } else {
+            sessionExpireInterval = newExpireInterval;
+        }
+    }
+
+    public boolean isSessionExpireImmediately() {
+        return sessionExpireInterval == SessionExpireInterval.EXPIRE_IMMEDIATELY.getSecondTime();
+    }
+
+    public boolean isSessionNeverExpire() {
+        return sessionExpireInterval == SessionExpireInterval.NEVER_EXPIRE.getSecondTime();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    enum SessionExpireInterval {
+        NEVER_EXPIRE(0xFFFFFFFF),
+        EXPIRE_IMMEDIATELY(0);
+
+        private final int secondTime;
+    }
+}

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/restrictions/ClientRestrictions.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/restrictions/ClientRestrictions.java
@@ -25,12 +25,11 @@ import lombok.ToString;
 @ToString
 @EqualsAndHashCode
 public class ClientRestrictions {
-    // describe by mqtt 5.0 version
-    private static final int MQTT5_DEFAULT_RECEIVE_MAXIMUM = 65535;
-    public static final int BEFORE_DEFAULT_RECEIVE_MAXIMUM = 1000;
+
+    private static final int DEFAULT_RECEIVE_MAXIMUM = 1000;
 
     private Integer sessionExpireInterval;
-    private Integer clientReceiveMaximum;
+    private Integer receiveMaximum;
     private Integer keepAliveTime;
     @Getter
     private boolean cleanSession;
@@ -40,8 +39,8 @@ public class ClientRestrictions {
                 .orElse(SessionExpireInterval.EXPIRE_IMMEDIATELY.getSecondTime());
     }
 
-    public int getClientReceiveMaximum() {
-        return Optional.ofNullable(clientReceiveMaximum).orElse(MQTT5_DEFAULT_RECEIVE_MAXIMUM);
+    public int getReceiveMaximum() {
+        return Optional.ofNullable(receiveMaximum).orElse(DEFAULT_RECEIVE_MAXIMUM);
     }
 
     public int getKeepAliveTime() {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/restrictions/ServerRestrictions.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/restrictions/ServerRestrictions.java
@@ -11,20 +11,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.streamnative.pulsar.handlers.mqtt.restrictions;
 
-package io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
-public enum SessionExpireInterval {
-    NEVER_EXPIRE(0xFFFFFFFF),
-    EXPIRE_IMMEDIATELY(0);
-
-    private final int secondTime;
-
-    SessionExpireInterval(int secondTime) {
-        this.secondTime = secondTime;
-    }
-
-    public int getSecondTime() {
-        return secondTime;
-    }
+@Builder
+@ToString
+@EqualsAndHashCode
+public class ServerRestrictions {
+    @Getter
+    private int serverReceiveMaximum;
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/restrictions/ServerRestrictions.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/restrictions/ServerRestrictions.java
@@ -23,5 +23,5 @@ import lombok.ToString;
 @EqualsAndHashCode
 public class ServerRestrictions {
     @Getter
-    private int serverReceiveMaximum;
+    private int receiveMaximum;
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/restrictions/package-info.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/restrictions/package-info.java
@@ -1,0 +1,18 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Package info.
+ */
+package io.streamnative.pulsar.handlers.mqtt.restrictions;

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
@@ -20,11 +20,9 @@ import static io.streamnative.pulsar.handlers.mqtt.utils.MqttMessageUtils.topicS
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttMessage;
-import io.netty.handler.codec.mqtt.MqttProperties;
 import io.netty.handler.codec.mqtt.MqttPubAckMessage;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.handler.codec.mqtt.MqttQoS;
-import io.netty.handler.codec.mqtt.MqttReasonCodeAndPropertiesVariableHeader;
 import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
 import io.netty.handler.codec.mqtt.MqttTopicSubscription;
 import io.netty.handler.codec.mqtt.MqttUnsubscribeMessage;
@@ -40,6 +38,7 @@ import io.streamnative.pulsar.handlers.mqtt.QosPublishHandlers;
 import io.streamnative.pulsar.handlers.mqtt.exception.MQTTNoSubscriptionExistedException;
 import io.streamnative.pulsar.handlers.mqtt.exception.MQTTServerException;
 import io.streamnative.pulsar.handlers.mqtt.exception.MQTTTopicNotExistedException;
+import io.streamnative.pulsar.handlers.mqtt.exception.restrictions.InvalidSessionExpireIntervalException;
 import io.streamnative.pulsar.handlers.mqtt.messages.MqttPropertyUtils;
 import io.streamnative.pulsar.handlers.mqtt.messages.ack.DisconnectAck;
 import io.streamnative.pulsar.handlers.mqtt.messages.ack.PublishAck;
@@ -48,8 +47,9 @@ import io.streamnative.pulsar.handlers.mqtt.messages.ack.UnsubscribeAck;
 import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5DisConnReasonCode;
 import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5PubReasonCode;
 import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5UnsubReasonCode;
-import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.SessionExpireInterval;
 import io.streamnative.pulsar.handlers.mqtt.messages.factory.MqttSubAckMessageHelper;
+import io.streamnative.pulsar.handlers.mqtt.restrictions.ClientRestrictions;
+import io.streamnative.pulsar.handlers.mqtt.restrictions.ServerRestrictions;
 import io.streamnative.pulsar.handlers.mqtt.support.handler.AckHandler;
 import io.streamnative.pulsar.handlers.mqtt.utils.ExceptionUtils;
 import io.streamnative.pulsar.handlers.mqtt.utils.MqttUtils;
@@ -107,19 +107,17 @@ public class DefaultProtocolMethodProcessorImpl extends AbstractCommonProtocolMe
     }
 
     @Override
-    public void doProcessConnect(MqttConnectMessage msg, String userRole) {
+    public void doProcessConnect(MqttConnectMessage msg, String userRole, ClientRestrictions clientRestrictions) {
+        ServerRestrictions serverRestrictions = ServerRestrictions.builder()
+                .serverReceiveMaximum(configuration.getReceiveMaximum())
+                .build();
         connection = Connection.builder()
                 .protocolVersion(msg.variableHeader().version())
                 .clientId(msg.payload().clientIdentifier())
                 .userRole(userRole)
                 .willMessage(createWillMessage(msg))
-                .cleanSession(msg.variableHeader().isCleanSession())
-                .sessionExpireInterval(MqttPropertyUtils.getExpireInterval(msg.variableHeader().properties())
-                        .orElse(SessionExpireInterval.EXPIRE_IMMEDIATELY.getSecondTime()))
-                .clientReceiveMaximum(MqttPropertyUtils.getReceiveMaximum(msg.variableHeader().version(),
-                        msg.variableHeader().properties()))
-                .serverReceivePubMaximum(configuration.getReceiveMaximum())
-                .keepAliveTime(msg.variableHeader().keepAliveTimeSeconds())
+                .clientRestrictions(clientRestrictions)
+                .serverRestrictions(serverRestrictions)
                 .channel(channel)
                 .connectionManager(connectionManager)
                 .build();
@@ -207,15 +205,15 @@ public class DefaultProtocolMethodProcessorImpl extends AbstractCommonProtocolMe
         if (!MqttUtils.isMqtt5(connection.getProtocolVersion())) {
             return;
         }
-        if (connection.getServerReceivePubMessage() >= connection.getServerReceivePubMaximum()) {
+        if (connection.getServerReceivePubMessage() >= connection.getClientRestrictions().getClientReceiveMaximum()) {
             log.warn("Client publish exceed server receive maximum , the receive maximum is {}",
-                    connection.getServerReceivePubMaximum());
+                    connection.getServerRestrictions().getServerReceiveMaximum());
             PublishAck quotaExceededAck = PublishAck.builder()
                     .success(false)
                     .reasonCode(Mqtt5PubReasonCode.QUOTA_EXCEEDED)
                     .packetId(msg.variableHeader().packetId())
                     .reasonString(String.format("Publish exceed server receive maximum %s.",
-                            connection.getServerReceivePubMaximum()))
+                            connection.getServerRestrictions().getServerReceiveMaximum()))
                     .build();
             connection.getAckHandler().sendPublishAck(connection, quotaExceededAck);
         } else {
@@ -234,48 +232,34 @@ public class DefaultProtocolMethodProcessorImpl extends AbstractCommonProtocolMe
         if (log.isDebugEnabled()) {
             log.debug("[Disconnect] [{}] ", clientId);
         }
-        // when reset expire interval present, we need to reset session expire interval.
-        Object header = msg.variableHeader();
-        if (header instanceof MqttReasonCodeAndPropertiesVariableHeader) {
-            MqttProperties properties = ((MqttReasonCodeAndPropertiesVariableHeader) header).properties();
-            if (!checkAndUpdateSessionExpireIntervalIfNeed(clientId, connection, properties)){
-                // If the session expire interval value is illegal.
-                return;
-            }
+        // If client update session timeout interval property.
+        Optional<Integer> newSessionExpireInterval;
+        if ((newSessionExpireInterval = MqttPropertyUtils
+                .getUpdateSessionExpireIntervalIfExist(connection.getProtocolVersion(), msg)).isPresent()) {
+                try {
+                    connection.updateSessionExpireInterval(newSessionExpireInterval.get());
+                } catch (InvalidSessionExpireIntervalException e) {
+                    DisconnectAck disconnectAck = DisconnectAck
+                            .builder()
+                            .success(false)
+                            .reasonCode(Mqtt5DisConnReasonCode.PROTOCOL_ERROR)
+                            .reasonString(String.format("Disconnect with wrong session expire interval value."
+                                    + " the value is %s", newSessionExpireInterval))
+                            .build();
+                    connection.getAckHandler().sendDisconnectAck(connection, disconnectAck);
+                }
+        } else {
+            DisconnectAck disconnectAck = DisconnectAck
+                    .builder()
+                    .success(true)
+                    .build();
+            connection.getAckHandler()
+                    .sendDisconnectAck(connection, disconnectAck)
+                    .addListener(__ -> {
+                        metricsCollector.removeClient(NettyUtils.getAddress(channel));
+                        connectionManager.removeConnection(connection);
+                    });
         }
-        DisconnectAck disconnectAck = DisconnectAck
-                .builder()
-                .success(true)
-                .build();
-        connection.getAckHandler()
-                .sendDisconnectAck(connection, disconnectAck)
-                .addListener(__ -> {
-                    metricsCollector.removeClient(NettyUtils.getAddress(channel));
-                    connectionManager.removeConnection(connection);
-                });
-    }
-
-    private boolean checkAndUpdateSessionExpireIntervalIfNeed(String clientId,
-                                                              Connection connection, MqttProperties properties) {
-        Optional<Integer> expireInterval = MqttPropertyUtils.getExpireInterval(properties);
-        if (expireInterval.isPresent()) {
-            Integer sessionExpireInterval = expireInterval.get();
-            boolean checkResult = connection.checkIsLegalExpireInterval(sessionExpireInterval);
-            if (!checkResult) {
-                DisconnectAck disconnectAck = DisconnectAck
-                        .builder()
-                        .success(false)
-                        .reasonCode(Mqtt5DisConnReasonCode.PROTOCOL_ERROR)
-                        .reasonString(
-                                String.format("Disconnect with wrong session expire interval value. the value is %s",
-                                sessionExpireInterval))
-                        .build();
-                connection.getAckHandler().sendDisconnectAck(connection, disconnectAck);
-                return false;
-            }
-            connection.updateSessionExpireInterval(sessionExpireInterval);
-        }
-        return true;
     }
 
     @Override
@@ -383,7 +367,7 @@ public class DefaultProtocolMethodProcessorImpl extends AbstractCommonProtocolMe
                         try {
                             MQTTConsumer consumer = new MQTTConsumer(sub, subTopic.topicName(), topic,
                                     connection.getClientId(), serverCnx, subTopic.qualityOfService(), packetIdGenerator,
-                                    outstandingPacketContainer, metricsCollector, connection.getClientReceiveMaximum());
+                                    outstandingPacketContainer, metricsCollector, connection.getClientRestrictions());
                             sub.addConsumer(consumer);
                             consumer.addAllPermits();
                             connection.getTopicSubscriptionManager().putIfAbsent(sub.getTopic(), sub, consumer);

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
@@ -109,7 +109,7 @@ public class DefaultProtocolMethodProcessorImpl extends AbstractCommonProtocolMe
     @Override
     public void doProcessConnect(MqttConnectMessage msg, String userRole, ClientRestrictions clientRestrictions) {
         ServerRestrictions serverRestrictions = ServerRestrictions.builder()
-                .serverReceiveMaximum(configuration.getReceiveMaximum())
+                .receiveMaximum(configuration.getReceiveMaximum())
                 .build();
         connection = Connection.builder()
                 .protocolVersion(msg.variableHeader().version())
@@ -205,15 +205,15 @@ public class DefaultProtocolMethodProcessorImpl extends AbstractCommonProtocolMe
         if (!MqttUtils.isMqtt5(connection.getProtocolVersion())) {
             return;
         }
-        if (connection.getServerReceivePubMessage() >= connection.getClientRestrictions().getClientReceiveMaximum()) {
+        if (connection.getServerReceivePubMessage() >= connection.getClientRestrictions().getReceiveMaximum()) {
             log.warn("Client publish exceed server receive maximum , the receive maximum is {}",
-                    connection.getServerRestrictions().getServerReceiveMaximum());
+                    connection.getServerRestrictions().getReceiveMaximum());
             PublishAck quotaExceededAck = PublishAck.builder()
                     .success(false)
                     .reasonCode(Mqtt5PubReasonCode.QUOTA_EXCEEDED)
                     .packetId(msg.variableHeader().packetId())
                     .reasonString(String.format("Publish exceed server receive maximum %s.",
-                            connection.getServerRestrictions().getServerReceiveMaximum()))
+                            connection.getServerRestrictions().getReceiveMaximum()))
                     .build();
             connection.getAckHandler().sendPublishAck(connection, quotaExceededAck);
         } else {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTConsumer.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTConsumer.java
@@ -58,7 +58,7 @@ public class MQTTConsumer extends Consumer {
     private static final AtomicIntegerFieldUpdater<MQTTConsumer> ADD_PERMITS_UPDATER =
             AtomicIntegerFieldUpdater.newUpdater(MQTTConsumer.class, "addPermits");
     private volatile int addPermits = 0;
-    private ClientRestrictions clientRestrictions;
+    private final ClientRestrictions clientRestrictions;
 
     public MQTTConsumer(Subscription subscription, String mqttTopicName, String pulsarTopicName, String consumerName,
                         MQTTServerCnx cnx, MqttQoS qos, PacketIdGenerator packetIdGenerator,
@@ -129,7 +129,7 @@ public class MQTTConsumer extends Consumer {
 
     public void incrementPermits(int permits) {
         int var = ADD_PERMITS_UPDATER.addAndGet(this, permits);
-        if (var > clientRestrictions.getClientReceiveMaximum() / 2) {
+        if (var > clientRestrictions.getReceiveMaximum() / 2) {
             MESSAGE_PERMITS_UPDATER.addAndGet(this, var);
             this.getSubscription().consumerFlow(this, availablePermits);
             ADD_PERMITS_UPDATER.set(this, 0);
@@ -137,7 +137,7 @@ public class MQTTConsumer extends Consumer {
     }
 
     public void addAllPermits() {
-        this.availablePermits = clientRestrictions.getClientReceiveMaximum();
+        this.availablePermits = clientRestrictions.getReceiveMaximum();
         this.getSubscription().consumerFlow(this, availablePermits);
     }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTConsumer.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTConsumer.java
@@ -20,6 +20,7 @@ import io.netty.handler.codec.mqtt.MqttQoS;
 import io.streamnative.pulsar.handlers.mqtt.OutstandingPacket;
 import io.streamnative.pulsar.handlers.mqtt.OutstandingPacketContainer;
 import io.streamnative.pulsar.handlers.mqtt.PacketIdGenerator;
+import io.streamnative.pulsar.handlers.mqtt.restrictions.ClientRestrictions;
 import io.streamnative.pulsar.handlers.mqtt.utils.PulsarMessageConverter;
 import io.streamnative.pulsar.handlers.mqtt.utils.PulsarTopicUtils;
 import java.util.Collections;
@@ -57,12 +58,12 @@ public class MQTTConsumer extends Consumer {
     private static final AtomicIntegerFieldUpdater<MQTTConsumer> ADD_PERMITS_UPDATER =
             AtomicIntegerFieldUpdater.newUpdater(MQTTConsumer.class, "addPermits");
     private volatile int addPermits = 0;
-    private final int maxPermits;
+    private ClientRestrictions clientRestrictions;
 
     public MQTTConsumer(Subscription subscription, String mqttTopicName, String pulsarTopicName, String consumerName,
                         MQTTServerCnx cnx, MqttQoS qos, PacketIdGenerator packetIdGenerator,
                         OutstandingPacketContainer outstandingPacketContainer, MQTTMetricsCollector metricsCollector,
-                        int clientReceiveMaximum) {
+                        ClientRestrictions clientRestrictions) {
         super(subscription, CommandSubscribe.SubType.Shared, pulsarTopicName, 0, 0, consumerName, 0, cnx,
                 "", null, false, CommandSubscribe.InitialPosition.Latest, null, MessageId.latest);
         this.pulsarTopicName = pulsarTopicName;
@@ -72,7 +73,7 @@ public class MQTTConsumer extends Consumer {
         this.packetIdGenerator = packetIdGenerator;
         this.outstandingPacketContainer = outstandingPacketContainer;
         this.metricsCollector = metricsCollector;
-        this.maxPermits = clientReceiveMaximum;
+        this.clientRestrictions = clientRestrictions;
     }
 
     @Override
@@ -128,7 +129,7 @@ public class MQTTConsumer extends Consumer {
 
     public void incrementPermits(int permits) {
         int var = ADD_PERMITS_UPDATER.addAndGet(this, permits);
-        if (var > maxPermits / 2) {
+        if (var > clientRestrictions.getClientReceiveMaximum() / 2) {
             MESSAGE_PERMITS_UPDATER.addAndGet(this, var);
             this.getSubscription().consumerFlow(this, availablePermits);
             ADD_PERMITS_UPDATER.set(this, 0);
@@ -136,7 +137,7 @@ public class MQTTConsumer extends Consumer {
     }
 
     public void addAllPermits() {
-        this.availablePermits = maxPermits;
+        this.availablePermits = clientRestrictions.getClientReceiveMaximum();
         this.getSubscription().consumerFlow(this, availablePermits);
     }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/handler/MqttV3xAckHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/handler/MqttV3xAckHandler.java
@@ -37,7 +37,7 @@ public class MqttV3xAckHandler extends AbstractAckHandler {
     MqttMessage getConnAckMessage(Connection connection) {
         return MqttConnectAckHelper.builder()
                 .returnCode(Mqtt3ConnReasonCode.CONNECTION_ACCEPTED.convertToNettyKlass())
-                .sessionPresent(!connection.isCleanSession())
+                .sessionPresent(!connection.getClientRestrictions().isCleanSession())
                 .build();
     }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/handler/MqttV5AckHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/handler/MqttV5AckHandler.java
@@ -41,11 +41,11 @@ public class MqttV5AckHandler extends AbstractAckHandler {
         MqttProperties properties = new MqttProperties();
         MqttProperties.IntegerProperty property =
                 new MqttProperties.IntegerProperty(MqttProperties.MqttPropertyType.RECEIVE_MAXIMUM.value(),
-                        connection.getServerReceivePubMaximum());
+                        connection.getServerRestrictions().getServerReceiveMaximum());
         properties.add(property);
         return MqttConnectAckHelper.builder()
                 .returnCode(Mqtt5ConnReasonCode.SUCCESS.convertToNettyKlass())
-                .sessionPresent(!connection.isCleanSession())
+                .sessionPresent(!connection.getClientRestrictions().isCleanSession())
                 .properties(properties)
                 .build();
     }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/handler/MqttV5AckHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/handler/MqttV5AckHandler.java
@@ -41,7 +41,7 @@ public class MqttV5AckHandler extends AbstractAckHandler {
         MqttProperties properties = new MqttProperties();
         MqttProperties.IntegerProperty property =
                 new MqttProperties.IntegerProperty(MqttProperties.MqttPropertyType.RECEIVE_MAXIMUM.value(),
-                        connection.getServerRestrictions().getServerReceiveMaximum());
+                        connection.getServerRestrictions().getReceiveMaximum());
         properties.add(property);
         return MqttConnectAckHelper.builder()
                 .returnCode(Mqtt5ConnReasonCode.SUCCESS.convertToNettyKlass())


### PR DESCRIPTION
### Motivation

Because of MQTT protocol version 5 have some other restrictions like ``maximum packet size``,``maximum qos``, ``retain avaliable`` etc.
I think it's a best way to refactor some previous logic.

### Modification

- Add ``ClientRestriction`` store some restrictions about client side.
- Add ``ServerRestriction`` store some restrictions about server side.
- Refactor some logic implementation.