### PR TITLE
Bump MOP version to 2.9.1.5

### DIFF
--- a/mqtt-impl/pom.xml
+++ b/mqtt-impl/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>pulsar-protocol-handler-mqtt-parent</artifactId>
         <groupId>io.streamnative.pulsar.handlers</groupId>
-        <version>2.9.0-SNAPSHOT</version>
+        <version>2.9.1.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pulsar-protocol-handler-mqtt</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <groupId>io.streamnative.pulsar.handlers</groupId>
     <artifactId>pulsar-protocol-handler-mqtt-parent</artifactId>
-    <version>2.9.0-SNAPSHOT</version>
+    <version>2.9.1.5</version>
     <name>StreamNative :: Pulsar Protocol Handler :: MoP Parent</name>
     <description>Parent for MQTT on Pulsar implemented using Pulsar Protocol Handler.</description>
 
@@ -49,7 +49,7 @@
         <mockito.version>2.22.0</mockito.version>
         <testng.version>6.14.3</testng.version>
         <awaitility.version>4.0.2</awaitility.version>
-        <pulsar.version>2.9.0-rc-202110221101</pulsar.version>
+        <pulsar.version>2.9.1.5</pulsar.version>
         <mqtt.codec.version>4.1.67.Final</mqtt.codec.version>
         <log4j2.version>2.17.1</log4j2.version>
         <lombok.version>1.18.4</lombok.version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>pulsar-protocol-handler-mqtt-parent</artifactId>
         <groupId>io.streamnative.pulsar.handlers</groupId>
-        <version>2.9.0-SNAPSHOT</version>
+        <version>2.9.1.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pulsar-protocol-handler-mqtt-tests</artifactId>


### PR DESCRIPTION
### Motivation

The latest mop version is in branch 2.9.1 is 2.9.1.5, but the current version is ``2.9.0-SNAPSHOT``. so, we need to upgrade it.

### Modification

- bump mop version to 2.9.1.5

