### PR TITLE
Fix wrong behaviour when broker sends `DISCONNECT` message to proxy.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/adapter/MQTTProxyAdapter.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/adapter/MQTTProxyAdapter.java
@@ -164,6 +164,8 @@ public class MQTTProxyAdapter {
                         if (MqttUtils.isNotMqtt3(connection.getProtocolVersion())) {
                             processor.getChannel().writeAndFlush(adapterMsg);
                         }
+                        // When the adapter receives DISCONNECT, we don't need to trigger send disconnect to broker.
+                        processor.getIsDisconnected().set(true);
                         processor.getChannel().close();
                         break;
                     case PUBLISH:

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/adapter/MQTTProxyAdapter.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/adapter/MQTTProxyAdapter.java
@@ -162,9 +162,9 @@ public class MQTTProxyAdapter {
                 switch (messageType) {
                     case DISCONNECT:
                         if (MqttUtils.isNotMqtt3(connection.getProtocolVersion())) {
-                            connection.getChannel().writeAndFlush(adapterMsg);
+                            processor.getChannel().writeAndFlush(adapterMsg);
                         }
-                        connection.getChannel().close();
+                        processor.getChannel().close();
                         break;
                     case PUBLISH:
                         MqttPublishMessage pubMessage = (MqttPublishMessage) msg;

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/adapter/MQTTProxyAdapter.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/adapter/MQTTProxyAdapter.java
@@ -183,7 +183,7 @@ public class MQTTProxyAdapter {
                             processor.getChannel().writeAndFlush(adapterMsg);
                         }
                         // When the adapter receives DISCONNECT, we don't need to trigger send disconnect to broker.
-                        processor.getIsDisconnected().set(true);
+                        processor.isDisconnected().set(true);
                         processor.getChannel().close();
                         break;
                     case PUBLISH:

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -86,6 +86,7 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
     private final SystemEventService eventService;
     private final PulsarEventCenter pulsarEventCenter;
     private final MQTTProxyAdapter proxyAdapter;
+    @Getter
     private final AtomicBoolean isDisconnected = new AtomicBoolean(false);
 
     private int pendingSendRequest = 0;
@@ -250,12 +251,9 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
         if (connection != null) {
             // If client close the channel without calling disconnect, then we should call disconnect to notify broker
             // to clean up the resource.
-            if (!isDisconnected.get()) {
-                processDisconnect(new MqttAdapterMessage(MqttMessageUtils.createMqttDisconnectMessage()));
-            } else {
-                connectionManager.removeConnection(connection);
-                connection.close();
-            }
+            processDisconnect(new MqttAdapterMessage(MqttMessageUtils.createMqttDisconnectMessage()));
+            connectionManager.removeConnection(connection);
+            connection.close();
         }
         topicBrokers.clear();
     }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -86,7 +86,6 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
     private final SystemEventService eventService;
     private final PulsarEventCenter pulsarEventCenter;
     private final MQTTProxyAdapter proxyAdapter;
-    @Getter
     private final AtomicBoolean isDisconnected = new AtomicBoolean(false);
 
     private int pendingSendRequest = 0;
@@ -454,5 +453,9 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
             return false;
         }
         return decreaseSubscribeTopicsCount(packetId) == 0;
+    }
+
+    public AtomicBoolean isDisconnected() {
+        return this.isDisconnected;
     }
 }


### PR DESCRIPTION
### Motivation

Current, when the broker sends a `DISCONNECT` message to the proxy, the proxy will close the channel and trigger `processConnectionLost`,  then the proxy will re-send a `DISCONNECT` message to the broker. 
This is wrong behaviour. when the broker sends a `DISCONNECT` message to the proxy, it means that the broker just wants the proxy to close the client's connection, and the broker has cleaned up the relevant state.

### Modifications

- When the proxy receives a `DISCONNECT` message from the broker, do not trigger the handler to resend `DISCONNECT` to the broker.
- Fixed NPE with null connection when processor invokes `processConnectionLost`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 
  
