### PR TITLE
Fix wrong servlet path in test

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
@@ -521,7 +521,7 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         producer2.connect();
         //
         HttpClient httpClient = HttpClientBuilder.create().build();
-        final String mopEndPoint = "http://localhost:" + brokerWebservicePortList.get(0) + "/mop-stats";
+        final String mopEndPoint = "http://localhost:" + brokerWebservicePortList.get(0) + "/mop/stats";
         HttpResponse response = httpClient.execute(new HttpGet(mopEndPoint));
         InputStream inputStream = response.getEntity().getContent();
         InputStreamReader isReader = new InputStreamReader(inputStream);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/proxy/ProxyTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/proxy/ProxyTest.java
@@ -227,7 +227,7 @@ public class ProxyTest extends MQTTTestBase {
         broker.thenAccept(pair -> {
             try {
                 HttpClient httpClient = HttpClientBuilder.create().build();
-                final String mopEndPoint = "http://localhost:" + (pair.getLeft().getPort() + 2) + "/mop-stats";
+                final String mopEndPoint = "http://localhost:" + (pair.getLeft().getPort() + 2) + "/mop/stats";
                 HttpResponse response = httpClient.execute(new HttpGet(mopEndPoint));
                 InputStream inputStream = response.getEntity().getContent();
                 InputStreamReader isReader = new InputStreamReader(inputStream);


### PR DESCRIPTION
### Motivation

In PR #584 we introduce new servlet path from `mop-stats` to `/mop/*`

### Modifications

- Change test servlet path.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 
  
