### PR TITLE
Provide separate TLS parameters for MoP

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,8 @@ openssl req -new -x509 -nodes -sha256 -days 365 -key server.key -out server.crt
 ...
 tlsEnabled=true
 mqttListeners=mqtt+ssl://127.0.0.1:8883
-tlsCertificateFilePath=/xxx/server.crt
-tlsKeyFilePath=/xxx/server.key
+mqttTlsCertificateFilePath=/xxx/server.crt
+mqttTlsKeyFilePath=/xxx/server.key
 ...
 ```
 
@@ -242,8 +242,8 @@ connection.connect();
 ...
 mqttProxyEnable=true
 mqttProxyTlsEnabled=true
-tlsCertificateFilePath=/xxx/server.crt
-tlsKeyFilePath=/xxx/server.key
+mqttTlsCertificateFilePath=/xxx/server.crt
+mqttTlsKeyFilePath=/xxx/server.key
 ...
 ```
 
@@ -274,21 +274,21 @@ Please reference [here](https://en.wikipedia.org/wiki/TLS-PSK) to learn more abo
 1. Config mqtt broker to load tls psk config.
 ```conf
 ...
-tlsPskEnabled=true
+mqttTlsPskEnabled=true
 mqttListeners=mqtt+ssl+psk://127.0.0.1:8884
 // any string can be specified
-tlsPskIdentityHint=alpha
+mqttTlsPskIdentityHint=alpha
 // identity is semicolon list of string with identity:secret format
-tlsPskIdentity=mqtt:mqtt123
+mqttTlsPskIdentity=mqtt:mqtt123
 ...
 ```
 Optional configs
 
-|  Config key   | Comment  |
-|  :---------:  | -------- |
-|  tlsPskIdentityFile | When you want identities in a single file with many pairs, you can config this. Identities will load from both `tlsPskIdentity` and `tlsPskIdentityFile`  |
-|  tlsProtocols  | TLS PSK protocols, default are [ TLSv1, TLSv1.1, TLSv1.2 ]  |
-|  tlsCiphers | TLS PSK ciphers, default are [ TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA, TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA, TLS_PSK_WITH_AES_128_CBC_SHA, TLS_PSK_WITH_AES_256_CBC_SHA ] |
+|       Config key       | Comment  |
+|:----------------------:| -------- |
+| mqttTlsPskIdentityFile | When you want identities in a single file with many pairs, you can config this. Identities will load from both `tlsPskIdentity` and `tlsPskIdentityFile`  |
+|    mqttTlsProtocols    | TLS PSK protocols, default are [ TLSv1, TLSv1.1, TLSv1.2 ]  |
+|     mqttTlsCiphers     | TLS PSK ciphers, default are [ TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA, TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA, TLS_PSK_WITH_AES_128_CBC_SHA, TLS_PSK_WITH_AES_256_CBC_SHA ] |
 
 2. As current known mqtt Java client does not support TLS-PSK, it's better to verify this by `mosquitto cli`
 ```cli
@@ -314,9 +314,9 @@ mqttProxyTlsPskEnabled=true
 // default tls psk port
 mqttProxyTlsPskPort=5684
 // any string can be specified
-tlsPskIdentityHint=alpha
+mqttTlsPskIdentityHint=alpha
 // identity is semicolon list of string with identity:secret format
-tlsPskIdentity=mqtt:mqtt123
+mqttTlsPskIdentity=mqtt:mqtt123
 ...
 ```
 

--- a/docs/mop-configuration.md
+++ b/docs/mop-configuration.md
@@ -29,35 +29,35 @@
 
 ## TLS
 
-| Property | Default value | Comment
-|----------| --------------| --------
-|tlsEnabled | false | Enabled tls |
-|tlsCertRefreshCheckDurationSec | 300 | Tls cert refresh duration in seconds (set 0 to check on every new connection) |
-|tlsCertificateFilePath  | | The path of TLS certificate path |
-|tlsKeyFilePath | null | The path of TLS key file |
-|tlsTrustCertsFilePath | | Path for the trusted TLS certificate file | 
-|tlsProtocols | | TLS protocols, available values [TLSv1.3, TLSv1.2, TlSv1.1, TLSv1] |
-|tlsCiphers | | Specify the tls cipher the proxy will use to negotiate during TLS Handshake (a comma-separated list of ciphers). Examples:- [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256] |
-|tlsAllowInsecureConnection | false | Accept untrusted TLS certificate from client. If true, a client with a cert which cannot be verified with the `tlsTrustCertsFilePath`" cert will be allowed to connect to the server, though the cert will not be used for client authentication |
-|tlsRequireTrustedClientCertOnConnect | false | Whether client certificates are required for TLS. Connections are rejected if the client certificate isn't trusted |
-|tlsEnabledWithKeyStore | false | Enable TLS with KeyStore type configuration for proxy |
-|tlsProvider | | TLS Provider |
-|tlsKeyStoreType | JKS | TLS KeyStore type configuration for proxy: JKS, PKCS12 |
-|tlsKeyStore | | TLS KeyStore path for proxy |
-|tlsKeyStorePassword | | TLS KeyStore password for proxy |
-|tlsTrustStoreType | JKS | TLS TrustStore type configuration for proxy: JKS, PKCS12 |
-|tlsTrustStore | | TLS TrustStore path for proxy | 
-|tlsTrustStorePassword| | TLS TrustStore password for proxy |
+| Property                                 | Default value | Comment
+|------------------------------------------| --------------| --------
+| tlsEnabled                               | false | Enabled tls |
+| mqttTlsCertRefreshCheckDurationSec       | 300 | Tls cert refresh duration in seconds (set 0 to check on every new connection) |
+| mqttTlsCertificateFilePath               | | The path of TLS certificate path |
+| mqttTlsKeyFilePath                       | null | The path of TLS key file |
+| mqttTlsTrustCertsFilePath                | | Path for the trusted TLS certificate file | 
+| mqttTlsProtocols                         | | TLS protocols, available values [TLSv1.3, TLSv1.2, TlSv1.1, TLSv1] |
+| mqttTlsCiphers                           | | Specify the tls cipher the proxy will use to negotiate during TLS Handshake (a comma-separated list of ciphers). Examples:- [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256] |
+| mqttTlsAllowInsecureConnection           | false | Accept untrusted TLS certificate from client. If true, a client with a cert which cannot be verified with the `tlsTrustCertsFilePath`" cert will be allowed to connect to the server, though the cert will not be used for client authentication |
+| mqttTlsRequireTrustedClientCertOnConnect | false | Whether client certificates are required for TLS. Connections are rejected if the client certificate isn't trusted |
+| mqttTlsEnabledWithKeyStore               | false | Enable TLS with KeyStore type configuration for proxy |
+| mqttTlsProvider                          | | TLS Provider |
+| mqttTlsKeyStoreType                      | JKS | TLS KeyStore type configuration for proxy: JKS, PKCS12 |
+| mqttTlsKeyStore                          | | TLS KeyStore path for proxy |
+| mqttTlsKeyStorePassword                  | | TLS KeyStore password for proxy |
+| mqttTlsTrustStoreType                    | JKS | TLS TrustStore type configuration for proxy: JKS, PKCS12 |
+| mqttTlsTrustStore                        | | TLS TrustStore path for proxy | 
+| mqttTlsTrustStorePassword                | | TLS TrustStore password for proxy |
 
 
 ## TLS-PSK
 
-| Property | Default value | Comment
-|----------| --------------| --------
-|tlsPskIdentityFile | | When you want identities in a single file with many pairs, you can config this. Identities will load from both `tlsPskIdentity` and `tlsPskIdentityFile` |
-|tlsPskEnabled | false | Enable tls psk |
-|tlsPskIdentityHint |  | Any string can be specified |
-|tlsPskIdentity |  | Identity is semicolon list of string with identity:secret format |
+| Property               | Default value | Comment
+|------------------------| --------------| --------
+| mqttTlsPskIdentityFile | | When you want identities in a single file with many pairs, you can config this. Identities will load from both `tlsPskIdentity` and `tlsPskIdentityFile` |
+| mqttTlsPskEnabled      | false | Enable tls psk |
+| mqttTlsPskIdentityHint |  | Any string can be specified |
+| mqttTlsPskIdentity     |  | Identity is semicolon list of string with identity:secret format |
 
 
 ## Socket

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTChannelInitializer.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTChannelInitializer.java
@@ -52,40 +52,40 @@ public class MQTTChannelInitializer extends ChannelInitializer<SocketChannel> {
         this.mqttConfig = mqttService.getServerConfiguration();
         this.enableTls = enableTls;
         this.enableTlsPsk = enableTlsPsk;
-        this.tlsEnabledWithKeyStore = mqttConfig.isTlsEnabledWithKeyStore();
+        this.tlsEnabledWithKeyStore = mqttConfig.isMqttTlsEnabledWithKeyStore();
         if (this.enableTls) {
             if (tlsEnabledWithKeyStore) {
                 nettySSLContextAutoRefreshBuilder = new NettySSLContextAutoRefreshBuilder(
-                        mqttConfig.getTlsProvider(),
-                        mqttConfig.getTlsKeyStoreType(),
-                        mqttConfig.getTlsKeyStore(),
-                        mqttConfig.getTlsKeyStorePassword(),
-                        mqttConfig.isTlsAllowInsecureConnection(),
-                        mqttConfig.getTlsTrustStoreType(),
-                        mqttConfig.getTlsTrustStore(),
-                        mqttConfig.getTlsTrustStorePassword(),
-                        mqttConfig.isTlsRequireTrustedClientCertOnConnect(),
-                        mqttConfig.getTlsCiphers(),
-                        mqttConfig.getTlsProtocols(),
-                        mqttConfig.getTlsCertRefreshCheckDurationSec());
+                        mqttConfig.getMqttTlsProvider(),
+                        mqttConfig.getMqttTlsKeyStoreType(),
+                        mqttConfig.getMqttTlsKeyStore(),
+                        mqttConfig.getMqttTlsKeyStorePassword(),
+                        mqttConfig.isMqttTlsAllowInsecureConnection(),
+                        mqttConfig.getMqttTlsTrustStoreType(),
+                        mqttConfig.getMqttTlsTrustStore(),
+                        mqttConfig.getMqttTlsTrustStorePassword(),
+                        mqttConfig.isMqttTlsRequireTrustedClientCertOnConnect(),
+                        mqttConfig.getMqttTlsCiphers(),
+                        mqttConfig.getMqttTlsProtocols(),
+                        mqttConfig.getMqttTlsCertRefreshCheckDurationSec());
             } else {
                 sslCtxRefresher = new NettyServerSslContextBuilder(
-                        mqttConfig.isTlsAllowInsecureConnection(),
-                        mqttConfig.getTlsTrustCertsFilePath(),
-                        mqttConfig.getTlsCertificateFilePath(),
-                        mqttConfig.getTlsKeyFilePath(),
-                        mqttConfig.getTlsCiphers(),
-                        mqttConfig.getTlsProtocols(),
-                        mqttConfig.isTlsRequireTrustedClientCertOnConnect(),
-                        mqttConfig.getTlsCertRefreshCheckDurationSec());
+                        mqttConfig.isMqttTlsAllowInsecureConnection(),
+                        mqttConfig.getMqttTlsTrustCertsFilePath(),
+                        mqttConfig.getMqttTlsCertificateFilePath(),
+                        mqttConfig.getMqttTlsKeyFilePath(),
+                        mqttConfig.getMqttTlsCiphers(),
+                        mqttConfig.getMqttTlsProtocols(),
+                        mqttConfig.isMqttTlsRequireTrustedClientCertOnConnect(),
+                        mqttConfig.getMqttTlsCertRefreshCheckDurationSec());
             }
         } else if (this.enableTlsPsk) {
             pskConfiguration = new PSKConfiguration();
-            pskConfiguration.setIdentityHint(mqttConfig.getTlsPskIdentityHint());
-            pskConfiguration.setIdentity(mqttConfig.getTlsPskIdentity());
-            pskConfiguration.setIdentityFile(mqttConfig.getTlsPskIdentityFile());
-            pskConfiguration.setProtocols(mqttConfig.getTlsProtocols());
-            pskConfiguration.setCiphers(mqttConfig.getTlsCiphers());
+            pskConfiguration.setIdentityHint(mqttConfig.getMqttTlsPskIdentityHint());
+            pskConfiguration.setIdentity(mqttConfig.getMqttTlsPskIdentity());
+            pskConfiguration.setIdentityFile(mqttConfig.getMqttTlsPskIdentityFile());
+            pskConfiguration.setProtocols(mqttConfig.getMqttTlsProtocols());
+            pskConfiguration.setCiphers(mqttConfig.getMqttTlsCiphers());
         } else {
             this.sslCtxRefresher = null;
         }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTCommonConfiguration.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTCommonConfiguration.java
@@ -16,9 +16,12 @@ package io.streamnative.pulsar.handlers.mqtt;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.common.configuration.Category;
 import org.apache.pulsar.common.configuration.FieldContext;
@@ -173,25 +176,34 @@ public class MQTTCommonConfiguration extends ServiceConfiguration {
             required = false,
             doc = "Whether broker start mqtt protocol handler with tls psk"
     )
+    private boolean mqttTlsPskEnabled = false;
+
+    @Deprecated
+    @FieldContext(
+            category = CATEGORY_TLS,
+            required = false,
+            deprecated = true,
+            doc = "Whether broker start mqtt protocol handler with tls psk"
+    )
     private boolean tlsPskEnabled = false;
 
     @FieldContext(
             category = CATEGORY_TLS,
             doc = "Tls cert refresh duration in seconds (set 0 to check on every new connection)"
     )
-    private long tlsCertRefreshCheckDurationSec = 300; // 5 mins
+    private long mqttTlsCertRefreshCheckDurationSec = 300; // 5 mins
 
     @FieldContext(
             category = CATEGORY_TLS,
             doc = "Path for the TLS certificate file"
     )
-    private String tlsCertificateFilePath;
+    private String mqttTlsCertificateFilePath;
 
     @FieldContext(
             category = CATEGORY_TLS,
             doc = "Path for the TLS private key file"
     )
-    private String tlsKeyFilePath;
+    private String mqttTlsKeyFilePath;
 
     @FieldContext(
             category = CATEGORY_TLS,
@@ -200,7 +212,7 @@ public class MQTTCommonConfiguration extends ServiceConfiguration {
                     + " are signed by a certificate authority. If this verification fails, then the"
                     + " certs are untrusted and the connections are dropped"
     )
-    private String tlsTrustCertsFilePath;
+    private String mqttTlsTrustCertsFilePath;
 
     @FieldContext(
             category = CATEGORY_TLS,
@@ -208,14 +220,14 @@ public class MQTTCommonConfiguration extends ServiceConfiguration {
                     + " (a comma-separated list of protocol names).\n\n"
                     + "Examples:- [TLSv1.3, TLSv1.2]"
     )
-    private Set<String> tlsProtocols = Sets.newTreeSet();
+    private Set<String> mqttTlsProtocols = Sets.newTreeSet();
     @FieldContext(
             category = CATEGORY_TLS,
             doc = "Specify the tls cipher the proxy will use to negotiate during TLS Handshake"
                     + " (a comma-separated list of ciphers).\n\n"
                     + "Examples:- [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]"
     )
-    private Set<String> tlsCiphers = Sets.newTreeSet();
+    private Set<String> mqttTlsCiphers = Sets.newTreeSet();
 
     @FieldContext(
             category = CATEGORY_TLS,
@@ -224,66 +236,74 @@ public class MQTTCommonConfiguration extends ServiceConfiguration {
                     + " cert will be allowed to connect to the server, though the cert will not be used for"
                     + " client authentication"
     )
-    private boolean tlsAllowInsecureConnection = false;
+    private boolean mqttTlsAllowInsecureConnection = false;
 
     @FieldContext(
             category = CATEGORY_TLS,
             doc = "Whether client certificates are required for TLS.\n\n"
                     + " Connections are rejected if the client certificate isn't trusted"
     )
-    private boolean tlsRequireTrustedClientCertOnConnect = false;
+    private boolean mqttTlsRequireTrustedClientCertOnConnect = false;
 
     @FieldContext(
             category = CATEGORY_KEYSTORE_TLS,
             doc = "Enable TLS with KeyStore type configuration for proxy"
     )
-    private boolean tlsEnabledWithKeyStore = false;
+    private boolean mqttTlsEnabledWithKeyStore = false;
 
     @FieldContext(
             category = CATEGORY_KEYSTORE_TLS,
             doc = "TLS Provider"
     )
-    private String tlsProvider = null;
+    private String mqttTlsProvider = null;
 
     @FieldContext(
             category = CATEGORY_KEYSTORE_TLS,
             doc = "TLS KeyStore type configuration for proxy: JKS, PKCS12"
     )
-    private String tlsKeyStoreType = "JKS";
+    private String mqttTlsKeyStoreType = "JKS";
 
     @FieldContext(
             category = CATEGORY_KEYSTORE_TLS,
             doc = "TLS KeyStore path for proxy"
     )
-    private String tlsKeyStore = null;
+    private String mqttTlsKeyStore = null;
 
     @FieldContext(
             category = CATEGORY_KEYSTORE_TLS,
             doc = "TLS KeyStore password for proxy"
     )
-    private String tlsKeyStorePassword = null;
+    private String mqttTlsKeyStorePassword = null;
 
     @FieldContext(
             category = CATEGORY_KEYSTORE_TLS,
             doc = "TLS TrustStore type configuration for proxy: JKS, PKCS12"
     )
-    private String tlsTrustStoreType = "JKS";
+    private String mqttTlsTrustStoreType = "JKS";
 
     @FieldContext(
             category = CATEGORY_KEYSTORE_TLS,
             doc = "TLS TrustStore path for proxy"
     )
-    private String tlsTrustStore = null;
+    private String mqttTlsTrustStore = null;
 
     @FieldContext(
             category = CATEGORY_KEYSTORE_TLS,
             doc = "TLS TrustStore password for proxy"
     )
-    private String tlsTrustStorePassword = null;
+    private String mqttTlsTrustStorePassword = null;
 
     @FieldContext(
             category = CATEGORY_TLS_PSK,
             doc = "TLS psk identity hint"
+    )
+    private String mqttTlsPskIdentityHint = null;
+
+    @Deprecated
+    @FieldContext(
+            category = CATEGORY_TLS_PSK,
+            doc = "TLS psk identity hint",
+            deprecated = true
     )
     private String tlsPskIdentityHint = null;
 
@@ -291,10 +311,26 @@ public class MQTTCommonConfiguration extends ServiceConfiguration {
             category = CATEGORY_TLS_PSK,
             doc = "TLS psk identity file"
     )
+    private String mqttTlsPskIdentityFile = null;
+
+    @Deprecated
+    @FieldContext(
+            category = CATEGORY_TLS_PSK,
+            doc = "TLS psk identity file",
+            deprecated = true
+    )
     private String tlsPskIdentityFile = null;
 
     @FieldContext(
             category = CATEGORY_TLS_PSK,
+            doc = "TLS psk identity with plain text"
+    )
+    private String mqttTlsPskIdentity = null;
+
+    @Deprecated
+    @FieldContext(
+            category = CATEGORY_TLS_PSK,
+            deprecated = true,
             doc = "TLS psk identity with plain text"
     )
     private String tlsPskIdentity = null;
@@ -310,4 +346,144 @@ public class MQTTCommonConfiguration extends ServiceConfiguration {
             doc = "Event center callback pool size."
     )
     private int eventCenterCallbackPoolThreadNum = 1;
+
+    public long getMqttTlsCertRefreshCheckDurationSec() {
+        if (getTlsCertRefreshCheckDurationSec() != 300) {
+            return getTlsCertRefreshCheckDurationSec();
+        }
+        return mqttTlsCertRefreshCheckDurationSec;
+    }
+
+    public String getMqttTlsCertificateFilePath() {
+        if (StringUtils.isNotBlank(getTlsCertificateFilePath())) {
+            return getTlsCertificateFilePath();
+        }
+        return mqttTlsCertificateFilePath;
+    }
+
+    public String getMqttTlsKeyFilePath() {
+        if (StringUtils.isNotBlank(getTlsKeyFilePath())) {
+            return getTlsKeyFilePath();
+        }
+        return mqttTlsKeyFilePath;
+    }
+
+    public String getMqttTlsTrustCertsFilePath() {
+        if (StringUtils.isNotBlank(getTlsTrustCertsFilePath())) {
+            return getTlsTrustCertsFilePath();
+        }
+        return mqttTlsTrustCertsFilePath;
+    }
+
+    public Set<String> getMqttTlsProtocols() {
+        if (CollectionUtils.isNotEmpty(getTlsProtocols())) {
+            return getTlsProtocols();
+        }
+        return mqttTlsProtocols;
+    }
+
+    public Set<String> getMqttTlsCiphers() {
+        if (CollectionUtils.isNotEmpty(getTlsCiphers())) {
+            return getTlsCiphers();
+        }
+        return mqttTlsCiphers;
+    }
+
+    public boolean isMqttTlsAllowInsecureConnection() {
+        if (isTlsAllowInsecureConnection()) {
+            return isTlsAllowInsecureConnection();
+        }
+        return mqttTlsAllowInsecureConnection;
+    }
+
+    public boolean isMqttTlsRequireTrustedClientCertOnConnect() {
+        if (isTlsRequireTrustedClientCertOnConnect()) {
+            return isTlsRequireTrustedClientCertOnConnect();
+        }
+        return mqttTlsRequireTrustedClientCertOnConnect;
+    }
+
+    public boolean isMqttTlsEnabledWithKeyStore() {
+        if (isTlsEnabledWithKeyStore()) {
+            return isTlsEnabledWithKeyStore();
+        }
+        return mqttTlsEnabledWithKeyStore;
+    }
+
+    public String getMqttTlsProvider() {
+        if (StringUtils.isNotBlank(getTlsProvider())) {
+            return getTlsProvider();
+        }
+        return mqttTlsProvider;
+    }
+
+    public String getMqttTlsKeyStoreType() {
+        if (!Objects.equals(getTlsKeyStoreType(), "JKS")) {
+            return getTlsKeyStoreType();
+        }
+        return mqttTlsKeyStoreType;
+    }
+
+    public String getMqttTlsKeyStore() {
+        if (StringUtils.isNotBlank(getTlsKeyStore())) {
+            return getTlsKeyStore();
+        }
+        return mqttTlsKeyStore;
+    }
+
+    public String getMqttTlsKeyStorePassword() {
+        if (StringUtils.isNotBlank(getTlsKeyStorePassword())) {
+            return getTlsKeyStorePassword();
+        }
+        return mqttTlsKeyStorePassword;
+    }
+
+    public String getMqttTlsTrustStoreType() {
+        if (!Objects.equals(getTlsTrustStoreType(), "JKS")) {
+            return getTlsTrustStoreType();
+        }
+        return mqttTlsTrustStoreType;
+    }
+
+    public String getMqttTlsTrustStore() {
+        if (StringUtils.isNotBlank(getTlsTrustStore())) {
+            return getTlsTrustStore();
+        }
+        return mqttTlsTrustStore;
+    }
+
+    public String getMqttTlsTrustStorePassword() {
+        if (StringUtils.isNotBlank(getTlsTrustStorePassword())) {
+            return getTlsTrustStorePassword();
+        }
+        return mqttTlsTrustStorePassword;
+    }
+
+    public boolean isMqttTlsPskEnabled() {
+        if (tlsPskEnabled) {
+            return true;
+        }
+        return mqttTlsPskEnabled;
+    }
+
+    public String getMqttTlsPskIdentityHint() {
+        if (StringUtils.isNotBlank(tlsPskIdentityHint)) {
+            return tlsPskIdentityHint;
+        }
+        return mqttTlsPskIdentityHint;
+    }
+
+    public String getMqttTlsPskIdentityFile() {
+        if (StringUtils.isNotBlank(tlsPskIdentityFile)) {
+            return tlsPskIdentityFile;
+        }
+        return mqttTlsPskIdentityFile;
+    }
+
+    public String getMqttTlsPskIdentity() {
+        if (StringUtils.isNotBlank(tlsPskIdentity)) {
+            return tlsPskIdentity;
+        }
+        return mqttTlsPskIdentity;
+    }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTProtocolHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTProtocolHandler.java
@@ -129,7 +129,7 @@ public class MQTTProtocolHandler implements ProtocolHandler {
                             new InetSocketAddress(brokerService.pulsar().getBindAddress(), getListenerPort(listener)),
                             new MQTTChannelInitializer(mqttService, true));
 
-                } else if (listener.startsWith(SSL_PSK_PREFIX) && mqttConfig.isTlsPskEnabled()) {
+                } else if (listener.startsWith(SSL_PSK_PREFIX) && mqttConfig.isMqttTlsPskEnabled()) {
                     builder.put(
                             new InetSocketAddress(brokerService.pulsar().getBindAddress(), getListenerPort(listener)),
                             new MQTTChannelInitializer(mqttService, false, true));

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyChannelInitializer.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyChannelInitializer.java
@@ -56,40 +56,40 @@ public class MQTTProxyChannelInitializer extends ChannelInitializer<SocketChanne
         this.proxyConfig = proxyConfig;
         this.enableTls = enableTls;
         this.enableTlsPsk = enableTlsPsk;
-        this.tlsEnabledWithKeyStore = proxyConfig.isTlsEnabledWithKeyStore();
+        this.tlsEnabledWithKeyStore = proxyConfig.isMqttTlsEnabledWithKeyStore();
         if (this.enableTls) {
             if (tlsEnabledWithKeyStore) {
                 serverSSLContextAutoRefreshBuilder = new NettySSLContextAutoRefreshBuilder(
-                        proxyConfig.getTlsProvider(),
-                        proxyConfig.getTlsKeyStoreType(),
-                        proxyConfig.getTlsKeyStore(),
-                        proxyConfig.getTlsKeyStorePassword(),
-                        proxyConfig.isTlsAllowInsecureConnection(),
-                        proxyConfig.getTlsTrustStoreType(),
-                        proxyConfig.getTlsTrustStore(),
-                        proxyConfig.getTlsTrustStorePassword(),
-                        proxyConfig.isTlsRequireTrustedClientCertOnConnect(),
-                        proxyConfig.getTlsCiphers(),
-                        proxyConfig.getTlsProtocols(),
-                        proxyConfig.getTlsCertRefreshCheckDurationSec());
+                        proxyConfig.getMqttTlsProvider(),
+                        proxyConfig.getMqttTlsKeyStoreType(),
+                        proxyConfig.getMqttTlsKeyStore(),
+                        proxyConfig.getMqttTlsKeyStorePassword(),
+                        proxyConfig.isMqttTlsAllowInsecureConnection(),
+                        proxyConfig.getMqttTlsTrustStoreType(),
+                        proxyConfig.getMqttTlsTrustStore(),
+                        proxyConfig.getMqttTlsTrustStorePassword(),
+                        proxyConfig.isMqttTlsRequireTrustedClientCertOnConnect(),
+                        proxyConfig.getMqttTlsCiphers(),
+                        proxyConfig.getMqttTlsProtocols(),
+                        proxyConfig.getMqttTlsCertRefreshCheckDurationSec());
             } else {
                 serverSslCtxRefresher = new NettyServerSslContextBuilder(
-                        proxyConfig.isTlsAllowInsecureConnection(),
-                        proxyConfig.getTlsTrustCertsFilePath(),
-                        proxyConfig.getTlsCertificateFilePath(),
-                        proxyConfig.getTlsKeyFilePath(),
-                        proxyConfig.getTlsCiphers(),
-                        proxyConfig.getTlsProtocols(),
-                        proxyConfig.isTlsRequireTrustedClientCertOnConnect(),
-                        proxyConfig.getTlsCertRefreshCheckDurationSec());
+                        proxyConfig.isMqttTlsAllowInsecureConnection(),
+                        proxyConfig.getMqttTlsTrustCertsFilePath(),
+                        proxyConfig.getMqttTlsCertificateFilePath(),
+                        proxyConfig.getMqttTlsKeyFilePath(),
+                        proxyConfig.getMqttTlsCiphers(),
+                        proxyConfig.getMqttTlsProtocols(),
+                        proxyConfig.isMqttTlsRequireTrustedClientCertOnConnect(),
+                        proxyConfig.getMqttTlsCertRefreshCheckDurationSec());
             }
         } else if (this.enableTlsPsk) {
             pskConfiguration = new PSKConfiguration();
-            pskConfiguration.setIdentityHint(proxyConfig.getTlsPskIdentityHint());
-            pskConfiguration.setIdentity(proxyConfig.getTlsPskIdentity());
-            pskConfiguration.setIdentityFile(proxyConfig.getTlsPskIdentityFile());
-            pskConfiguration.setProtocols(proxyConfig.getTlsProtocols());
-            pskConfiguration.setCiphers(proxyConfig.getTlsCiphers());
+            pskConfiguration.setIdentityHint(proxyConfig.getMqttTlsPskIdentityHint());
+            pskConfiguration.setIdentity(proxyConfig.getMqttTlsPskIdentity());
+            pskConfiguration.setIdentityFile(proxyConfig.getMqttTlsPskIdentityFile());
+            pskConfiguration.setProtocols(proxyConfig.getMqttTlsProtocols());
+            pskConfiguration.setCiphers(proxyConfig.getMqttTlsCiphers());
         } else {
             this.serverSslCtxRefresher = null;
         }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTProtocolHandlerTestBase.java
@@ -340,7 +340,7 @@ public abstract class MQTTProtocolHandlerTestBase {
             mqttBrokerPortTlsList.add(mqttBrokerTlsPort);
         }
         int mqttBrokerTlsPskPort = -1;
-        if (conf.isTlsPskEnabled()) {
+        if (conf.isMqttTlsPskEnabled()) {
             mqttBrokerTlsPskPort = PortManager.nextFreePort();
             mqttBrokerPortTlsPskList.add(mqttBrokerTlsPskPort);
         }
@@ -374,7 +374,7 @@ public abstract class MQTTProtocolHandlerTestBase {
         if (conf.isTlsEnabled()) {
             tlsListener = "mqtt+ssl://127.0.0.1:" + mqttBrokerTlsPort;
         }
-        if (conf.isTlsPskEnabled()) {
+        if (conf.isMqttTlsPskEnabled()) {
             tlsPskListener = "mqtt+ssl+psk://127.0.0.1:" + mqttBrokerTlsPskPort;
         }
         conf.getProperties().setProperty("mqttListeners",

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/broker/ConfigurationCompatibilityTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/broker/ConfigurationCompatibilityTest.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.broker;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import com.google.common.collect.Sets;
+import io.streamnative.pulsar.handlers.mqtt.MQTTCommonConfiguration;
+import java.util.Set;
+import org.testng.annotations.Test;
+
+public class ConfigurationCompatibilityTest {
+
+    @Test
+    public void testTlsConfigurationCompatibility() {
+        final MQTTCommonConfiguration conf = new MQTTCommonConfiguration();
+        final String identity = "test";
+        conf.setTlsPskIdentity(identity);
+        assertEquals(conf.getMqttTlsPskIdentity(), identity);
+        final String testFile = "testFile";
+        conf.setTlsPskIdentityFile(testFile);
+        assertEquals(conf.getMqttTlsPskIdentityFile(), testFile);
+        final String testHint = "hint";
+        conf.setTlsPskIdentityHint(testHint);
+        assertEquals(conf.getMqttTlsPskIdentityHint(), testHint);
+        conf.setTlsPskEnabled(true);
+        assertTrue(conf.isMqttTlsPskEnabled());
+        final String psw = "psw";
+        conf.setTlsTrustStorePassword(psw);
+        assertEquals(conf.getMqttTlsTrustStorePassword(), psw);
+        final String store = "store";
+        conf.setTlsTrustStore(store);
+        assertEquals(conf.getMqttTlsTrustStore(), store);
+        final String type = "ABC";
+        conf.setTlsTrustStoreType(type);
+        assertEquals(conf.getMqttTlsTrustStoreType(), type);
+        final String ksPsw = "ksPsw";
+        conf.setTlsKeyStorePassword(ksPsw);
+        assertEquals(conf.getMqttTlsKeyStorePassword(), ksPsw);
+        final String kStore = "kstore";
+        conf.setTlsKeyStore(kStore);
+        assertEquals(conf.getMqttTlsKeyStore(), kStore);
+        final String ksType = "ksType";
+        conf.setTlsKeyStoreType(ksType);
+        assertEquals(conf.getMqttTlsKeyStoreType(), ksType);
+        final String provider = "provider";
+        conf.setTlsProvider(provider);
+        assertEquals(conf.getMqttTlsProvider(), provider);
+        conf.setTlsEnabledWithKeyStore(true);
+        assertTrue(conf.isMqttTlsEnabledWithKeyStore());
+        conf.setTlsRequireTrustedClientCertOnConnect(true);
+        assertTrue(conf.isMqttTlsRequireTrustedClientCertOnConnect());
+        conf.setTlsAllowInsecureConnection(true);
+        assertTrue(conf.isMqttTlsAllowInsecureConnection());
+        final Set<String> cipher = Sets.newHashSet("cipher") ;
+        conf.setTlsCiphers(cipher);
+        assertEquals(conf.getMqttTlsCiphers(), cipher);
+        final Set<String> protocols = Sets.newHashSet("123") ;
+        conf.setTlsProtocols(protocols);
+        assertEquals(conf.getMqttTlsProtocols(), protocols);
+        final String path = "path";
+        conf.setTlsTrustCertsFilePath(path);
+        assertEquals(conf.getMqttTlsTrustCertsFilePath(), path);
+        final String tlsKeyPath = "tlsKeyPath";
+        conf.setTlsKeyFilePath(tlsKeyPath);
+        assertEquals(conf.getMqttTlsKeyFilePath(), tlsKeyPath);
+        final String tlsCertPath = "tlsCertPath";
+        conf.setTlsCertificateFilePath(tlsCertPath);
+        assertEquals(conf.getMqttTlsCertificateFilePath(), tlsCertPath);
+        final long durationSec = 214314;
+        conf.setTlsCertRefreshCheckDurationSec(durationSec);
+        assertEquals(conf.getMqttTlsCertRefreshCheckDurationSec(), durationSec);
+    }
+
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/broker/ConfigurationCompatibilityTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/broker/ConfigurationCompatibilityTest.java
@@ -63,10 +63,10 @@ public class ConfigurationCompatibilityTest {
         assertTrue(conf.isMqttTlsRequireTrustedClientCertOnConnect());
         conf.setTlsAllowInsecureConnection(true);
         assertTrue(conf.isMqttTlsAllowInsecureConnection());
-        final Set<String> cipher = Sets.newHashSet("cipher") ;
+        final Set<String> cipher = Sets.newHashSet("cipher");
         conf.setTlsCiphers(cipher);
         assertEquals(conf.getMqttTlsCiphers(), cipher);
-        final Set<String> protocols = Sets.newHashSet("123") ;
+        final Set<String> protocols = Sets.newHashSet("123");
         conf.setTlsProtocols(protocols);
         assertEquals(conf.getMqttTlsProtocols(), protocols);
         final String path = "path";

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
@@ -68,9 +68,9 @@ public class SimpleIntegrationTest extends MQTTTestBase {
     protected MQTTCommonConfiguration initConfig() throws Exception {
         MQTTCommonConfiguration mqtt = super.initConfig();
 
-        mqtt.setTlsPskEnabled(true);
-        mqtt.setTlsPskIdentityHint("alpha");
-        mqtt.setTlsPskIdentity("mqtt:mqtt123");
+        mqtt.setMqttTlsPskEnabled(true);
+        mqtt.setMqttTlsPskIdentityHint("alpha");
+        mqtt.setMqttTlsPskIdentity("mqtt:mqtt123");
         return mqtt;
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/TLSTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/TLSTest.java
@@ -40,8 +40,8 @@ public class TLSTest extends MQTTTestBase {
         MQTTCommonConfiguration mqtt = super.initConfig();
 
         mqtt.setTlsEnabled(true);
-        mqtt.setTlsCertificateFilePath(TLS_SERVER_CERT_FILE_PATH);
-        mqtt.setTlsKeyFilePath(TLS_SERVER_KEY_FILE_PATH);
+        mqtt.setMqttTlsCertificateFilePath(TLS_SERVER_CERT_FILE_PATH);
+        mqtt.setMqttTlsKeyFilePath(TLS_SERVER_KEY_FILE_PATH);
 
         return mqtt;
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/proxy/ProxyTLSTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/proxy/ProxyTLSTest.java
@@ -56,11 +56,11 @@ public class ProxyTLSTest extends MQTTTestBase {
 
         mqtt.setMqttProxyEnabled(true);
         mqtt.setMqttProxyTlsEnabled(true);
-        mqtt.setTlsCertificateFilePath(TLS_SERVER_CERT_FILE_PATH);
-        mqtt.setTlsKeyFilePath(TLS_SERVER_KEY_FILE_PATH);
+        mqtt.setMqttTlsCertificateFilePath(TLS_SERVER_CERT_FILE_PATH);
+        mqtt.setMqttTlsKeyFilePath(TLS_SERVER_KEY_FILE_PATH);
         mqtt.setMqttProxyTlsPskEnabled(true);
-        mqtt.setTlsPskIdentityHint("alpha");
-        mqtt.setTlsPskIdentity("mqtt:mqtt123");
+        mqtt.setMqttTlsPskIdentityHint("alpha");
+        mqtt.setMqttTlsPskIdentity("mqtt:mqtt123");
 
         return mqtt;
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/proxy/ProxyTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/proxy/ProxyTest.java
@@ -75,8 +75,8 @@ public class ProxyTest extends MQTTTestBase {
         mqtt.setDefaultNumberOfNamespaceBundles(4);
         mqtt.setMqttProxyEnabled(true);
         mqtt.setMqttProxyTlsPskEnabled(true);
-        mqtt.setTlsPskIdentityHint("alpha");
-        mqtt.setTlsPskIdentity("mqtt:mqtt123");
+        mqtt.setMqttTlsPskIdentityHint("alpha");
+        mqtt.setMqttTlsPskIdentity("mqtt:mqtt123");
         mqtt.getProperties().setProperty("systemEventEnabled", "true");
         return mqtt;
     }


### PR DESCRIPTION
### Motivation

The current MoP broker/proxy TLS use Apache Pulsar parameters, users can't set pulsar and MoP TLS separately.

### Modifications

- Move TLS part configuration with mqtt prefix. e.g: `tlsAllowInsecureConnection` to `mqttTlsAllowInsecureConnection`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `doc-required` 
  
### Compatibility

Use the `getXX` method to be compatible with the old configuration.