### PR TITLE
Fix issue 484

### DIFF
--- a/mqtt-impl/pom.xml
+++ b/mqtt-impl/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>pulsar-protocol-handler-mqtt-parent</artifactId>
         <groupId>io.streamnative.pulsar.handlers</groupId>
-        <version>2.9.0-SNAPSHOT</version>
+        <version>2.9.1.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pulsar-protocol-handler-mqtt</artifactId>

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTInboundHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTInboundHandler.java
@@ -31,6 +31,8 @@ import io.streamnative.pulsar.handlers.mqtt.support.DefaultProtocolMethodProcess
 import io.streamnative.pulsar.handlers.mqtt.utils.NettyUtils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import java.io.IOException;
+
 /**
  * MQTT in bound handler.
  */
@@ -116,12 +118,14 @@ public class MQTTInboundHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        log.warn(
-                "An unexpected exception was caught while processing MQTT message. "
-                + "Closing Netty channel {}. connection = {}",
-                ctx.channel(),
-                NettyUtils.getConnection(ctx.channel()),
-                cause);
+        if (!(cause instanceof IOException)) {
+            log.warn(
+                    "An unexpected exception was caught while processing MQTT message. "
+                            + "Closing Netty channel {}. connection = {}",
+                    ctx.channel(),
+                    NettyUtils.getConnection(ctx.channel()),
+                    cause);
+        }
         ctx.close();
     }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
@@ -67,7 +67,7 @@ public class Qos1PublishHandler extends AbstractQosPublishHandler {
                             log.debug("[{}] Send Pub Ack {} to {}", topic, msg.variableHeader().packetId(),
                                     connection.getClientId());
                         }
-                    } else {
+                    } else if (channel.isActive()){
                         log.warn("[{}] Failed to send Pub Ack {} to {}", topic, msg.variableHeader().packetId(),
                                 connection.getClientId(), future.cause());
                     }

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <groupId>io.streamnative.pulsar.handlers</groupId>
     <artifactId>pulsar-protocol-handler-mqtt-parent</artifactId>
-    <version>2.9.0-SNAPSHOT</version>
+    <version>2.9.1.5</version>
     <name>StreamNative :: Pulsar Protocol Handler :: MoP Parent</name>
     <description>Parent for MQTT on Pulsar implemented using Pulsar Protocol Handler.</description>
 
@@ -49,7 +49,7 @@
         <mockito.version>2.22.0</mockito.version>
         <testng.version>6.14.3</testng.version>
         <awaitility.version>4.0.2</awaitility.version>
-        <pulsar.version>2.9.0-rc-202110221101</pulsar.version>
+        <pulsar.version>2.9.1.5</pulsar.version>
         <mqtt.codec.version>4.1.67.Final</mqtt.codec.version>
         <log4j2.version>2.16.0</log4j2.version>
         <lombok.version>1.18.4</lombok.version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>pulsar-protocol-handler-mqtt-parent</artifactId>
         <groupId>io.streamnative.pulsar.handlers</groupId>
-        <version>2.9.0-SNAPSHOT</version>
+        <version>2.9.1.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pulsar-protocol-handler-mqtt-tests</artifactId>


### PR DESCRIPTION
**Motivation**
Fix issue#484，In the standalone boot mode of pulsar, I only encounter that the broker prints a lot of NPE logs when when I have killed the producer process

**problem causes**
Normally, the producer is connected to the broker and maintains the state of the channel through some heartbeat mechanism. But the producer is suddenly disconnected, and io.netty.channel is not aware of it. The original code does not judge this situation and writes directly to the broker log, so we need to add some judgments to avoid this situation

**solution process**
Through the error log, locate the location of the error log record and intercept it at this location. The modification force is the smallest

In the first piece of code, because the channel is not sensed in time when the producer is disconnected, this situation cannot be sensed through the channel state at this time, only by judging the type of error
![image](https://user-images.githubusercontent.com/50951693/156932422-4cb7995c-2250-45bf-a454-9a3690266595.png)

In the second code, because the channel calls the writeAndFlush method to monitor the failure, it will trigger the update of the channel state, that is, the judgment that channel.isActive is equal to false is established
![image](https://user-images.githubusercontent.com/50951693/156932595-06d1fae5-48b1-4546-b8e8-49113dda06cc.png)
