### PR TITLE
Fix NPE caused by the connection doesn't init complete then invoke close.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
@@ -97,7 +97,6 @@ public class Connection {
         this.userRole = builder.userRole;
         this.channel = builder.channel;
         this.manager = builder.connectionManager;
-        this.manager.addConnection(this);
         this.connectMessage = builder.connectMessage;
         this.ackHandler = AckHandlerFactory.of(protocolVersion).getAckHandler();
         this.channel.attr(ATTR_KEY_CONNECTION).set(this);
@@ -105,6 +104,7 @@ public class Connection {
         this.addIdleStateHandler();
         this.eventCenter = builder.eventCenter;
         this.listeners = Collections.synchronizedList(new ArrayList<>());
+        this.manager.addConnection(this);
     }
 
     private void addIdleStateHandler() {
@@ -155,8 +155,8 @@ public class Connection {
 
     public CompletableFuture<Void> close(boolean force) {
         log.info("Closing connection clientId = {} force : {}", clientId, force);
-        assignState(ESTABLISHED, DISCONNECTED);
         if (force) {
+            assignState(ESTABLISHED, DISCONNECTED);
             if (MqttUtils.isMqtt5(protocolVersion)) {
                 MqttMessage mqttMessage = MqttMessageBuilders
                         .disconnect()


### PR DESCRIPTION
### Motivation

Relative issue #579 

The connection will throw NPE when the connection doesn't init complete then to invoke close.

Relative code as below:

https://github.com/streamnative/mop/blob/9022ce42ecfde5d63706f9ecbe7de2bcc92e5d06/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java#L91-L108

https://github.com/streamnative/mop/blob/9022ce42ecfde5d63706f9ecbe7de2bcc92e5d06/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java#L156-L173

When thread A creates a connection, just after invoking the `this.manager.addConnection(this)` method, thread B gets this connection and invokes the `close` method, which will throw NPE because the listener is not initialized.

### Modifications

- Move `this.manager.addConnection(this)` method to end of the constructor.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 

