### PR TITLE
Change ``connection`` close logic to fix some potential probelms.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTConnectionManager.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTConnectionManager.java
@@ -55,11 +55,7 @@ public class MQTTConnectionManager {
         Connection existing = connections.put(connection.getClientId(), connection);
         if (existing != null) {
             log.warn("The clientId is existed. Close existing connection. CId={}", existing.getClientId());
-            existing.close(true)
-                    .exceptionally(ex -> {
-                        log.error("close existing connection : {} error", existing, ex);
-                        return null;
-                    });
+            existing.disconnect();
         }
     }
 
@@ -93,7 +89,7 @@ public class MQTTConnectionManager {
     }
 
     public void close() {
-        connections.values().forEach(connection -> connection.close());
+        connections.values().forEach(connection -> connection.getChannel().close());
     }
 
     class ConnectEventListener implements EventListener {
@@ -106,12 +102,7 @@ public class MQTTConnectionManager {
                     Connection connection = getConnection(connectEvent.getClientId());
                     if (connection != null) {
                         log.warn("[ConnectEvent] close existing connection : {}", connection);
-                        connection.close(true)
-                                .thenRun(() -> removeConnection(connection))
-                                .exceptionally(ex -> {
-                                    log.error("[ConnectEvent] close existing connection : {} error", connection, ex);
-                                    return null;
-                                });
+                        connection.disconnect();
                     }
                 }
             }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/TopicSubscriptionManager.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/TopicSubscriptionManager.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.Consumer;
@@ -61,15 +60,9 @@ public class TopicSubscriptionManager {
             log.error("[ Subscription ] Subscription {} Remove consumer fail.", subscriberName, e);
             FutureUtil.failedFuture(e);
         }
-        if (CollectionUtils.isEmpty(subscriptionConsumerPair.getLeft().getConsumers())) {
-            return topic.unsubscribe(subscriberName)
-                    .thenCompose(__ -> {
-                        if (cleanSubscription) {
-                            return subscriptionConsumerPair.getLeft().deleteForcefully()
-                                    .thenAccept(unused -> topicSubscriptions.remove(topic));
-                        }
-                        return CompletableFuture.completedFuture(null);
-                    });
+        if (cleanSubscription) {
+            return subscriptionConsumerPair.getLeft().deleteForcefully()
+                    .thenAccept(unused -> topicSubscriptions.remove(topic));
         } else {
             return CompletableFuture.completedFuture(null);
         }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -215,7 +215,6 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
                 log.debug("[Proxy Connection Lost] [{}] ", connection.getClientId());
             }
             connectionManager.removeConnection(connection);
-            connection.close();
         }
         brokerPool.forEach((k, v) -> v.close());
         brokerPool.clear();

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -203,8 +203,8 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
             log.warn("connection is null. close CId={}", clientId);
             channel.close();
         } else {
-            connection.close()
-                    .thenAccept(__-> connectionManager.removeConnection(connection));
+            connectionManager.removeConnection(connection);
+            connection.close();
         }
     }
 
@@ -215,6 +215,7 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
                 log.debug("[Proxy Connection Lost] [{}] ", connection.getClientId());
             }
             connectionManager.removeConnection(connection);
+            connection.close();
         }
         brokerPool.forEach((k, v) -> v.close());
         brokerPool.clear();

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
@@ -211,7 +211,8 @@ public class DefaultProtocolMethodProcessorImpl extends AbstractCommonProtocolMe
                 return this.qosPublishHandlers.qos2().publish(msg);
             default:
                 log.error("[Publish] Unknown QoS-Type:{}", qos);
-                return connection.close();
+                connection.getChannel().close();
+                return FutureUtil.failedFuture(new IllegalArgumentException("Unknown Qos-Type: " + qos));
         }
     }
 
@@ -269,11 +270,7 @@ public class DefaultProtocolMethodProcessorImpl extends AbstractCommonProtocolMe
                     .success(true)
                     .build();
             connection.getAckHandler()
-                    .sendDisconnectAck(connection, disconnectAck)
-                    .addListener(__ -> {
-                        metricsCollector.removeClient(NettyUtils.getAddress(channel));
-                        connectionManager.removeConnection(connection);
-                    });
+                    .sendDisconnectAck(connection, disconnectAck);
         }
     }
 
@@ -292,11 +289,9 @@ public class DefaultProtocolMethodProcessorImpl extends AbstractCommonProtocolMe
         if (willMessage != null) {
             willMessageHandler.fireWillMessage(clientId, willMessage);
         }
-        connection.close()
-                .thenAccept(__ -> {
-                    connectionManager.removeConnection(connection);
-                    mqttSubscriptionManager.removeSubscription(clientId);
-                });
+        connectionManager.removeConnection(connection);
+        mqttSubscriptionManager.removeSubscription(clientId);
+        connection.close();
     }
 
     @Override

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/DefaultProtocolMethodProcessorImpl.java
@@ -268,6 +268,7 @@ public class DefaultProtocolMethodProcessorImpl extends AbstractCommonProtocolMe
             DisconnectAck disconnectAck = DisconnectAck
                     .builder()
                     .success(true)
+                    .reasonCode(Mqtt5DisConnReasonCode.NORMAL)
                     .build();
             connection.getAckHandler()
                     .sendDisconnectAck(connection, disconnectAck);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
@@ -46,6 +46,7 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.policies.data.BundlesData;
+import org.apache.pulsar.common.policies.data.TopicStats;
 import org.awaitility.Awaitility;
 import org.fusesource.mqtt.client.BlockingConnection;
 import org.fusesource.mqtt.client.MQTT;
@@ -293,6 +294,10 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         connection2.subscribe(topics);
         Assert.assertTrue(connection2.isConnected());
         connection2.disconnect();
+        Awaitility.await().untilAsserted(()-> {
+            TopicStats stats = admin.topics().getStats(topicName);
+            Assert.assertEquals(stats.getSubscriptions().size(), 0);
+        });
         connection1.disconnect();
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
@@ -270,7 +270,7 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         connection.disconnect();
     }
 
-    @Test(timeOut = TIMEOUT, invocationCount = 1000)
+    @Test(timeOut = TIMEOUT)
     public void testSubscribeRejectionWithSameClientId() throws Exception {
         final String topicName = "persistent://public/default/testSubscribeWithSameClientId";
         MQTT mqtt = createMQTTClient();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
@@ -270,11 +270,13 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         connection.disconnect();
     }
 
-    @Test(timeOut = TIMEOUT)
+    @Test(timeOut = TIMEOUT, invocationCount = 1000)
     public void testSubscribeRejectionWithSameClientId() throws Exception {
         final String topicName = "persistent://public/default/testSubscribeWithSameClientId";
         MQTT mqtt = createMQTTClient();
         mqtt.setClientId("client-id-0");
+        mqtt.setReconnectDelay(Integer.MAX_VALUE);
+        mqtt.setReconnectAttemptsMax(0);
         BlockingConnection connection1 = mqtt.blockingConnection();
         connection1.connect();
         Topic[] topics = { new Topic(topicName, QoS.AT_LEAST_ONCE) };
@@ -283,12 +285,13 @@ public class SimpleIntegrationTest extends MQTTTestBase {
 
         BlockingConnection connection2;
         MQTT mqtt2 = createMQTTClient();
-        mqtt.setClientId("client-id-0");
+        mqtt2.setClientId("client-id-0");
         connection2 = mqtt2.blockingConnection();
         connection2.connect();
         Assert.assertTrue(connection2.isConnected());
-        Awaitility.await().untilAsserted(() -> Assert.assertTrue(connection1.isConnected()));
+        Awaitility.await().untilAsserted(() -> Assert.assertFalse(connection1.isConnected()));
         connection2.subscribe(topics);
+        Assert.assertTrue(connection2.isConnected());
         connection2.disconnect();
         connection1.disconnect();
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt5/hivemq/base/MQTT5ReasonCodeOnAllACKTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt5/hivemq/base/MQTT5ReasonCodeOnAllACKTest.java
@@ -107,13 +107,14 @@ public class MQTT5ReasonCodeOnAllACKTest extends MQTTTestBase {
         }
         client.unsubscribeWith().topicFilter(topic).send();
         client.disconnect();
-        client.connect();
-        Mqtt5SubAck secondConsumerACK = client.subscribeWith().topicFilter(topic).qos(MqttQos.AT_MOST_ONCE).send();
+        Mqtt5BlockingClient client2 = MQTT5ClientUtils.createMqtt5Client(getMqttBrokerPortList().get(0));
+        client2.connect();
+        Mqtt5SubAck secondConsumerACK = client2.subscribeWith().topicFilter(topic).qos(MqttQos.AT_MOST_ONCE).send();
         for (Mqtt5SubAckReasonCode reasonCode : secondConsumerACK.getReasonCodes()) {
             Assert.assertEquals(reasonCode.getCode(), Mqtt5SubAckReasonCode.GRANTED_QOS_0.getCode());
         }
-        client.unsubscribeWith().topicFilter(topic).send();
-        client.disconnect();
+        client2.unsubscribeWith().topicFilter(topic).send();
+        client2.disconnect();
     }
 
     @Test(dataProvider = "mqttPersistentTopicNames", timeOut = TIMEOUT)


### PR DESCRIPTION
Fixes #579 

Master Issue: #579

### Motivation

Based on issue #579, I found we exist a problem.

The `Connection#close` method is called multiple times when the previous connection is overwritten and closed by the `client id`, and some errors are thrown when it triggers a race condition.

### Modifications

- Changed all connection close actions to `channel#close` to trigger `channelInactive`, which then calls `Connection#close` to clean up data.
- Fix issue #579 by stopping connection 1 reconnecting and quickly cleaning up `subscriptionManager` to avoid duplicate subscriptions.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 
  

