### PR TITLE
Support adding PSK dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Please reference [here](https://en.wikipedia.org/wiki/TLS-PSK) to learn more abo
    mosquitto_pub --psk-identity mqtt --psk 6d717474313233 -p 5684 -t "/a/b/c" -m "hello mqtt"
    ```
 
-3. Add PSK identities dynamically.  
+3. Add PSK identities dynamically.   
    You can add psk identities dynamically by REST API in proxy mode.
    ```
    curl -X POST http://pulsar-broker-webservice-address:port/mop/add_psk_identity -d "identity=mqtt2:mqtt222;mqtt3:mqtt333"

--- a/README.md
+++ b/README.md
@@ -205,125 +205,121 @@ openssl req -new -x509 -nodes -sha256 -days 365 -key server.key -out server.crt
 #### TLS with broker
 
 1. Config mqtt broker to load tls config.
-```conf
-...
-tlsEnabled=true
-mqttListeners=mqtt+ssl://127.0.0.1:8883
-mqttTlsCertificateFilePath=/xxx/server.crt
-mqttTlsKeyFilePath=/xxx/server.key
-...
-```
+   ```conf
+   tlsEnabled=true
+   mqttListeners=mqtt+ssl://127.0.0.1:8883
+   mqttTlsCertificateFilePath=/xxx/server.crt
+   mqttTlsKeyFilePath=/xxx/server.key
+   ```
 
 2. Config client to load tls config.
-```java
-MQTT mqtt = new MQTT();
-// default tls port
-mqtt.setHost(URI.create("ssl://127.0.0.1:8883")); 
-File crtFile = new File("server.crt");
-Certificate certificate = CertificateFactory.getInstance("X.509").generateCertificate(new FileInputStream(crtFile));
-KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
-keyStore.load(null, null);
-keyStore.setCertificateEntry("server", certificate);
-TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-trustManagerFactory.init(keyStore);
-SSLContext sslContext = SSLContext.getInstance("TLS");
-sslContext.init(null, trustManagerFactory.getTrustManagers(), null);
-mqtt.setSslContext(sslContext);
-BlockingConnection connection = mqtt.blockingConnection();
-connection.connect();
-...
-```
+   ```java
+   MQTT mqtt = new MQTT();
+   // default tls port
+   mqtt.setHost(URI.create("ssl://127.0.0.1:8883")); 
+   File crtFile = new File("server.crt");
+   Certificate certificate = CertificateFactory.getInstance("X.509").generateCertificate(new FileInputStream(crtFile));
+   KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+   keyStore.load(null, null);
+   keyStore.setCertificateEntry("server", certificate);
+   TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+   trustManagerFactory.init(keyStore);
+   SSLContext sslContext = SSLContext.getInstance("TLS");
+   sslContext.init(null, trustManagerFactory.getTrustManagers(), null);
+   mqtt.setSslContext(sslContext);
+   BlockingConnection connection = mqtt.blockingConnection();
+   connection.connect();
+   ```
 
 
 #### TLS with proxy
 
 1. Config mqtt broker to load tls config.
-```conf
-...
-mqttProxyEnable=true
-mqttProxyTlsEnabled=true
-mqttTlsCertificateFilePath=/xxx/server.crt
-mqttTlsKeyFilePath=/xxx/server.key
-...
-```
+   ```conf
+   mqttProxyEnable=true
+   mqttProxyTlsEnabled=true
+   mqttTlsCertificateFilePath=/xxx/server.crt
+   mqttTlsKeyFilePath=/xxx/server.key
+   ```
 
 2. Config client to load tls config.
-```java
-MQTT mqtt = new MQTT();
-// default proxy tls port
-mqtt.setHost(URI.create("ssl://127.0.0.1:5683")); 
-File crtFile = new File("server.crt");
-Certificate certificate = CertificateFactory.getInstance("X.509").generateCertificate(new FileInputStream(crtFile));
-KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
-keyStore.load(null, null);
-keyStore.setCertificateEntry("server", certificate);
-TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-trustManagerFactory.init(keyStore);
-SSLContext sslContext = SSLContext.getInstance("TLS");
-sslContext.init(null, trustManagerFactory.getTrustManagers(), null);
-mqtt.setSslContext(sslContext);
-BlockingConnection connection = mqtt.blockingConnection();
-connection.connect();
-...
-```
+   ```java
+   MQTT mqtt = new MQTT();
+   // default proxy tls port
+   mqtt.setHost(URI.create("ssl://127.0.0.1:5683")); 
+   File crtFile = new File("server.crt");
+   Certificate certificate = CertificateFactory.getInstance("X.509").generateCertificate(new FileInputStream(crtFile));
+   KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+   keyStore.load(null, null);
+   keyStore.setCertificateEntry("server", certificate);
+   TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+   trustManagerFactory.init(keyStore);
+   SSLContext sslContext = SSLContext.getInstance("TLS");
+   sslContext.init(null, trustManagerFactory.getTrustManagers(), null);
+   mqtt.setSslContext(sslContext);
+   BlockingConnection connection = mqtt.blockingConnection();
+   connection.connect();
+   ```
 
 #### TLS PSK with broker
 
 Please reference [here](https://en.wikipedia.org/wiki/TLS-PSK) to learn more about TLS-PSK.
 
 1. Config mqtt broker to load tls psk config.
-```conf
-...
-mqttTlsPskEnabled=true
-mqttListeners=mqtt+ssl+psk://127.0.0.1:8884
-// any string can be specified
-mqttTlsPskIdentityHint=alpha
-// identity is semicolon list of string with identity:secret format
-mqttTlsPskIdentity=mqtt:mqtt123
-...
-```
-Optional configs
-
-|       Config key       | Comment  |
-|:----------------------:| -------- |
-| mqttTlsPskIdentityFile | When you want identities in a single file with many pairs, you can config this. Identities will load from both `tlsPskIdentity` and `tlsPskIdentityFile`  |
-|    mqttTlsProtocols    | TLS PSK protocols, default are [ TLSv1, TLSv1.1, TLSv1.2 ]  |
-|     mqttTlsCiphers     | TLS PSK ciphers, default are [ TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA, TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA, TLS_PSK_WITH_AES_128_CBC_SHA, TLS_PSK_WITH_AES_256_CBC_SHA ] |
+   ```conf
+   mqttTlsPskEnabled=true
+   mqttListeners=mqtt+ssl+psk://127.0.0.1:8884
+   // any string can be specified
+   mqttTlsPskIdentityHint=alpha
+   // identity is semicolon list of string with identity:secret format
+   mqttTlsPskIdentity=mqtt:mqtt123
+   ```
+   Optional configs
+   
+   |       Config key       | Comment  |
+   |:----------------------:| -------- |
+   | mqttTlsPskIdentityFile | When you want identities in a single file with many pairs, you can config this. Identities will load from both `tlsPskIdentity` and `tlsPskIdentityFile`  |
+   |    mqttTlsProtocols    | TLS PSK protocols, default are [ TLSv1, TLSv1.1, TLSv1.2 ]  |
+   |     mqttTlsCiphers     | TLS PSK ciphers, default are [ TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA, TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA, TLS_PSK_WITH_AES_128_CBC_SHA, TLS_PSK_WITH_AES_256_CBC_SHA ] |
 
 2. As current known mqtt Java client does not support TLS-PSK, it's better to verify this by `mosquitto cli`
-```cli
-# Default with tlsv1.2
-mosquitto_pub --psk-identity mqtt --psk 6d717474313233 -p 8884 -t "/a/b/c" -m "hello mqtt"
-
-# Test with tlsv1.1
-mosquitto_pub --psk-identity mqtt --psk 6d717474313233 -p 8884 -t "/a/b/c" -m "hello mqtt" --tls-version tlsv1.1
-
-# Test with tlsv1
-mosquitto_pub --psk-identity mqtt --psk 6d717474313233 -p 8884 -t "/a/b/c" -m "hello mqtt" --tls-version tlsv1
-```
+   ```cli
+   # Default with tlsv1.2
+   mosquitto_pub --psk-identity mqtt --psk 6d717474313233 -p 8884 -t "/a/b/c" -m "hello mqtt"
+   
+   # Test with tlsv1.1
+   mosquitto_pub --psk-identity mqtt --psk 6d717474313233 -p 8884 -t "/a/b/c" -m "hello mqtt" --tls-version tlsv1.1
+   
+   # Test with tlsv1
+   mosquitto_pub --psk-identity mqtt --psk 6d717474313233 -p 8884 -t "/a/b/c" -m "hello mqtt" --tls-version tlsv1
+   ```
 - Download [mosquitto](https://mosquitto.org/download/) with Mac version.
 - The secret `mqtt123` is converted to `6d717474313233` using [Hex Code Converter](https://www.rapidtables.com/convert/number/ascii-to-hex.html)
 
 #### TLS PSK with proxy
 
 1. Config mqtt proxy to load tls psk config.
-```conf
-...
-mqttProxyEnable=true
-mqttProxyTlsPskEnabled=true
-// default tls psk port
-mqttProxyTlsPskPort=5684
-// any string can be specified
-mqttTlsPskIdentityHint=alpha
-// identity is semicolon list of string with identity:secret format
-mqttTlsPskIdentity=mqtt:mqtt123
-...
-```
+   ```conf
+   mqttProxyEnable=true
+   mqttProxyTlsPskEnabled=true
+   // default tls psk port
+   mqttProxyTlsPskPort=5684
+   // any string can be specified
+   mqttTlsPskIdentityHint=alpha
+   // identity is semicolon list of string with identity:secret format
+   mqttTlsPskIdentity=mqtt:mqtt123
+   ```
 
 2. Test with `mosquitto cli`
-```
-mosquitto_pub --psk-identity mqtt --psk 6d717474313233 -p 5684 -t "/a/b/c" -m "hello mqtt"
-```
+   ```
+   mosquitto_pub --psk-identity mqtt --psk 6d717474313233 -p 5684 -t "/a/b/c" -m "hello mqtt"
+   ```
+
+3. Add PSK identities dynamically.  
+   You can add psk identities dynamically by REST API in proxy mode.
+   ```
+   curl -X POST http://pulsar-broker-webservice-address:port/mop/add_psk_identity -d "identity=mqtt2:mqtt222;mqtt3:mqtt333"
+   ```
 
 ## Topic Names & Filters
 
@@ -401,9 +397,9 @@ MoP can also expose metrics through the http interface. Add below configs first 
 additionalServlets=mqtt-servlet
 additionalServletDirectory=[protocolHandlerDir]
 ```
-Then you can obtain mop information in json format through `/mop-stats`:
+Then you can obtain mop information in json format through `/mop/stats`:
 ```
-curl http://pulsar-broker-webservice-address:port/mop-stats/
+curl http://pulsar-broker-webservice-address:port/mop/stats
 {"cluster":"test","subscriptions":{"subs":["/a/b/c"],"count":1},"clients":{"total":1,"maximum":1,"active":0,"active_clients":[]},"namespace":"default","messages":{"received_bytes":57351,"received_count":10,"send_count":20,"send_bytes":60235},"version":"2.9.0-SNAPSHOT","tenant":"public","uptime":"46 seconds"}
 ```
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,8 @@ Please reference [here](https://en.wikipedia.org/wiki/TLS-PSK) to learn more abo
    mosquitto_pub --psk-identity mqtt --psk 6d717474313233 -p 5684 -t "/a/b/c" -m "hello mqtt"
    ```
 
-3. Add PSK identities dynamically.   
+3. Add PSK identities dynamically.
+   
    You can add psk identities dynamically by REST API in proxy mode.
    ```
    curl -X POST http://pulsar-broker-webservice-address:port/mop/add_psk_identity -d "identity=mqtt2:mqtt222;mqtt3:mqtt333"

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTAdditionalServlet.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTAdditionalServlet.java
@@ -32,7 +32,7 @@ public class MQTTAdditionalServlet implements AdditionalServletWithPulsarService
 
     @Override
     public String getBasePath() {
-        return "/mop-stats";
+        return "/mop";
     }
 
     @Override

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTChannelInitializer.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTChannelInitializer.java
@@ -21,7 +21,6 @@ import io.netty.handler.codec.mqtt.MqttEncoder;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateHandler;
-import io.streamnative.pulsar.handlers.mqtt.support.psk.PSKConfiguration;
 import io.streamnative.pulsar.handlers.mqtt.support.psk.PSKUtils;
 import org.apache.pulsar.common.util.NettyServerSslContextBuilder;
 import org.apache.pulsar.common.util.SslContextAutoRefreshBuilder;
@@ -40,7 +39,6 @@ public class MQTTChannelInitializer extends ChannelInitializer<SocketChannel> {
 
     private SslContextAutoRefreshBuilder<SslContext> sslCtxRefresher;
     private NettySSLContextAutoRefreshBuilder nettySSLContextAutoRefreshBuilder;
-    private PSKConfiguration pskConfiguration;
 
     public MQTTChannelInitializer(MQTTService mqttService, boolean enableTls) {
         this(mqttService, enableTls, false);
@@ -79,15 +77,6 @@ public class MQTTChannelInitializer extends ChannelInitializer<SocketChannel> {
                         mqttConfig.isMqttTlsRequireTrustedClientCertOnConnect(),
                         mqttConfig.getMqttTlsCertRefreshCheckDurationSec());
             }
-        } else if (this.enableTlsPsk) {
-            pskConfiguration = new PSKConfiguration();
-            pskConfiguration.setIdentityHint(mqttConfig.getMqttTlsPskIdentityHint());
-            pskConfiguration.setIdentity(mqttConfig.getMqttTlsPskIdentity());
-            pskConfiguration.setIdentityFile(mqttConfig.getMqttTlsPskIdentityFile());
-            pskConfiguration.setProtocols(mqttConfig.getMqttTlsProtocols());
-            pskConfiguration.setCiphers(mqttConfig.getMqttTlsCiphers());
-        } else {
-            this.sslCtxRefresher = null;
         }
     }
 
@@ -102,7 +91,8 @@ public class MQTTChannelInitializer extends ChannelInitializer<SocketChannel> {
                 ch.pipeline().addLast(TLS_HANDLER, sslCtxRefresher.get().newHandler(ch.alloc()));
             }
         } else if (this.enableTlsPsk) {
-            ch.pipeline().addLast(TLS_HANDLER, new SslHandler(PSKUtils.createServerEngine(ch, pskConfiguration)));
+            ch.pipeline().addLast(TLS_HANDLER,
+                    new SslHandler(PSKUtils.createServerEngine(ch, mqttService.getPskConfiguration())));
         }
         ch.pipeline().addLast("decoder", new MqttDecoder(mqttConfig.getMqttMessageMaxLength()));
         ch.pipeline().addLast("encoder", MqttEncoder.INSTANCE);

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTService.java
@@ -20,6 +20,7 @@ import io.streamnative.pulsar.handlers.mqtt.support.WillMessageHandler;
 import io.streamnative.pulsar.handlers.mqtt.support.event.DisableEventCenter;
 import io.streamnative.pulsar.handlers.mqtt.support.event.PulsarEventCenter;
 import io.streamnative.pulsar.handlers.mqtt.support.event.PulsarEventCenterImpl;
+import io.streamnative.pulsar.handlers.mqtt.support.psk.PSKConfiguration;
 import io.streamnative.pulsar.handlers.mqtt.support.systemtopic.SystemEventService;
 import lombok.Getter;
 import lombok.Setter;
@@ -39,6 +40,9 @@ public class MQTTService {
 
     @Getter
     private final MQTTServerConfiguration serverConfiguration;
+
+    @Getter
+    private final PSKConfiguration pskConfiguration;
 
     @Getter
     private final PulsarService pulsarService;
@@ -81,6 +85,7 @@ public class MQTTService {
         this.brokerService = brokerService;
         this.pulsarService = brokerService.pulsar();
         this.serverConfiguration = serverConfiguration;
+        this.pskConfiguration = new PSKConfiguration(serverConfiguration);
         this.authorizationService = brokerService.getAuthorizationService();
         this.bundleOwnershipListener = new MQTTNamespaceBundleOwnershipListener(pulsarService.getNamespaceService());
         this.metricsCollector = new MQTTMetricsCollector(serverConfiguration);
@@ -99,6 +104,7 @@ public class MQTTService {
         }
         this.willMessageHandler = new WillMessageHandler(this);
         this.retainedMessageHandler = new RetainedMessageHandler(this);
+
     }
 
     public boolean isSystemTopicEnabled() {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyService.java
@@ -55,7 +55,7 @@ public class MQTTProxyService implements Closeable {
     @Getter
     private final PulsarEventCenter eventCenter;
     @Getter
-    private PSKConfiguration pskConfiguration = new PSKConfiguration();
+    private final PSKConfiguration pskConfiguration;
 
     private Channel listenChannel;
     private Channel listenChannelTls;
@@ -70,6 +70,7 @@ public class MQTTProxyService implements Closeable {
         configValid(proxyConfig);
         this.pulsarService = mqttService.getPulsarService();
         this.proxyConfig = proxyConfig;
+        this.pskConfiguration = new PSKConfiguration(proxyConfig);
         this.authenticationService = mqttService.getAuthenticationService();
         this.connectionManager = new MQTTConnectionManager(pulsarService.getAdvertisedAddress());
         this.eventService = proxyConfig.isSystemEventEnabled()

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/psk/PSKConfiguration.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/psk/PSKConfiguration.java
@@ -17,6 +17,8 @@ package io.streamnative.pulsar.handlers.mqtt.support.psk;
 import static io.streamnative.pulsar.handlers.mqtt.support.systemtopic.EventType.ADD_PSK_IDENTITY;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ApplicationProtocolNames;
+import io.streamnative.pulsar.handlers.mqtt.MQTTServerConfiguration;
+import io.streamnative.pulsar.handlers.mqtt.proxy.MQTTProxyConfiguration;
 import io.streamnative.pulsar.handlers.mqtt.support.systemtopic.EventListener;
 import io.streamnative.pulsar.handlers.mqtt.support.systemtopic.MqttEvent;
 import io.streamnative.pulsar.handlers.mqtt.support.systemtopic.PSKEvent;
@@ -90,6 +92,26 @@ public class PSKConfiguration {
 
     @Getter
     private final PSKEventListener eventListener = new PSKEventListener();
+
+    public PSKConfiguration() {
+
+    }
+
+    public PSKConfiguration(MQTTProxyConfiguration config) {
+        setIdentityHint(config.getMqttTlsPskIdentityHint());
+        setIdentity(config.getMqttTlsPskIdentity());
+        setIdentityFile(config.getMqttTlsPskIdentityFile());
+        setProtocols(config.getMqttTlsProtocols());
+        setCiphers(config.getMqttTlsCiphers());
+    }
+
+    public PSKConfiguration(MQTTServerConfiguration config) {
+        setIdentityHint(config.getMqttTlsPskIdentityHint());
+        setIdentity(config.getMqttTlsPskIdentity());
+        setIdentityFile(config.getMqttTlsPskIdentityFile());
+        setProtocols(config.getMqttTlsProtocols());
+        setCiphers(config.getMqttTlsCiphers());
+    }
 
     public void setIdentityFile(String identityFile) {
         if (StringUtils.isNotEmpty(identityFile)) {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/psk/PSKSecretKey.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/psk/PSKSecretKey.java
@@ -15,6 +15,7 @@
 package io.streamnative.pulsar.handlers.mqtt.support.psk;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import javax.crypto.SecretKey;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -44,5 +45,26 @@ public class PSKSecretKey implements SecretKey {
     @Override
     public byte[] getEncoded() {
         return pwd.getBytes(StandardCharsets.UTF_8);
+    }
+
+    public String getPlainText() {
+        return String.format("%s:%s", identity, pwd);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PSKSecretKey that = (PSKSecretKey) o;
+        return Objects.equals(identity, that.identity) && Objects.equals(pwd, that.pwd);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identity, pwd);
     }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/psk/PSKUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/psk/PSKUtils.java
@@ -13,18 +13,22 @@
  */
 package io.streamnative.pulsar.handlers.mqtt.support.psk;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.net.ssl.SSLEngine;
 import org.conscrypt.OpenSSLProvider;
 
@@ -68,6 +72,18 @@ public class PSKUtils {
             throw new IllegalArgumentException(e);
         }
         return result;
+    }
+
+    public static void write(File file, List<PSKSecretKey> pskKeys) {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(file, false))) {
+            String identity = Joiner
+                    .on(";")
+                    .skipNulls()
+                    .join(pskKeys.stream().map(key -> key.getPlainText()).collect(Collectors.toList()));
+            writer.write(identity);
+        } catch (Exception ex) {
+            throw new IllegalArgumentException(ex);
+        }
     }
 
     public static List<PSKSecretKey> parse(String identityText) {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/DisabledSystemEventService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/DisabledSystemEventService.java
@@ -48,6 +48,11 @@ public class DisabledSystemEventService implements SystemEventService{
     }
 
     @Override
+    public CompletableFuture<Void> sendPSKEvent(PSKEvent event) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
     public CompletableFuture<Void> sendEvent(MqttEvent event) {
         return CompletableFuture.completedFuture(null);
     }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/EventType.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/EventType.java
@@ -16,5 +16,6 @@ package io.streamnative.pulsar.handlers.mqtt.support.systemtopic;
 public enum EventType {
     CONNECT,
     LAST_WILL_MESSAGE,
-    RETAINED_MESSAGE;
+    RETAINED_MESSAGE,
+    ADD_PSK_IDENTITY;
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/MqttEventUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/MqttEventUtils.java
@@ -61,4 +61,18 @@ public class MqttEventUtils {
             throw new IllegalArgumentException(e);
         }
     }
+
+    public static MqttEvent getMqttEvent(PSKEvent event, ActionType actionType) {
+        MqttEvent.MqttEventBuilder builder = MqttEvent.builder();
+        try {
+            return builder
+                    .key("add_psk_identity")
+                    .eventType(EventType.ADD_PSK_IDENTITY)
+                    .actionType(actionType)
+                    .sourceEvent(JsonUtil.toJson(event))
+                    .build();
+        } catch (JsonUtil.ParseJsonException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/PSKEvent.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/PSKEvent.java
@@ -13,23 +13,16 @@
  */
 package io.streamnative.pulsar.handlers.mqtt.support.systemtopic;
 
-import java.util.concurrent.CompletableFuture;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-public interface SystemEventService {
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PSKEvent extends SourceEvent {
 
-    void start();
-
-    void close();
-
-    void addListener(EventListener listener);
-
-    CompletableFuture<Void> sendConnectEvent(ConnectEvent event);
-
-    CompletableFuture<Void> sendLWTEvent(LastWillMessageEvent event);
-
-    CompletableFuture<Void> sendRetainedEvent(RetainedMessageEvent event);
-
-    CompletableFuture<Void> sendPSKEvent(PSKEvent event);
-
-    CompletableFuture<Void> sendEvent(MqttEvent event);
+    String identity;
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/SystemTopicBasedSystemEventService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/SystemTopicBasedSystemEventService.java
@@ -100,6 +100,17 @@ public class SystemTopicBasedSystemEventService implements SystemEventService {
     }
 
     @Override
+    public CompletableFuture<Void> sendPSKEvent(PSKEvent event) {
+        checkReader();
+        return sendEvent(getMqttEvent(event, ActionType.INSERT))
+                .thenRun(() -> {
+                    if (log.isDebugEnabled()) {
+                        log.debug("send psk event : {}", event);
+                    }
+                });
+    }
+
+    @Override
     public CompletableFuture<Void> sendEvent(MqttEvent event) {
         CompletableFuture<SystemTopicClient.Writer<MqttEvent>> writerFuture = systemTopicClient.newWriterAsync();
         return writerFuture.thenCompose(writer -> {
@@ -215,6 +226,11 @@ public class SystemTopicBasedSystemEventService implements SystemEventService {
                     RetainedMessageEvent retainedEvent = JsonUtil.fromJson((String) value.getSourceEvent(),
                             RetainedMessageEvent.class);
                     value.setSourceEvent(retainedEvent);
+                    break;
+                case ADD_PSK_IDENTITY:
+                    PSKEvent pskEvent = JsonUtil.fromJson((String) value.getSourceEvent(),
+                            PSKEvent.class);
+                    value.setSourceEvent(pskEvent);
                     break;
                 default:
                     break;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
@@ -406,7 +406,7 @@ public class SimpleIntegrationTest extends MQTTTestBase {
     @SneakyThrows
     public void testServlet() {
         HttpClient httpClient = HttpClientBuilder.create().build();
-        final String mopEndPoint = "http://localhost:" + brokerWebservicePortList.get(0) + "/mop-stats";
+        final String mopEndPoint = "http://localhost:" + brokerWebservicePortList.get(0) + "/mop/stats";
         HttpResponse response = httpClient.execute(new HttpGet(mopEndPoint));
         InputStream inputStream = response.getEntity().getContent();
         InputStreamReader isReader = new InputStreamReader(inputStream);


### PR DESCRIPTION
Fixes #162 
Master Issue: #162

### Motivation

Currently, PSK identities are configured when MoP startup. If adding new identities, we have to restart the server, but new clients with new identities are a common scenario, so support adding PSK identities with REST API dynamically.

### Documentation


- [x] `doc-updated` 

