### PR TITLE
Support auto create topic affects by namespace policy.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
@@ -38,6 +38,7 @@ import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
 import org.apache.pulsar.common.util.FutureUtil;
 
 /**
@@ -52,8 +53,22 @@ public class PulsarTopicUtils {
                                                                        String defaultTenant, String defaultNamespace,
                                                                        boolean encodeTopicName,
                                                                        String defaultTopicDomain) {
-        return getTopicReference(pulsarService, topicName, defaultTenant, defaultNamespace, encodeTopicName,
-                defaultTopicDomain, pulsarService.getConfig().isAllowAutoTopicCreation());
+        return wrappedGetTopicName(topicName, defaultTenant, defaultNamespace, encodeTopicName, defaultTopicDomain)
+                .thenCompose(topic -> pulsarService.getPulsarResources().getNamespaceResources()
+                        .getPoliciesAsync(topic.getNamespaceObject())
+                        .thenApply(policies -> {
+                            if (!policies.isPresent()) {
+                                return pulsarService.getConfig().isAllowAutoTopicCreation();
+                            }
+                            AutoTopicCreationOverride autoTopicCreationOverride =
+                                    policies.get().autoTopicCreationOverride;
+                            if (autoTopicCreationOverride == null) {
+                                return pulsarService.getConfig().isAllowAutoTopicCreation();
+                            } else {
+                                return autoTopicCreationOverride.isAllowAutoTopicCreation();
+                            }
+                        }).thenCompose(isAllowTopicCreation ->
+                                getTopicReference(pulsarService, topic, isAllowTopicCreation)));
     }
 
     public static CompletableFuture<Optional<Topic>> getTopicReference(PulsarService pulsarService, String topicName,
@@ -61,13 +76,12 @@ public class PulsarTopicUtils {
                                                                        boolean encodeTopicName,
                                                                        String defaultTopicDomain,
                                                                        Boolean createIfMissing) {
-        final TopicName topic;
-        try {
-            topic = TopicName.get(getPulsarTopicName(topicName, defaultTenant, defaultNamespace, encodeTopicName,
-                    TopicDomain.getEnum(defaultTopicDomain)));
-        } catch (Exception e) {
-            return FutureUtil.failedFuture(e);
-        }
+        return wrappedGetTopicName(topicName, defaultTenant, defaultNamespace, encodeTopicName, defaultTopicDomain)
+                .thenCompose(topic -> getTopicReference(pulsarService, topic, createIfMissing));
+    }
+
+    public static CompletableFuture<Optional<Topic>> getTopicReference(PulsarService pulsarService, TopicName topic,
+                                                                       Boolean createIfMissing) {
         return pulsarService.getNamespaceService().getBrokerServiceUrlAsync(topic,
                         LookupOptions.builder().authoritative(false).loadTopicsInBundle(false).build())
                 .thenCompose(lookupOp -> pulsarService.getBrokerService().getTopic(topic.toString(), createIfMissing));
@@ -229,6 +243,19 @@ public class PulsarTopicUtils {
                     + URLDecoder.decode(topicName.getLocalName());
         } else {
             return URLDecoder.decode(TopicName.get(pulsarTopicName).getLocalName());
+        }
+    }
+
+    public static CompletableFuture<TopicName> wrappedGetTopicName(String topicName, String defaultTenant,
+                                                                     String defaultNamespace, boolean encodeTopicName,
+                                                                     String defaultTopicDomain) {
+        try {
+            return CompletableFuture.completedFuture(
+                    TopicName.get(
+                            getPulsarTopicName(topicName, defaultTenant, defaultNamespace, encodeTopicName,
+                                TopicDomain.getEnum(defaultTopicDomain))));
+        } catch (Exception e) {
+            return FutureUtil.failedFuture(e);
         }
     }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
@@ -53,7 +53,7 @@ public class PulsarTopicUtils {
                                                                        String defaultTenant, String defaultNamespace,
                                                                        boolean encodeTopicName,
                                                                        String defaultTopicDomain) {
-        return wrappedGetTopicName(topicName, defaultTenant, defaultNamespace, encodeTopicName, defaultTopicDomain)
+        return getTopicName(topicName, defaultTenant, defaultNamespace, encodeTopicName, defaultTopicDomain)
                 .thenCompose(topic -> pulsarService.getPulsarResources().getNamespaceResources()
                         .getPoliciesAsync(topic.getNamespaceObject())
                         .thenApply(policies -> {
@@ -76,7 +76,7 @@ public class PulsarTopicUtils {
                                                                        boolean encodeTopicName,
                                                                        String defaultTopicDomain,
                                                                        Boolean createIfMissing) {
-        return wrappedGetTopicName(topicName, defaultTenant, defaultNamespace, encodeTopicName, defaultTopicDomain)
+        return getTopicName(topicName, defaultTenant, defaultNamespace, encodeTopicName, defaultTopicDomain)
                 .thenCompose(topic -> getTopicReference(pulsarService, topic, createIfMissing));
     }
 
@@ -246,9 +246,9 @@ public class PulsarTopicUtils {
         }
     }
 
-    public static CompletableFuture<TopicName> wrappedGetTopicName(String topicName, String defaultTenant,
-                                                                     String defaultNamespace, boolean encodeTopicName,
-                                                                     String defaultTopicDomain) {
+    public static CompletableFuture<TopicName> getTopicName(String topicName, String defaultTenant,
+                                                            String defaultNamespace, boolean encodeTopicName,
+                                                            String defaultTopicDomain) {
         try {
             return CompletableFuture.completedFuture(
                     TopicName.get(


### PR DESCRIPTION
Fixes #540

Master Issue: 540

### Motivation

The current auto-create topic is just affected by broker configuration, this PR support can be affected by namespace policy.

### Modifications

- Add logic that gets policy to determine whether to automatically create a topic.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation
  
- [x] `no-need-doc` 

