### PR TITLE
Support retained message semantics.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/AbstractQosPublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/AbstractQosPublishHandler.java
@@ -17,6 +17,7 @@ import static io.streamnative.pulsar.handlers.mqtt.utils.PulsarMessageConverter.
 import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.streamnative.pulsar.handlers.mqtt.exception.MQTTNoMatchingSubscriberException;
+import io.streamnative.pulsar.handlers.mqtt.support.RetainedMessageHandler;
 import io.streamnative.pulsar.handlers.mqtt.utils.MessagePublishContext;
 import io.streamnative.pulsar.handlers.mqtt.utils.PulsarTopicUtils;
 import java.util.Optional;
@@ -34,12 +35,14 @@ import org.apache.pulsar.common.util.FutureUtil;
 public abstract class AbstractQosPublishHandler implements QosPublishHandler {
 
     protected final PulsarService pulsarService;
+    protected final RetainedMessageHandler retainedMessageHandler;
     protected final MQTTServerConfiguration configuration;
     protected final Channel channel;
 
-    protected AbstractQosPublishHandler(PulsarService pulsarService, MQTTServerConfiguration configuration,
+    protected AbstractQosPublishHandler(MQTTService mqttService, MQTTServerConfiguration configuration,
                                         Channel channel) {
-        this.pulsarService = pulsarService;
+        this.pulsarService = mqttService.getPulsarService();
+        this.retainedMessageHandler = mqttService.getRetainedMessageHandler();
         this.configuration = configuration;
         this.channel = channel;
     }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTService.java
@@ -15,6 +15,7 @@ package io.streamnative.pulsar.handlers.mqtt;
 
 import io.streamnative.pulsar.handlers.mqtt.support.MQTTMetricsCollector;
 import io.streamnative.pulsar.handlers.mqtt.support.MQTTMetricsProvider;
+import io.streamnative.pulsar.handlers.mqtt.support.RetainedMessageHandler;
 import io.streamnative.pulsar.handlers.mqtt.support.WillMessageHandler;
 import io.streamnative.pulsar.handlers.mqtt.support.event.DisableEventCenter;
 import io.streamnative.pulsar.handlers.mqtt.support.event.PulsarEventCenter;
@@ -70,6 +71,9 @@ public class MQTTService {
     private final WillMessageHandler willMessageHandler;
 
     @Getter
+    private final RetainedMessageHandler retainedMessageHandler;
+
+    @Getter
     @Setter
     private SystemEventService eventService;
 
@@ -94,6 +98,7 @@ public class MQTTService {
                     serverConfiguration.getEventCenterCallbackPoolThreadNum());
         }
         this.willMessageHandler = new WillMessageHandler(this);
+        this.retainedMessageHandler = new RetainedMessageHandler(this);
     }
 
     public boolean isSystemTopicEnabled() {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -43,6 +43,7 @@ import io.streamnative.pulsar.handlers.mqtt.support.event.PulsarTopicChangeListe
 import io.streamnative.pulsar.handlers.mqtt.support.handler.AckHandler;
 import io.streamnative.pulsar.handlers.mqtt.support.systemtopic.ConnectEvent;
 import io.streamnative.pulsar.handlers.mqtt.support.systemtopic.SystemEventService;
+import io.streamnative.pulsar.handlers.mqtt.utils.MqttUtils;
 import io.streamnative.pulsar.handlers.mqtt.utils.NettyUtils;
 import io.streamnative.pulsar.handlers.mqtt.utils.PulsarTopicUtils;
 import java.net.InetSocketAddress;
@@ -249,7 +250,7 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
     private void registerTopicListener(MqttSubscribeMessage msg) {
         for (MqttTopicSubscription subscription : msg.payload().topicSubscriptions()) {
             String topicFilter = subscription.topicName();
-            if (PulsarTopicUtils.isRegexFilter(topicFilter)) {
+            if (MqttUtils.isRegexFilter(topicFilter)) {
                 connection.addTopicChangeListener(new PulsarTopicChangeListener() {
                     @Override
                     public void onTopicLoad(TopicName changedTopicName) {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyService.java
@@ -74,6 +74,7 @@ public class MQTTProxyService implements Closeable {
                 new DisabledSystemEventService();
         this.eventService.addListener(connectionManager.getEventListener());
         this.eventService.addListener(mqttService.getWillMessageHandler().getEventListener());
+        this.eventService.addListener(mqttService.getRetainedMessageHandler().getEventListener());
         mqttService.setEventService(eventService);
         this.acceptorGroup = EventLoopUtil.newEventLoopGroup(proxyConfig.getMqttProxyNumAcceptorThreads(),
                 false, acceptorThreadFactory);

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos0PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos0PublishHandler.java
@@ -17,21 +17,25 @@ import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.streamnative.pulsar.handlers.mqtt.AbstractQosPublishHandler;
 import io.streamnative.pulsar.handlers.mqtt.MQTTServerConfiguration;
+import io.streamnative.pulsar.handlers.mqtt.MQTTService;
+import io.streamnative.pulsar.handlers.mqtt.utils.MqttUtils;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.broker.PulsarService;
 /**
  * Publish handler implementation for Qos 0.
  */
 @Slf4j
 public class Qos0PublishHandler extends AbstractQosPublishHandler {
 
-    public Qos0PublishHandler(PulsarService pulsarService, MQTTServerConfiguration configuration, Channel channel) {
-        super(pulsarService, configuration, channel);
+    public Qos0PublishHandler(MQTTService mqttService, MQTTServerConfiguration configuration, Channel channel) {
+        super(mqttService, configuration, channel);
     }
 
     @Override
     public CompletableFuture<Void> publish(MqttPublishMessage msg) {
+        if (MqttUtils.isRetainedMessage(msg)) {
+            return retainedMessageHandler.addRetainedMessage(msg);
+        }
         return writeToPulsarTopic(msg).thenAccept(__ -> {});
     }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
@@ -18,6 +18,7 @@ import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.streamnative.pulsar.handlers.mqtt.AbstractQosPublishHandler;
 import io.streamnative.pulsar.handlers.mqtt.Connection;
 import io.streamnative.pulsar.handlers.mqtt.MQTTServerConfiguration;
+import io.streamnative.pulsar.handlers.mqtt.MQTTService;
 import io.streamnative.pulsar.handlers.mqtt.exception.MQTTNoMatchingSubscriberException;
 import io.streamnative.pulsar.handlers.mqtt.messages.ack.PublishAck;
 import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5PubReasonCode;
@@ -26,7 +27,6 @@ import io.streamnative.pulsar.handlers.mqtt.utils.MqttUtils;
 import io.streamnative.pulsar.handlers.mqtt.utils.NettyUtils;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.common.util.FutureUtil;
 
@@ -36,8 +36,8 @@ import org.apache.pulsar.common.util.FutureUtil;
 @Slf4j
 public class Qos1PublishHandler extends AbstractQosPublishHandler {
 
-    public Qos1PublishHandler(PulsarService pulsarService, MQTTServerConfiguration configuration, Channel channel) {
-        super(pulsarService, configuration, channel);
+    public Qos1PublishHandler(MQTTService mqttService, MQTTServerConfiguration configuration, Channel channel) {
+        super(mqttService, configuration, channel);
     }
 
     @Override
@@ -47,8 +47,14 @@ public class Qos1PublishHandler extends AbstractQosPublishHandler {
         final boolean isMqtt5 = MqttUtils.isMqtt5(protocolVersion);
         final int packetId = msg.variableHeader().packetId();
         final String topic = msg.variableHeader().topicName();
+        final CompletableFuture<Void> ret;
+        if (MqttUtils.isRetainedMessage(msg)) {
+            ret = retainedMessageHandler.addRetainedMessage(msg);
+        } else {
+            ret = writeToPulsarTopic(msg, isMqtt5).thenApply(__ -> null);
+        }
         // we need to check if subscription exist when protocol version is mqtt 5.x
-        return writeToPulsarTopic(msg, isMqtt5)
+        return ret
                 .thenCompose(__ -> {
                     PublishAck publishAck = PublishAck.builder()
                             .success(true)

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos2PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos2PublishHandler.java
@@ -17,9 +17,9 @@ import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.streamnative.pulsar.handlers.mqtt.AbstractQosPublishHandler;
 import io.streamnative.pulsar.handlers.mqtt.MQTTServerConfiguration;
+import io.streamnative.pulsar.handlers.mqtt.MQTTService;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.broker.PulsarService;
 
 /**
  * Publish handler implementation for Qos 2.
@@ -27,8 +27,8 @@ import org.apache.pulsar.broker.PulsarService;
 @Slf4j
 public class Qos2PublishHandler extends AbstractQosPublishHandler {
 
-    public Qos2PublishHandler(PulsarService pulsarService, MQTTServerConfiguration configuration, Channel channel) {
-        super(pulsarService, configuration, channel);
+    public Qos2PublishHandler(MQTTService mqttService, MQTTServerConfiguration configuration, Channel channel) {
+        super(mqttService, configuration, channel);
     }
 
     @Override

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/QosPublishHandlersImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/QosPublishHandlersImpl.java
@@ -15,9 +15,9 @@ package io.streamnative.pulsar.handlers.mqtt.support;
 
 import io.netty.channel.Channel;
 import io.streamnative.pulsar.handlers.mqtt.MQTTServerConfiguration;
+import io.streamnative.pulsar.handlers.mqtt.MQTTService;
 import io.streamnative.pulsar.handlers.mqtt.QosPublishHandler;
 import io.streamnative.pulsar.handlers.mqtt.QosPublishHandlers;
-import org.apache.pulsar.broker.PulsarService;
 
 /**
  * Default implementation of QosPublishHandlers.
@@ -28,10 +28,10 @@ public class QosPublishHandlersImpl implements QosPublishHandlers {
     private final QosPublishHandler qos1Handler;
     private final QosPublishHandler qos2Handler;
 
-    public QosPublishHandlersImpl(PulsarService pulsarService, MQTTServerConfiguration configuration, Channel channel) {
-        this.qos0Handler = new Qos0PublishHandler(pulsarService, configuration, channel);
-        this.qos1Handler = new Qos1PublishHandler(pulsarService, configuration, channel);
-        this.qos2Handler = new Qos2PublishHandler(pulsarService, configuration, channel);
+    public QosPublishHandlersImpl(MQTTService mqttService, MQTTServerConfiguration configuration, Channel channel) {
+        this.qos0Handler = new Qos0PublishHandler(mqttService, configuration, channel);
+        this.qos1Handler = new Qos1PublishHandler(mqttService, configuration, channel);
+        this.qos2Handler = new Qos2PublishHandler(mqttService, configuration, channel);
     }
 
     @Override

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/RetainedMessageHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/RetainedMessageHandler.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.support;
+
+import static io.streamnative.pulsar.handlers.mqtt.support.systemtopic.EventType.RETAINED_MESSAGE;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.streamnative.pulsar.handlers.mqtt.MQTTService;
+import io.streamnative.pulsar.handlers.mqtt.TopicFilterImpl;
+import io.streamnative.pulsar.handlers.mqtt.support.systemtopic.EventListener;
+import io.streamnative.pulsar.handlers.mqtt.support.systemtopic.MqttEvent;
+import io.streamnative.pulsar.handlers.mqtt.support.systemtopic.RetainedMessageEvent;
+import io.streamnative.pulsar.handlers.mqtt.utils.MqttMessageUtils;
+import io.streamnative.pulsar.handlers.mqtt.utils.MqttUtils;
+import io.streamnative.pulsar.handlers.mqtt.utils.RetainedMessage;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class RetainedMessageHandler {
+
+    @Getter
+    private final EventListener eventListener;
+    private final MQTTService mqttService;
+    private final Map<String, RetainedMessage> retainedMessages = new ConcurrentHashMap<>();
+
+    public RetainedMessageHandler(MQTTService mqttService) {
+        this.mqttService = mqttService;
+        this.eventListener = new RetainedMessageEventListener();
+    }
+
+    public CompletableFuture<Void> addRetainedMessage(MqttPublishMessage retainedMessage) {
+        if (mqttService.isSystemTopicEnabled()) {
+            RetainedMessageEvent event = RetainedMessageEvent
+                    .builder()
+                    .retainedMessage(MqttMessageUtils.createRetainedMessage(retainedMessage))
+                    .build();
+            mqttService.getEventService().sendRetainedEvent(event);
+        } else {
+            // Standalone mode
+            addRetainedMessage(MqttMessageUtils.createRetainedMessage(retainedMessage));
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+
+    public Optional<String> getRetainedTopic(String topic) {
+        if (MqttUtils.isRegexFilter(topic)) {
+            TopicFilterImpl topicFilter = new TopicFilterImpl(topic);
+            return retainedMessages.keySet().stream().filter(topicFilter::test).findFirst();
+        }
+        return retainedMessages.keySet().stream().filter(key -> key.equals(topic)).findFirst();
+    }
+
+    public RetainedMessage getRetainedMessage(String topic) {
+        return retainedMessages.get(topic);
+    }
+
+    private void addRetainedMessage(RetainedMessage msg) {
+        String topicName = msg.getTopic();
+        if (msg.getPayload().length == 0) {
+            retainedMessages.remove(topicName);
+        } else {
+            retainedMessages.put(topicName, msg);
+        }
+    }
+
+    class RetainedMessageEventListener implements EventListener {
+
+        @Override
+        public void onChange(MqttEvent event) {
+            if (event.getEventType() == RETAINED_MESSAGE) {
+                RetainedMessageEvent retainedEvent = (RetainedMessageEvent) event.getSourceEvent();
+                if (log.isDebugEnabled()) {
+                    log.debug("add retained message : {}", retainedEvent.getRetainedMessage());
+                }
+                addRetainedMessage(retainedEvent.getRetainedMessage());
+            }
+        }
+    }
+}

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/WillMessageHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/WillMessageHandler.java
@@ -80,6 +80,9 @@ public class WillMessageHandler {
             if (event.getEventType() == LAST_WILL_MESSAGE) {
                 LastWillMessageEvent lwtEvent = (LastWillMessageEvent) event.getSourceEvent();
                 if (!lwtEvent.getAddress().equals(advertisedAddress)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("fire will message : {}", lwtEvent.getWillMessage());
+                    }
                     fireWillMessage("", lwtEvent.getWillMessage());
                 }
             }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/DisabledSystemEventService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/DisabledSystemEventService.java
@@ -43,6 +43,11 @@ public class DisabledSystemEventService implements SystemEventService{
     }
 
     @Override
+    public CompletableFuture<Void> sendRetainedEvent(RetainedMessageEvent event) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
     public CompletableFuture<Void> sendEvent(MqttEvent event) {
         return CompletableFuture.completedFuture(null);
     }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/MqttEventUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/MqttEventUtils.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.support.systemtopic;
+
+import org.apache.bookkeeper.common.util.JsonUtil;
+
+/**
+ * Event message utils.
+ */
+public class MqttEventUtils {
+
+    public static MqttEvent getMqttEvent(LastWillMessageEvent event, ActionType actionType) {
+        MqttEvent.MqttEventBuilder builder = MqttEvent.builder();
+        try {
+            return builder
+                    .key(event.getClientId() + "-LWT")
+                    .eventType(EventType.LAST_WILL_MESSAGE)
+                    .actionType(actionType)
+                    .sourceEvent(JsonUtil.toJson(event))
+                    .build();
+        } catch (JsonUtil.ParseJsonException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public static MqttEvent getMqttEvent(RetainedMessageEvent event, ActionType actionType) {
+        MqttEvent.MqttEventBuilder builder = MqttEvent.builder();
+        try {
+            return builder
+                    .key(event.getRetainedMessage().getTopic())
+                    .eventType(EventType.RETAINED_MESSAGE)
+                    .actionType(actionType)
+                    .sourceEvent(JsonUtil.toJson(event))
+                    .build();
+        } catch (JsonUtil.ParseJsonException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public static MqttEvent getMqttEvent(ConnectEvent event, ActionType actionType) {
+        MqttEvent.MqttEventBuilder builder = MqttEvent.builder();
+        try {
+            return builder
+                    .key(event.getClientId())
+                    .eventType(EventType.CONNECT)
+                    .actionType(actionType)
+                    .sourceEvent(JsonUtil.toJson(event))
+                    .build();
+        } catch (JsonUtil.ParseJsonException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/RetainedMessageEvent.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/RetainedMessageEvent.java
@@ -13,8 +13,17 @@
  */
 package io.streamnative.pulsar.handlers.mqtt.support.systemtopic;
 
-public enum EventType {
-    CONNECT,
-    LAST_WILL_MESSAGE,
-    RETAINED_MESSAGE;
+import io.streamnative.pulsar.handlers.mqtt.utils.RetainedMessage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RetainedMessageEvent extends SourceEvent {
+
+    private RetainedMessage retainedMessage;
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/SystemEventService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/SystemEventService.java
@@ -27,5 +27,7 @@ public interface SystemEventService {
 
     CompletableFuture<Void> sendLWTEvent(LastWillMessageEvent event);
 
+    CompletableFuture<Void> sendRetainedEvent(RetainedMessageEvent event);
+
     CompletableFuture<Void> sendEvent(MqttEvent event);
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/SystemTopicBasedSystemEventService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/SystemTopicBasedSystemEventService.java
@@ -13,6 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.mqtt.support.systemtopic;
 
+import static io.streamnative.pulsar.handlers.mqtt.support.systemtopic.MqttEventUtils.getMqttEvent;
 import com.google.common.annotations.Beta;
 import java.util.ArrayList;
 import java.util.List;
@@ -88,6 +89,17 @@ public class SystemTopicBasedSystemEventService implements SystemEventService {
     }
 
     @Override
+    public CompletableFuture<Void> sendRetainedEvent(RetainedMessageEvent event) {
+        checkReader();
+        return sendEvent(getMqttEvent(event, ActionType.INSERT))
+                .thenRun(() -> {
+                    if (log.isDebugEnabled()) {
+                        log.debug("send retained event : {}", event);
+                    }
+                });
+    }
+
+    @Override
     public CompletableFuture<Void> sendEvent(MqttEvent event) {
         CompletableFuture<SystemTopicClient.Writer<MqttEvent>> writerFuture = systemTopicClient.newWriterAsync();
         return writerFuture.thenCompose(writer -> {
@@ -104,34 +116,6 @@ public class SystemTopicBasedSystemEventService implements SystemEventService {
             log.error("[{}] send event error.", SYSTEM_EVENT_TOPIC, ex);
             return null;
         });
-    }
-
-    private MqttEvent getMqttEvent(LastWillMessageEvent event, ActionType actionType) {
-        MqttEvent.MqttEventBuilder builder = MqttEvent.builder();
-        try {
-            return builder
-                    .key(event.getClientId() + "-LWT")
-                    .eventType(EventType.LAST_WILL_MESSAGE)
-                    .actionType(actionType)
-                    .sourceEvent(JsonUtil.toJson(event))
-                    .build();
-        } catch (JsonUtil.ParseJsonException e) {
-            throw new IllegalArgumentException(e);
-        }
-    }
-
-    private MqttEvent getMqttEvent(ConnectEvent event, ActionType actionType) {
-        MqttEvent.MqttEventBuilder builder = MqttEvent.builder();
-        try {
-            return builder
-                    .key(event.getClientId())
-                    .eventType(EventType.CONNECT)
-                    .actionType(actionType)
-                    .sourceEvent(JsonUtil.toJson(event))
-                    .build();
-        } catch (JsonUtil.ParseJsonException e) {
-            throw new IllegalArgumentException(e);
-        }
     }
 
     protected CompletableFuture<SystemTopicClient.Reader<MqttEvent>> createReader() {
@@ -226,6 +210,11 @@ public class SystemTopicBasedSystemEventService implements SystemEventService {
                     LastWillMessageEvent lwtEvent = JsonUtil.fromJson((String) value.getSourceEvent(),
                             LastWillMessageEvent.class);
                     value.setSourceEvent(lwtEvent);
+                    break;
+                case RETAINED_MESSAGE:
+                    RetainedMessageEvent retainedEvent = JsonUtil.fromJson((String) value.getSourceEvent(),
+                            RetainedMessageEvent.class);
+                    value.setSourceEvent(retainedEvent);
                     break;
                 default:
                     break;

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MqttUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/MqttUtils.java
@@ -14,8 +14,10 @@
 package io.streamnative.pulsar.handlers.mqtt.utils;
 
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.handler.codec.mqtt.MqttVersion;
+import io.streamnative.pulsar.handlers.mqtt.TopicFilter;
 
 /**
  * Some Mqtt protocol utilities.
@@ -48,5 +50,14 @@ public class MqttUtils {
         int willQos = msg.variableHeader().willQos();
         MqttQoS mqttQoS = MqttQoS.valueOf(willQos);
         return mqttQoS == MqttQoS.AT_LEAST_ONCE || mqttQoS == MqttQoS.AT_MOST_ONCE;
+    }
+
+    public static boolean isRetainedMessage(MqttPublishMessage msg) {
+        return msg.fixedHeader().isRetain();
+    }
+
+    public static boolean isRegexFilter(String topicFilter) {
+        return topicFilter.contains(TopicFilter.SINGLE_LEVEL)
+                || topicFilter.contains(TopicFilter.MULTI_LEVEL);
     }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarTopicUtils.java
@@ -13,6 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.mqtt.utils;
 
+import static io.streamnative.pulsar.handlers.mqtt.utils.MqttUtils.isRegexFilter;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
@@ -40,6 +41,7 @@ import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
 import org.apache.pulsar.common.util.FutureUtil;
+
 
 /**
  * Pulsar topic utils.
@@ -210,11 +212,6 @@ public class PulsarTopicUtils {
                         return topics;
                     })
                 ).orElseGet(()-> CompletableFuture.completedFuture(Collections.emptyList()));
-    }
-
-    public static boolean isRegexFilter(String topicFilter) {
-        return topicFilter.contains(TopicFilter.SINGLE_LEVEL)
-                || topicFilter.contains(TopicFilter.MULTI_LEVEL);
     }
 
     public static CompletableFuture<List<String>> asyncGetTopicListFromTopicSubscription(String topicFilter,

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/RetainedMessage.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/RetainedMessage.java
@@ -11,10 +11,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamnative.pulsar.handlers.mqtt.support.systemtopic;
+package io.streamnative.pulsar.handlers.mqtt.utils;
 
-public enum EventType {
-    CONNECT,
-    LAST_WILL_MESSAGE,
-    RETAINED_MESSAGE;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Retained Message.
+ */
+@Getter
+@Setter
+public class RetainedMessage {
+
+    String topic;
+    byte[] payload;
+    MqttQoS qos;
+
+    public RetainedMessage() {
+    }
+
+    public RetainedMessage(final String topic, final byte[] payload, final MqttQoS qos) {
+        this.topic = topic;
+        this.payload = payload;
+        this.qos = qos;
+    }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
@@ -668,4 +668,28 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         received.ack();
         connection.disconnect();
     }
+
+    @Test
+    public void testRetainedMessage() throws Exception {
+        String topicName = "persistent://public/default/a";
+        MQTT mqtt = createMQTTClient();
+        BlockingConnection connection = mqtt.blockingConnection();
+        connection.connect();
+        String message1 = "Retained Message";
+        String message2 = "Hello Message";
+        admin.topics().createNonPartitionedTopic(topicName);
+        Topic[] topics = { new Topic(topicName, QoS.AT_LEAST_ONCE) };
+        connection.publish(topicName, message1.getBytes(), QoS.AT_LEAST_ONCE, true);
+        connection.subscribe(topics);
+        connection.publish(topicName, message2.getBytes(), QoS.AT_LEAST_ONCE, false);
+        Message received1 = connection.receive(5, TimeUnit.SECONDS);
+        Assert.assertNotNull(received1);
+        received1.ack();
+        Assert.assertEquals(new String(received1.getPayload()), message1);
+        Message received2 = connection.receive(5, TimeUnit.SECONDS);
+        Assert.assertNotNull(received2);
+        received2.ack();
+        Assert.assertEquals(new String(received2.getPayload()), message2);
+        connection.disconnect();
+    }
 }


### PR DESCRIPTION
Fix #250.

### Motivation

Support retained message semantics in standalone and cluster.
In standalone mode, the retained message is stored in the memory, which means it may lose data when the broker restart.

### Documentation

- [x] `no-need-doc` 

