### PR TITLE
Close MoP resource when protocol handler close.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTConnectionManager.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTConnectionManager.java
@@ -92,6 +92,9 @@ public class MQTTConnectionManager {
         return connections.get(clientId);
     }
 
+    public void close() {
+        connections.values().forEach(connection -> connection.close());
+    }
 
     class ConnectEventListener implements EventListener {
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTProtocolHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTProtocolHandler.java
@@ -141,7 +141,7 @@ public class MQTTProtocolHandler implements ProtocolHandler {
             }
 
             return builder.build();
-        } catch (Exception e){
+        } catch (Exception e) {
             log.error("MQTTProtocolHandler newChannelInitializers failed with", e);
             return null;
         }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTService.java
@@ -101,5 +101,9 @@ public class MQTTService {
 
     public void close() {
         this.connectionManager.close();
+        this.eventCenter.shutdown();
+        if (eventService != null) {
+            eventService.close();
+        }
     }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTService.java
@@ -98,4 +98,8 @@ public class MQTTService {
     public boolean isSystemTopicEnabled() {
         return eventService != null;
     }
+
+    public void close() {
+        this.connectionManager.close();
+    }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyService.java
@@ -135,9 +135,10 @@ public class MQTTProxyService implements Closeable {
         if (listenChannelTlsPsk != null) {
             listenChannelTlsPsk.close();
         }
+        this.acceptorGroup.shutdownGracefully();
+        this.workerGroup.shutdownGracefully();
         this.eventService.close();
-        lookupHandler.close();
-        acceptorGroup.shutdownGracefully();
-        workerGroup.shutdownGracefully();
+        this.lookupHandler.close();
+        this.connectionManager.close();
     }
 }


### PR DESCRIPTION
Fixes #520 

Master Issue: #520 

### Motivation

When protocol handler close, MoP should close gracefully.

### Modifications

### Documentation
  
- [x] `no-need-doc` 


