### PR TITLE
Fix MQTT proxy ``PUB-ACK`` topic with slash.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -138,10 +138,10 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
         }
         int packetId = msg.variableHeader().messageId();
         String topicName = packetIdTopic.remove(packetId);
-        final String pulsarTopicName = PulsarTopicUtils.getEncodedPulsarTopicName(topicName,
-                proxyConfig.getDefaultTenant(), proxyConfig.getDefaultNamespace(),
-                TopicDomain.getEnum(proxyConfig.getDefaultTopicDomain()));
-        if (pulsarTopicName != null) {
+        if (topicName != null) {
+            final String pulsarTopicName = PulsarTopicUtils.getEncodedPulsarTopicName(topicName,
+                    proxyConfig.getDefaultTenant(), proxyConfig.getDefaultNamespace(),
+                    TopicDomain.getEnum(proxyConfig.getDefaultTopicDomain()));
             writeToBroker(pulsarTopicName, msg)
                     .exceptionally(ex -> {
                         log.error("[Proxy Publish] Failed write pub ack {} to topic {} CId : {}",

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -138,8 +138,11 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
         }
         int packetId = msg.variableHeader().messageId();
         String topicName = packetIdTopic.remove(packetId);
-        if (topicName != null) {
-            writeToBroker(topicName, msg)
+        final String pulsarTopicName = PulsarTopicUtils.getEncodedPulsarTopicName(topicName,
+                proxyConfig.getDefaultTenant(), proxyConfig.getDefaultNamespace(),
+                TopicDomain.getEnum(proxyConfig.getDefaultTopicDomain()));
+        if (pulsarTopicName != null) {
+            writeToBroker(pulsarTopicName, msg)
                     .exceptionally(ex -> {
                         log.error("[Proxy Publish] Failed write pub ack {} to topic {} CId : {}",
                                 msg, topicName, connection.getClientId(), ex);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt5/hivemq/proxy/MQTT5ClientReceiveMaximumTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt5/hivemq/proxy/MQTT5ClientReceiveMaximumTest.java
@@ -41,7 +41,7 @@ public class MQTT5ClientReceiveMaximumTest extends MQTTTestBase {
 
     @Test(timeOut = TIMEOUT)
     public void testExceedReceiveMaximumWillBlock() throws Exception {
-        final String topic = "proxy-test-receive-maximum-1";
+        final String topic = "proxy/test-receive-maximum-1";
         Mqtt5BlockingClient client = MQTT5ClientUtils.createMqtt5ProxyClient(
                 getMqttProxyPortList().get(random.nextInt(mqttProxyPortList.size())));
         Mqtt5ConnectRestrictions restrictions = Mqtt5ConnectRestrictions.builder()
@@ -70,7 +70,7 @@ public class MQTT5ClientReceiveMaximumTest extends MQTTTestBase {
 
     @Test(timeOut = TIMEOUT)
     public void testReceiveMaximumNormalCondition() throws Exception {
-        final String topic = "proxy-test-receive-maximum-2";
+        final String topic = "proxy/test-receive-maximum-2";
         Mqtt5BlockingClient client = MQTT5ClientUtils.createMqtt5ProxyClient(
                 getMqttProxyPortList().get(random.nextInt(mqttProxyPortList.size())));
         Mqtt5ConnectRestrictions restrictions = Mqtt5ConnectRestrictions.builder()
@@ -103,7 +103,7 @@ public class MQTT5ClientReceiveMaximumTest extends MQTTTestBase {
 
     @Test(timeOut = TIMEOUT)
     public void testQos0ExceedReceiveMaximumWillNotBlock() throws Exception {
-        final String topic = "proxy-test-receive-maximum-3";
+        final String topic = "proxy/test-receive-maximum-3";
         Mqtt5BlockingClient client = MQTT5ClientUtils.createMqtt5ProxyClient(
                 getMqttProxyPortList().get(random.nextInt(mqttProxyPortList.size())));
         Mqtt5ConnectRestrictions restrictions = Mqtt5ConnectRestrictions.builder()


### PR DESCRIPTION
### Motivation

#528  Support MQTT Proxy ``PUB-ACK``,  but if user use topic name like ``abc/def`` the broker will get exception:

```java
2022-03-17T05:28:46,766+0000 [mqtt-redirect-io-67-8] ERROR io.streamnative.pulsar.handlers.mqtt.MQTTCommonInboundHandler - Exception was caught while processing MQTT message,
java.lang.IllegalArgumentException: Invalid short topic name 'bench/8453', it should be in the format of <tenant>/<namespace>/<topic> or <topic>
	at org.apache.pulsar.common.naming.TopicName.<init>(TopicName.java:117) ~[org.apache.pulsar-pulsar-common-2.9.1.jar:2.9.1]
	at org.apache.pulsar.common.naming.TopicName.<init>(TopicName.java:36) ~[org.apache.pulsar-pulsar-common-2.9.1.jar:2.9.1]
	at org.apache.pulsar.common.naming.TopicName$1.load(TopicName.java:59) ~[org.apache.pulsar-pulsar-common-2.9.1.jar:2.9.1]
	at org.apache.pulsar.common.naming.TopicName$1.load(TopicName.java:56) ~[org.apache.pulsar-pulsar-common-2.9.1.jar:2.9.1]
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529) ~[com.google.guava-guava-30.1-jre.jar:?]
```

### Modifications

- Encode MQTT topic name to pulsar topic name.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 
