### PR TITLE
Bump version 2.10.0.0 rc4

### DIFF
--- a/mqtt-impl/pom.xml
+++ b/mqtt-impl/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>pulsar-protocol-handler-mqtt-parent</artifactId>
         <groupId>io.streamnative.pulsar.handlers</groupId>
-        <version>2.10.0.0-rc3</version>
+        <version>2.10.0.0-rc4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pulsar-protocol-handler-mqtt</artifactId>

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTConsumer.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTConsumer.java
@@ -37,6 +37,7 @@ import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.common.api.proto.CommandAck;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
+import org.apache.pulsar.common.protocol.Commands;
 
 /**
  * MQTT consumer.
@@ -65,7 +66,8 @@ public class MQTTConsumer extends Consumer {
                         OutstandingPacketContainer outstandingPacketContainer, MQTTMetricsCollector metricsCollector,
                         ClientRestrictions clientRestrictions) {
         super(subscription, CommandSubscribe.SubType.Shared, pulsarTopicName, 0, 0, consumerName, true, cnx,
-                "", null, false, CommandSubscribe.InitialPosition.Latest, null, MessageId.latest);
+                "", null, false, CommandSubscribe.InitialPosition.Latest, null,
+                MessageId.latest, Commands.DEFAULT_CONSUMER_EPOCH);
         this.pulsarTopicName = pulsarTopicName;
         this.mqttTopicName = mqttTopicName;
         this.cnx = cnx;

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <groupId>io.streamnative.pulsar.handlers</groupId>
     <artifactId>pulsar-protocol-handler-mqtt-parent</artifactId>
-    <version>2.10.0.0-rc3</version>
+    <version>2.10.0.0-rc4</version>
     <name>StreamNative :: Pulsar Protocol Handler :: MoP Parent</name>
     <description>Parent for MQTT on Pulsar implemented using Pulsar Protocol Handler.</description>
 
@@ -49,7 +49,7 @@
         <mockito.version>2.22.0</mockito.version>
         <testng.version>6.14.3</testng.version>
         <awaitility.version>4.0.2</awaitility.version>
-        <pulsar.version>2.10.0.0-rc3</pulsar.version>
+        <pulsar.version>2.10.0.0-rc4</pulsar.version>
         <mqtt.codec.version>4.1.67.Final</mqtt.codec.version>
         <log4j2.version>2.17.1</log4j2.version>
         <lombok.version>1.18.4</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <testng.version>6.14.3</testng.version>
         <awaitility.version>4.0.2</awaitility.version>
         <pulsar.version>2.10.0.0-rc4</pulsar.version>
-        <mqtt.codec.version>4.1.67.Final</mqtt.codec.version>
+        <mqtt.codec.version>4.1.74.Final</mqtt.codec.version>
         <log4j2.version>2.17.1</log4j2.version>
         <lombok.version>1.18.4</lombok.version>
         <fusesource.client.version>1.16</fusesource.client.version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>pulsar-protocol-handler-mqtt-parent</artifactId>
         <groupId>io.streamnative.pulsar.handlers</groupId>
-        <version>2.10.0.0-rc3</version>
+        <version>2.10.0.0-rc4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pulsar-protocol-handler-mqtt-tests</artifactId>


### PR DESCRIPTION
https://github.com/apache/pulsar/pull/10478 introduced an API change to `MessageImpl#create`, which is included in 2.10.0.0-rc4, we need to fix the conflict.