### PR TITLE
Use ``BeanUtils#copyProperties`` to copy proxy config.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTProtocolHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTProtocolHandler.java
@@ -30,6 +30,7 @@ import java.net.InetSocketAddress;
 import java.util.Map;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.beanutils.BeanUtils;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.ServiceConfigurationUtils;
 import org.apache.pulsar.broker.protocol.ProtocolHandler;
@@ -89,59 +90,21 @@ public class MQTTProtocolHandler implements ProtocolHandler {
     public void start(BrokerService brokerService) {
         this.brokerService = brokerService;
         mqttService = new MQTTService(brokerService, mqttConfig);
-
         if (mqttConfig.isMqttProxyEnabled() || mqttConfig.isMqttProxyEnable()) {
             MQTTProxyConfiguration proxyConfig = new MQTTProxyConfiguration();
-            proxyConfig.setDefaultTenant(mqttConfig.getDefaultTenant());
-            proxyConfig.setDefaultTopicDomain(mqttConfig.getDefaultTopicDomain());
-            proxyConfig.setMaxNoOfChannels(mqttConfig.getMaxNoOfChannels());
-            proxyConfig.setMaxFrameSize(mqttConfig.getMaxFrameSize());
-            proxyConfig.setMqttProxyPort(mqttConfig.getMqttProxyPort());
-            proxyConfig.setMqttProxyTlsPort(mqttConfig.getMqttProxyTlsPort());
-            proxyConfig.setMqttProxyTlsPskPort(mqttConfig.getMqttProxyTlsPskPort());
-            proxyConfig.setMqttProxyTlsEnabled(mqttConfig.isMqttProxyTlsEnabled());
-            proxyConfig.setMqttProxyTlsPskEnabled(mqttConfig.isMqttProxyTlsPskEnabled());
-            proxyConfig.setBrokerServiceURL("pulsar://"
+            try {
+                BeanUtils.copyProperties(proxyConfig, mqttConfig);
+                proxyConfig.setBrokerServiceURL("pulsar://"
                     + ServiceConfigurationUtils.getAppliedAdvertisedAddress(mqttConfig, true)
                     + ":" + mqttConfig.getBrokerServicePort().get());
-            proxyConfig.setMqttProxyNumAcceptorThreads(mqttConfig.getMqttProxyNumAcceptorThreads());
-            proxyConfig.setMqttProxyNumIOThreads(mqttConfig.getMqttProxyNumIOThreads());
-            proxyConfig.setMqttAuthenticationEnabled(mqttConfig.isMqttAuthenticationEnabled());
-            proxyConfig.setMqttAuthenticationMethods(mqttConfig.getMqttAuthenticationMethods());
-            proxyConfig.setMqttAuthorizationEnabled(mqttConfig.isMqttAuthorizationEnabled());
-            proxyConfig.setBrokerClientAuthenticationPlugin(mqttConfig.getBrokerClientAuthenticationPlugin());
-            proxyConfig.setBrokerClientAuthenticationParameters(mqttConfig.getBrokerClientAuthenticationParameters());
-
-            proxyConfig.setTlsCertificateFilePath(mqttConfig.getTlsCertificateFilePath());
-            proxyConfig.setTlsCertRefreshCheckDurationSec(mqttConfig.getTlsCertRefreshCheckDurationSec());
-            proxyConfig.setTlsProtocols(mqttConfig.getTlsProtocols());
-            proxyConfig.setTlsCiphers(mqttConfig.getTlsCiphers());
-            proxyConfig.setTlsAllowInsecureConnection(mqttConfig.isTlsAllowInsecureConnection());
-
-            proxyConfig.setTlsPskIdentityHint(mqttConfig.getTlsPskIdentityHint());
-            proxyConfig.setTlsPskIdentity(mqttConfig.getTlsPskIdentity());
-            proxyConfig.setTlsPskIdentityFile(mqttConfig.getTlsPskIdentityFile());
-
-            proxyConfig.setTlsTrustStore(mqttConfig.getTlsTrustStore());
-            proxyConfig.setTlsTrustCertsFilePath(mqttConfig.getTlsTrustCertsFilePath());
-            proxyConfig.setTlsTrustStoreType(mqttConfig.getTlsTrustStoreType());
-            proxyConfig.setTlsTrustStorePassword(mqttConfig.getTlsTrustStorePassword());
-
-            proxyConfig.setTlsEnabledWithKeyStore(mqttConfig.isTlsEnabledWithKeyStore());
-            proxyConfig.setTlsKeyStore(mqttConfig.getTlsKeyStore());
-            proxyConfig.setTlsKeyStoreType(mqttConfig.getTlsKeyStoreType());
-            proxyConfig.setTlsKeyStorePassword(mqttConfig.getTlsTrustStorePassword());
-            proxyConfig.setTlsKeyFilePath(mqttConfig.getTlsKeyFilePath());
-            log.info("proxyConfig broker service URL: {}", proxyConfig.getBrokerServiceURL());
-            proxyService = new MQTTProxyService(mqttService, proxyConfig);
-            try {
+                log.info("proxyConfig broker service URL: {}", proxyConfig.getBrokerServiceURL());
+                proxyService = new MQTTProxyService(mqttService, proxyConfig);
                 proxyService.start();
                 log.info("Start MQTT proxy service at port: {}", proxyConfig.getMqttProxyPort());
             } catch (Exception ex) {
                 log.error("Failed to start MQTT proxy service.", ex);
             }
         }
-
         log.info("Starting MqttProtocolHandler, MoP version is: '{}'", MopVersion.getVersion());
         log.info("Git Revision {}", MopVersion.getGitSha());
         log.info("Built by {} on {} at {}",

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <lombok.version>1.18.4</lombok.version>
         <fusesource.client.version>1.16</fusesource.client.version>
         <hivemq.mqtt.client.version>1.2.2</hivemq.mqtt.client.version>
+        <apache.commons.bean-utils.version>1.9.4</apache.commons.bean-utils.version>
         <javac.target>1.8</javac.target>
         <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
@@ -92,6 +93,11 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-mqtt</artifactId>
             <version>${mqtt.codec.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>${apache.commons.bean-utils.version}</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>


### PR DESCRIPTION
### Motivation

Use ``BeanUtils#copyProperties`` to copy proxy config.

### Modifications

- Use ``BeanUtils#copyProperties`` to copy proxy config. 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
