### PR TITLE
Support Proxy `PulsarClient` connect to Broker with TLS

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTProtocolHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTProtocolHandler.java
@@ -87,10 +87,6 @@ public class MQTTProtocolHandler implements ProtocolHandler {
             try {
                 MQTTProxyConfiguration proxyConfig =
                         ConfigurationUtils.create(mqttConfig.getProperties(), MQTTProxyConfiguration.class);
-                proxyConfig.setBrokerServiceURL("pulsar://"
-                        + ServiceConfigurationUtils.getAppliedAdvertisedAddress(mqttConfig, true)
-                        + ":" + mqttConfig.getBrokerServicePort().get());
-                log.info("proxyConfig broker service URL: {}", proxyConfig.getBrokerServiceURL());
                 proxyService = new MQTTProxyService(mqttService, proxyConfig);
                 proxyService.start();
                 log.info("Start MQTT proxy service at port: {}", proxyConfig.getMqttProxyPort());

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyService.java
@@ -92,7 +92,6 @@ public class MQTTProxyService implements Closeable {
         checkNotNull(proxyConfig);
         checkArgument(proxyConfig.getMqttProxyPort() > 0);
         checkNotNull(proxyConfig.getDefaultTenant());
-        checkNotNull(proxyConfig.getBrokerServiceURL());
     }
 
     public void start() throws MQTTProxyException {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/PulsarServiceLookupHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/PulsarServiceLookupHandler.java
@@ -156,7 +156,7 @@ public class PulsarServiceLookupHandler implements LookupHandler {
             return new PulsarClientImpl(conf);
         } catch (PulsarClientException e) {
             log.error("Failed to create PulsarClient", e);
-            throw new IllegalStateException(e);
+            throw new IllegalArgumentException(e);
         }
     }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/ConfigurationUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/ConfigurationUtils.java
@@ -46,6 +46,7 @@ public final class ConfigurationUtils {
     public static final String SSL_PREFIX = "mqtt+ssl://";
     public static final String SSL_PSK_PREFIX = "mqtt+ssl+psk://";
     public static final String LISTENER_DEL = ",";
+    public static final String COLON = ":";
     public static final String LISTENER_PATTERN = "^(mqtt)(\\+ssl)?(\\+psk)?://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-0-9+]";
 
     /**

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/proxy/ProxyToPulsarTlsTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/proxy/ProxyToPulsarTlsTest.java
@@ -1,0 +1,38 @@
+package io.streamnative.pulsar.handlers.mqtt.mqtt3.fusesource.proxy;
+
+import io.streamnative.pulsar.handlers.mqtt.MQTTCommonConfiguration;
+import io.streamnative.pulsar.handlers.mqtt.base.MQTTTestBase;
+import org.fusesource.mqtt.client.*;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ProxyToPulsarTlsTest extends MQTTTestBase {
+
+    @Override
+    protected MQTTCommonConfiguration initConfig() throws Exception {
+        MQTTCommonConfiguration mqtt = super.initConfig();
+        mqtt.setMqttProxyEnabled(true);
+        mqtt.setTlsEnabled(true);
+        mqtt.setTlsKeyFilePath(TLS_SERVER_KEY_FILE_PATH);
+        mqtt.setTlsCertificateFilePath(TLS_SERVER_CERT_FILE_PATH);
+        return mqtt;
+    }
+
+
+    @Test(dataProvider = "mqttTopicNames", timeOut = TIMEOUT, priority = 4)
+    public void testSendAndConsume(String topicName) throws Exception {
+        MQTT mqtt = createMQTTProxyClient();
+        BlockingConnection connection = mqtt.blockingConnection();
+        connection.connect();
+        Topic[] topics = { new Topic(topicName, QoS.AT_MOST_ONCE) };
+        connection.subscribe(topics);
+        String message = "Hello MQTT Proxy";
+        connection.publish(topicName, message.getBytes(), QoS.AT_MOST_ONCE, false);
+        Message received = connection.receive();
+        Assert.assertEquals(received.getTopic(), topicName);
+        Assert.assertEquals(new String(received.getPayload()), message);
+        received.ack();
+        connection.disconnect();
+    }
+
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/proxy/ProxyToPulsarTlsTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/proxy/ProxyToPulsarTlsTest.java
@@ -16,7 +16,11 @@ package io.streamnative.pulsar.handlers.mqtt.mqtt3.fusesource.proxy;
 
 import io.streamnative.pulsar.handlers.mqtt.MQTTCommonConfiguration;
 import io.streamnative.pulsar.handlers.mqtt.base.MQTTTestBase;
-import org.fusesource.mqtt.client.*;
+import org.fusesource.mqtt.client.BlockingConnection;
+import org.fusesource.mqtt.client.MQTT;
+import org.fusesource.mqtt.client.Message;
+import org.fusesource.mqtt.client.QoS;
+import org.fusesource.mqtt.client.Topic;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/proxy/ProxyToPulsarTlsTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/proxy/ProxyToPulsarTlsTest.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.streamnative.pulsar.handlers.mqtt.mqtt3.fusesource.proxy;
 
 import io.streamnative.pulsar.handlers.mqtt.MQTTCommonConfiguration;


### PR DESCRIPTION
### Motivation

The broker lookup handler could not resolve the addresses of multiple MQTT listeners. Because we used to use hard code to parse `mqttBrokerUrl`. we just assume it's a single URL. But this property can be multiple, like `mqtt://127.0.0.1:1884,mqtt+ssl://127.0.0.1:1885`

### Modifications

- Support `LookupHandler` to resolve multiple addresses.
- Support Proxy inner client use TLS.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation
  
- [x] `no-need-doc` 
  
