### PR TITLE
Support unique client id in MoP cluster.

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,6 @@ Please refer [here](docs/mop-configuration.md)
 ## Declarations
 
 Currently, MoP has the following implementations that do not meet the MQTT Spec:
-- The MQTT spec calls for terminating existing clients with the same ClientID on `CONNECT`. But MoP only implements on proxy or broker side, not across cluster. 
 - `Last Will` implements not across cluster.
 
 ## Project maintainers

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTConnectionManager.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTConnectionManager.java
@@ -54,9 +54,7 @@ public class MQTTConnectionManager {
     public void addConnection(Connection connection) {
         Connection existing = connections.put(connection.getClientId(), connection);
         if (existing != null) {
-            if (log.isDebugEnabled()) {
-                log.debug("The clientId is existed. Close existing connection. CId={}", existing.getClientId());
-            }
+            log.warn("The clientId is existed. Close existing connection. CId={}", existing.getClientId());
             existing.close(true)
                     .exceptionally(ex -> {
                         log.error("close existing connection : {} error", existing, ex);
@@ -104,9 +102,7 @@ public class MQTTConnectionManager {
                 if (!connectEvent.getAddress().equals(advertisedAddress)) {
                     Connection connection = getConnection(connectEvent.getClientId());
                     if (connection != null) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[ConnectEvent] close existing connection : {}", connection);
-                        }
+                        log.warn("[ConnectEvent] close existing connection : {}", connection);
                         connection.close(true)
                                 .thenRun(() -> removeConnection(connection))
                                 .exceptionally(ex -> {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTConnectionManager.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTConnectionManager.java
@@ -13,9 +13,13 @@
  */
 package io.streamnative.pulsar.handlers.mqtt;
 
+import static io.streamnative.pulsar.handlers.mqtt.support.systemtopic.EventType.CONNECT;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timeout;
 import io.netty.util.concurrent.DefaultThreadFactory;
+import io.streamnative.pulsar.handlers.mqtt.support.systemtopic.ConnectEvent;
+import io.streamnative.pulsar.handlers.mqtt.support.systemtopic.EventListener;
+import io.streamnative.pulsar.handlers.mqtt.support.systemtopic.MqttEvent;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -36,8 +40,15 @@ public class MQTTConnectionManager {
             new HashedWheelTimer(
                     new DefaultThreadFactory("session-expire-interval"), 1, TimeUnit.SECONDS);
 
-    public MQTTConnectionManager() {
+    @Getter
+    private final EventListener eventListener;
+
+    private final String advertisedAddress;
+
+    public MQTTConnectionManager(String advertisedAddress) {
+        this.advertisedAddress = advertisedAddress;
         this.connections = new ConcurrentHashMap<>(2048);
+        this.eventListener = new ConnectEventListener();
     }
 
     public void addConnection(Connection connection) {
@@ -81,5 +92,30 @@ public class MQTTConnectionManager {
 
     public Connection getConnection(String clientId) {
         return connections.get(clientId);
+    }
+
+
+    class ConnectEventListener implements EventListener {
+
+        @Override
+        public void onChange(MqttEvent event) {
+            if (event.getEventType() == CONNECT) {
+                ConnectEvent connectEvent = (ConnectEvent) event.getSourceEvent();
+                if (!connectEvent.getAddress().equals(advertisedAddress)) {
+                    Connection connection = getConnection(connectEvent.getClientId());
+                    if (connection != null) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("[ConnectEvent] close existing connection : {}", connection);
+                        }
+                        connection.close(true)
+                                .thenRun(() -> removeConnection(connection))
+                                .exceptionally(ex -> {
+                                    log.error("[ConnectEvent] close existing connection : {} error", connection, ex);
+                                    return null;
+                                });
+                    }
+                }
+            }
+        }
     }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTService.java
@@ -75,7 +75,7 @@ public class MQTTService {
         this.authenticationService = serverConfiguration.isMqttAuthenticationEnabled()
             ? new MQTTAuthenticationService(brokerService.getAuthenticationService(),
                 serverConfiguration.getMqttAuthenticationMethods()) : null;
-        this.connectionManager = new MQTTConnectionManager();
+        this.connectionManager = new MQTTConnectionManager(pulsarService.getAdvertisedAddress());
         this.subscriptionManager = new MQTTSubscriptionManager();
         if (getServerConfiguration().isMqttProxyEnabled()) {
             this.eventCenter = new DisableEventCenter();

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyService.java
@@ -68,7 +68,7 @@ public class MQTTProxyService implements Closeable {
                 ? new SystemTopicBasedSystemEventService(mqttService.getPulsarService()) :
                 new DisabledSystemEventService();
 
-        this.connectionManager = new MQTTConnectionManager();
+        this.connectionManager = new MQTTConnectionManager(pulsarService.getAdvertisedAddress());
         this.acceptorGroup = EventLoopUtil.newEventLoopGroup(proxyConfig.getMqttProxyNumAcceptorThreads(),
                 false, acceptorThreadFactory);
         this.workerGroup = EventLoopUtil.newEventLoopGroup(proxyConfig.getMqttProxyNumIOThreads(),
@@ -119,6 +119,7 @@ public class MQTTProxyService implements Closeable {
         }
 
         this.lookupHandler = new PulsarServiceLookupHandler(pulsarService, proxyConfig);
+        this.eventService.addListener(connectionManager.getEventListener());
         this.eventService.start();
     }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/handler/MqttV5AckHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/handler/MqttV5AckHandler.java
@@ -22,7 +22,6 @@ import io.streamnative.pulsar.handlers.mqtt.messages.ack.PublishAck;
 import io.streamnative.pulsar.handlers.mqtt.messages.ack.SubscribeAck;
 import io.streamnative.pulsar.handlers.mqtt.messages.ack.UnsubscribeAck;
 import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5ConnReasonCode;
-import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5DisConnReasonCode;
 import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5PubReasonCode;
 import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5UnsubReasonCode;
 import io.streamnative.pulsar.handlers.mqtt.messages.factory.MqttConnectAckHelper;
@@ -73,7 +72,7 @@ public class MqttV5AckHandler extends AbstractAckHandler {
     MqttMessage getDisconnectAckMessage(Connection connection, DisconnectAck disconnectAck) {
         // Now this section same to V3, but Mqtt V5 has another different feature that will be supported in the future.
         return MqttDisconnectAckMessageHelper.builder()
-                .reasonCode(Mqtt5DisConnReasonCode.NORMAL.byteValue())
+                .reasonCode(disconnectAck.getReasonCode().byteValue())
                 .build();
     }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/ConnectEvent.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/ConnectEvent.java
@@ -26,5 +26,5 @@ public class ConnectEvent extends SourceEvent {
 
     private String clientId;
 
-    private String ip;
+    private String address;
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/DisabledSystemEventService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/DisabledSystemEventService.java
@@ -29,12 +29,12 @@ public class DisabledSystemEventService implements SystemEventService{
     }
 
     @Override
-    public CompletableFuture<Void> sendConnectEvent(Connection connection) {
-        return CompletableFuture.completedFuture(null);
+    public void addListener(EventListener listener) {
+        // NOP
     }
 
     @Override
-    public CompletableFuture<Void> sendDisconnectEvent(Connection connection) {
+    public CompletableFuture<Void> sendConnectEvent(Connection connection) {
         return CompletableFuture.completedFuture(null);
     }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/SystemEventService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/SystemEventService.java
@@ -22,9 +22,9 @@ public interface SystemEventService {
 
     void close();
 
-    CompletableFuture<Void> sendConnectEvent(Connection connection);
+    void addListener(EventListener listener);
 
-    CompletableFuture<Void> sendDisconnectEvent(Connection connection);
+    CompletableFuture<Void> sendConnectEvent(Connection connection);
 
     CompletableFuture<Void> sendEvent(MqttEvent event);
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTTestBase.java
@@ -145,9 +145,7 @@ public class MQTTTestBase extends MQTTProtocolHandlerTestBase {
 
     public MQTT createMQTTClient() throws URISyntaxException {
         List<Integer> mqttBrokerPortList = getMqttBrokerPortList();
-        MQTT mqtt = new MQTT();
-        mqtt.setHost("127.0.0.1", mqttBrokerPortList.get(random.nextInt(mqttBrokerPortList.size())));
-        return mqtt;
+        return createMQTT(mqttBrokerPortList.get(random.nextInt(mqttBrokerPortList.size())));
     }
 
     public MQTT createMQTTTlsClient() throws URISyntaxException {
@@ -160,8 +158,12 @@ public class MQTTTestBase extends MQTTProtocolHandlerTestBase {
 
     public MQTT createMQTTProxyClient() throws URISyntaxException {
         List<Integer> mqttProxyPortList = getMqttProxyPortList();
-        MQTT mqtt = createMQTTClient();
-        mqtt.setHost("127.0.0.1", mqttProxyPortList.get(random.nextInt(mqttProxyPortList.size())));
+        return createMQTT(mqttProxyPortList.get(random.nextInt(mqttProxyPortList.size())));
+    }
+
+    public MQTT createMQTT(int port) throws URISyntaxException {
+        MQTT mqtt = new MQTT();
+        mqtt.setHost("127.0.0.1", port);
         return mqtt;
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTTestBase.java
@@ -145,7 +145,9 @@ public class MQTTTestBase extends MQTTProtocolHandlerTestBase {
 
     public MQTT createMQTTClient() throws URISyntaxException {
         List<Integer> mqttBrokerPortList = getMqttBrokerPortList();
-        return createMQTT(mqttBrokerPortList.get(random.nextInt(mqttBrokerPortList.size())));
+        MQTT mqtt = new MQTT();
+        mqtt.setHost("127.0.0.1", mqttBrokerPortList.get(random.nextInt(mqttBrokerPortList.size())));
+        return mqtt;
     }
 
     public MQTT createMQTTTlsClient() throws URISyntaxException {
@@ -158,7 +160,9 @@ public class MQTTTestBase extends MQTTProtocolHandlerTestBase {
 
     public MQTT createMQTTProxyClient() throws URISyntaxException {
         List<Integer> mqttProxyPortList = getMqttProxyPortList();
-        return createMQTT(mqttProxyPortList.get(random.nextInt(mqttProxyPortList.size())));
+        MQTT mqtt = createMQTTClient();
+        mqtt.setHost("127.0.0.1", mqttProxyPortList.get(random.nextInt(mqttProxyPortList.size())));
+        return mqtt;
     }
 
     public MQTT createMQTT(int port) throws URISyntaxException {


### PR DESCRIPTION
Master Issue: #409

### Motivation

As #560 has introduced system topic, this patch is supporting unique client id in MoP cluster.



### Documentation

- [x] `doc-required` 

Update related doc together.  

