### PR TITLE
[MIP-5] Introduce event centre

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTCommonConfiguration.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTCommonConfiguration.java
@@ -304,4 +304,10 @@ public class MQTTCommonConfiguration extends ServiceConfiguration {
             doc = "Max length for per message."
     )
     private int mqttMessageMaxLength = 8092;
+
+    @FieldContext(
+            category = CATEGORY_MQTT,
+            doc = "Event center callback pool size."
+    )
+    private int eventCenterCallbackPoolTreadNum = 10;
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTService.java
@@ -13,6 +13,9 @@
  */
 package io.streamnative.pulsar.handlers.mqtt;
 
+import io.streamnative.pulsar.handlers.mqtt.event.DisableEventCenter;
+import io.streamnative.pulsar.handlers.mqtt.event.PulsarEventCenter;
+import io.streamnative.pulsar.handlers.mqtt.event.PulsarEventCenterImpl;
 import io.streamnative.pulsar.handlers.mqtt.support.MQTTMetricsCollector;
 import io.streamnative.pulsar.handlers.mqtt.support.MQTTMetricsProvider;
 import lombok.Getter;
@@ -57,6 +60,9 @@ public class MQTTService {
     @Getter
     private final MQTTNamespaceBundleOwnershipListener bundleOwnershipListener;
 
+    @Getter
+    private final PulsarEventCenter eventCenter;
+
     public MQTTService(BrokerService brokerService, MQTTServerConfiguration serverConfiguration) {
         this.brokerService = brokerService;
         this.pulsarService = brokerService.pulsar();
@@ -71,5 +77,10 @@ public class MQTTService {
                 serverConfiguration.getMqttAuthenticationMethods()) : null;
         this.connectionManager = new MQTTConnectionManager();
         this.subscriptionManager = new MQTTSubscriptionManager();
+        if (getServerConfiguration().isMqttProxyEnabled()) {
+            this.eventCenter = new DisableEventCenter();
+        } else {
+            this.eventCenter = new PulsarEventCenterImpl(brokerService, serverConfiguration);
+        }
     }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/event/DisableEventCenter.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/event/DisableEventCenter.java
@@ -1,0 +1,18 @@
+package io.streamnative.pulsar.handlers.mqtt.event;
+
+public class DisableEventCenter implements PulsarEventCenter {
+    @Override
+    public void register(PulsarEventListener listener) {
+        throw new UnsupportedOperationException("Unsupported operation.");
+    }
+
+    @Override
+    public void unRegister(PulsarEventListener listener) {
+        throw new UnsupportedOperationException("Unsupported operation.");
+    }
+
+    @Override
+    public void shutdown() {
+        throw new UnsupportedOperationException("Unsupported operation.");
+    }
+}

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/event/PulsarEventCenter.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/event/PulsarEventCenter.java
@@ -1,0 +1,10 @@
+package io.streamnative.pulsar.handlers.mqtt.event;
+
+public interface PulsarEventCenter {
+
+    void register(PulsarEventListener listener);
+
+    void unRegister(PulsarEventListener listener);
+
+    void shutdown();
+}

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/event/PulsarEventCenterImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/event/PulsarEventCenterImpl.java
@@ -1,0 +1,60 @@
+package io.streamnative.pulsar.handlers.mqtt.event;
+
+import io.streamnative.pulsar.handlers.mqtt.MQTTServerConfiguration;
+import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.metadata.api.Notification;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+public class PulsarEventCenterImpl implements Consumer<Notification>, PulsarEventCenter {
+    private final List<PulsarEventListener> listeners;
+    private final ExecutorService callbackExecutor;
+
+    @SuppressWarnings("UnstableApiUsage")
+    public PulsarEventCenterImpl(BrokerService brokerService, MQTTServerConfiguration serverConfiguration) {
+        this.listeners = Collections.synchronizedList(new ArrayList<>());
+        this.callbackExecutor =
+                Executors.newFixedThreadPool(serverConfiguration.getEventCenterCallbackPoolTreadNum());
+        brokerService.getPulsar()
+                .getConfigurationMetadataStore().registerListener(this);
+    }
+
+
+    @Override
+    public void register(PulsarEventListener listener) {
+        listeners.add(listener);
+    }
+
+    @Override
+    public void unRegister(PulsarEventListener listener) {
+        listeners.remove(listener);
+    }
+
+    @Override
+    public void shutdown() {
+        callbackExecutor.shutdown();
+    }
+
+    @Override
+    public void accept(Notification notification) {
+        String path = notification.getPath();
+        List<PulsarEventListener> needNotifyListener =
+                listeners.stream().filter(listeners -> listeners.matchPath(path)).collect(Collectors.toList());
+        callbackExecutor.execute(() -> needNotifyListener.parallelStream()
+                .forEach(listener -> callbackExecutor.execute(() -> {
+                    switch (notification.getType()) {
+                        case Created:
+                            listener.onNodeCreated(path);
+                            break;
+                        case Deleted:
+                            listener.onNodeDeleted(path);
+                            break;
+                    }
+                })));
+    }
+}

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/event/PulsarEventListener.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/event/PulsarEventListener.java
@@ -1,0 +1,10 @@
+package io.streamnative.pulsar.handlers.mqtt.event;
+
+public interface PulsarEventListener {
+
+    boolean matchPath(String path);
+
+    void onNodeCreated(String path);
+
+    void onNodeDeleted(String path);
+}

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/event/PulsarTopicChangeListener.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/event/PulsarTopicChangeListener.java
@@ -1,0 +1,43 @@
+package io.streamnative.pulsar.handlers.mqtt.event;
+
+import io.streamnative.pulsar.handlers.mqtt.utils.EventParserUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.pulsar.broker.resources.TopicResources;
+import org.apache.pulsar.common.naming.TopicName;
+import java.util.regex.Pattern;
+
+public interface PulsarTopicChangeListener extends PulsarEventListener {
+    String MANAGED_LEDGER_PATH = "/managed-ledgers";
+    String REGEX = MANAGED_LEDGER_PATH + "/" + ".*" + "/persistent/";
+    Pattern PATTERN = Pattern.compile(REGEX);
+
+    @Override
+    default boolean matchPath(String path) {
+        String listenNamespace = getListenNamespace();
+        if (!StringUtils.isEmpty(listenNamespace)){
+            return path.startsWith(MANAGED_LEDGER_PATH + "/" + listenNamespace + "/persistent/");
+        } else {
+            return PATTERN.matcher(path).find();
+        }
+    }
+
+    default String getListenNamespace() {
+        return "";
+    }
+
+    @Override
+    default void onNodeCreated(String path) {
+        TopicName topicName = EventParserUtils.parseFromManagedLedgerEvent(path);
+        onTopicLoad(topicName);
+    }
+
+    @Override
+    default void onNodeDeleted(String path) {
+        TopicName topicName = EventParserUtils.parseFromManagedLedgerEvent(path);
+        onTopicUnload(topicName);
+    };
+
+    void onTopicLoad(TopicName topicName);
+
+    void onTopicUnload(TopicName topicName);
+}

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/EventParserUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/EventParserUtils.java
@@ -1,0 +1,15 @@
+package io.streamnative.pulsar.handlers.mqtt.utils;
+
+import org.apache.pulsar.common.naming.TopicName;
+
+public class EventParserUtils {
+    public static TopicName parseFromManagedLedgerEvent(String path) {
+        // managed-ledgers/public/default/persistent/topicName
+        String[] pathArr = path.split("/");
+        String tenant = pathArr[2];
+        String namespace = pathArr[3];
+        String topicDomain = pathArr[4];
+        String topicName = pathArr[5];
+        return TopicName.get(topicDomain, tenant, namespace, topicName);
+    }
+}

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
@@ -211,10 +211,14 @@ public class PulsarTopicUtils {
                 ).orElseGet(()-> CompletableFuture.completedFuture(Collections.emptyList()));
     }
 
+    public static boolean isRegexFilter(String topicFilter) {
+        return topicFilter.contains(TopicFilter.SINGLE_LEVEL)
+                || topicFilter.contains(TopicFilter.MULTI_LEVEL);
+    }
+
     public static CompletableFuture<List<String>> asyncGetTopicListFromTopicSubscription(String topicFilter,
          String defaultTenant, String defaultNamespace, PulsarService pulsarService, String defaultTopicDomain) {
-        if (topicFilter.contains(TopicFilter.SINGLE_LEVEL)
-                || topicFilter.contains(TopicFilter.MULTI_LEVEL)) {
+        if (isRegexFilter(topicFilter)) {
             TopicFilter filter = PulsarTopicUtils.getTopicFilter(topicFilter);
             Pair<TopicDomain, NamespaceName> domainNamespacePair =
                     PulsarTopicUtils

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/EventCenterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/EventCenterTest.java
@@ -1,0 +1,48 @@
+package io.streamnative.pulsar.handlers.mqtt.base;
+
+import io.streamnative.pulsar.handlers.mqtt.MQTTProtocolHandler;
+import io.streamnative.pulsar.handlers.mqtt.event.PulsarEventCenter;
+import io.streamnative.pulsar.handlers.mqtt.event.PulsarTopicChangeListener;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.protocol.ProtocolHandler;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.common.naming.TopicName;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+@Test
+public class EventCenterTest extends MQTTTestBase {
+
+    public void testReceiveNotification() throws PulsarAdminException, InterruptedException, ExecutionException {
+        String topicName = "persistent://public/default/testEventCenter";
+        List<PulsarService> pulsarServiceList = getPulsarServiceList();
+        PulsarService pulsarService = pulsarServiceList.get(0);
+        ProtocolHandler mqtt = pulsarService.getProtocolHandlers().protocol("mqtt");
+        MQTTProtocolHandler protocolHandler = (MQTTProtocolHandler) mqtt;
+        PulsarEventCenter eventCenter = protocolHandler.getMqttService().getEventCenter();
+        CompletableFuture<String> onLoadEvent = new CompletableFuture<>();
+        CompletableFuture<String> unLoadEvent = new CompletableFuture<>();
+        eventCenter.register(new PulsarTopicChangeListener() {
+
+            @Override
+            public void onTopicLoad(TopicName topicName) {
+                onLoadEvent.complete(topicName.toString());
+            }
+
+            @Override
+            public void onTopicUnload(TopicName topicName) {
+                unLoadEvent.complete(topicName.toString());
+            }
+        });
+
+        admin.topics().createNonPartitionedTopic(topicName);
+        Assert.assertEquals(onLoadEvent.get(), topicName);
+        admin.topics().delete(topicName);
+        Assert.assertEquals(unLoadEvent.get(), topicName);
+    }
+
+
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/EventCenterWithProxyTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/EventCenterWithProxyTest.java
@@ -1,0 +1,49 @@
+package io.streamnative.pulsar.handlers.mqtt.base;
+
+import io.streamnative.pulsar.handlers.mqtt.MQTTProtocolHandler;
+import io.streamnative.pulsar.handlers.mqtt.MQTTServerConfiguration;
+import io.streamnative.pulsar.handlers.mqtt.event.DisableEventCenter;
+import io.streamnative.pulsar.handlers.mqtt.event.PulsarEventCenter;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.protocol.ProtocolHandler;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import java.util.List;
+
+@Test
+public class EventCenterWithProxyTest extends MQTTTestBase {
+
+    @Override
+    public MQTTServerConfiguration initConfig() throws Exception {
+        MQTTServerConfiguration conf = super.initConfig();
+        conf.setMqttProxyEnabled(true);
+        return conf;
+    }
+
+    public void testDisableBrokerEventCenter() {
+        List<PulsarService> pulsarServiceList = getPulsarServiceList();
+        PulsarService pulsarService = pulsarServiceList.get(0);
+        ProtocolHandler mqtt = pulsarService.getProtocolHandlers().protocol("mqtt");
+        MQTTProtocolHandler protocolHandler = (MQTTProtocolHandler) mqtt;
+        PulsarEventCenter eventCenter = protocolHandler.getMqttService().getEventCenter();
+        Assert.assertTrue(eventCenter instanceof DisableEventCenter);
+        try {
+            eventCenter.register(null);
+            Assert.fail("Unexpected result");
+        } catch (UnsupportedOperationException ex) {
+            // expected result
+        }
+        try {
+            eventCenter.unRegister(null);
+            Assert.fail("Unexpected result");
+        } catch (UnsupportedOperationException ex) {
+            // expected result
+        }
+        try {
+            eventCenter.shutdown();
+            Assert.fail("Unexpected result");
+        } catch (UnsupportedOperationException ex) {
+            // expected result
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

see #562 

### Modifications

- Register listener to pulsar metadata.
- Support using ``PulsarTopicChangeListener`` listen ``persistent`` topic life cycle event.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 
  
