### PR TITLE
Add maxPendingSendRequest to limit client side sending rate.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/adapter/MQTTProxyAdapter.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/adapter/MQTTProxyAdapter.java
@@ -197,5 +197,12 @@ public class MQTTProxyAdapter {
             log.error("exception caught when connect with MoP broker.", cause);
             ctx.close();
         }
+
+        @Override
+        public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+            if (log.isDebugEnabled()) {
+                log.debug("Channel writability has changed to: {}", ctx.channel().isWritable());
+            }
+        }
     }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/adapter/MqttAdapterMessage.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/adapter/MqttAdapterMessage.java
@@ -26,7 +26,7 @@ public class MqttAdapterMessage {
     public static final byte DEFAULT_VERSION = 0x00;
 
     private final byte version;
-    private final String clientId;
+    private String clientId;
     private MqttMessage mqttMessage;
     private EncodeType encodeType;
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyConfiguration.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyConfiguration.java
@@ -51,8 +51,15 @@ public class MQTTProxyConfiguration extends MQTTCommonConfiguration {
 
     @FieldContext(
             category = CATEGORY_MQTT_PROXY,
+            doc = "Maximum number of pending send requests allowed on "
+                    + "each proxy connection to prevent overloading a broker."
+    )
+    private int maxPendingSendRequest = 1000;
+
+    @FieldContext(
+            category = CATEGORY_MQTT_PROXY,
             doc = "Enable system event service."
     )
-    private boolean systemEventEnabled = false;
+    private boolean systemEventEnabled = true;
 
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -252,6 +252,7 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
                 log.debug("[Proxy Connection Lost] [{}] ", connection.getClientId());
             }
             connectionManager.removeConnection(connection);
+            connection.close();
         }
         topicBrokers.clear();
     }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -90,7 +90,7 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
 
     private int pendingSendRequest = 0;
     private final int maxPendingSendRequest;
-    private final int resumeReadsThreshold;
+    private final int resumeReadThreshold;
 
     public MQTTProxyProtocolMethodProcessor(MQTTProxyService proxyService, ChannelHandlerContext ctx) {
         super(proxyService.getAuthenticationService(),
@@ -107,7 +107,7 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
         this.pulsarEventCenter = proxyService.getEventCenter();
         this.proxyAdapter = proxyService.getProxyAdapter();
         this.maxPendingSendRequest = proxyConfig.getMaxPendingSendRequest();
-        this.resumeReadsThreshold = maxPendingSendRequest / 2;
+        this.resumeReadThreshold = maxPendingSendRequest / 2;
     }
 
     @Override
@@ -177,7 +177,7 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
     }
 
     private CompletableFuture<Void> endPublish() {
-        if (--pendingSendRequest == resumeReadsThreshold) {
+        if (--pendingSendRequest == resumeReadThreshold) {
             if (!ctx.channel().config().isAutoRead()) {
                 ctx.channel().config().setAutoRead(true);
                 ctx.read();

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyService.java
@@ -77,8 +77,8 @@ public class MQTTProxyService implements Closeable {
         this.authenticationService = mqttService.getAuthenticationService();
         this.connectionManager = new MQTTConnectionManager(pulsarService.getAdvertisedAddress());
         this.eventService = proxyConfig.isSystemEventEnabled()
-                ? new SystemTopicBasedSystemEventService(mqttService.getPulsarService()) :
-                new DisabledSystemEventService();
+                ? new SystemTopicBasedSystemEventService(mqttService.getPulsarService())
+                : new DisabledSystemEventService();
         this.eventService.addListener(connectionManager.getEventListener());
         this.eventService.addListener(mqttService.getWillMessageHandler().getEventListener());
         this.eventService.addListener(mqttService.getRetainedMessageHandler().getEventListener());

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/proxy/ProxyTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/proxy/ProxyTest.java
@@ -97,7 +97,7 @@ public class ProxyTest extends MQTTTestBase {
         Topic[] topics = { new Topic(topicName, QoS.AT_MOST_ONCE) };
         connection.subscribe(topics);
         String message = "Hello MQTT";
-        int numMessages = 1000;
+        int numMessages = 20000;
         for (int i = 0; i < numMessages; i++) {
             connection.publish(topicName, (message + i).getBytes(), QoS.AT_MOST_ONCE, false);
         }


### PR DESCRIPTION
Master Issue: #592

### Motivation
As #588 merged, the proxy to broker will create at least one channel. If sending data is to fast, the channel will be not writable. so add `maxPendingSendRequest` to limit client side seding rate.


### Modification
- Add `maxPendingSendRequest`
- Make proxy to re-use the adapter msg to avoid creating new one.


### Test
- ProxyTest#testBacklogShouldBeZeroWithQos0 will cover this patch.

### Documentation

- [x] `doc-required` 
  

