### PR TITLE
#Fix publish request get wrong connection when shared connection

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/QosPublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/QosPublishHandler.java
@@ -21,5 +21,5 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface QosPublishHandler {
 
-    CompletableFuture<Void> publish(MqttAdapterMessage msg);
+    CompletableFuture<Void> publish(MqttAdapterMessage msg, Connection connection);
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTBrokerProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTBrokerProtocolMethodProcessor.java
@@ -221,13 +221,13 @@ public class MQTTBrokerProtocolMethodProcessor extends AbstractCommonProtocolMet
         metricsCollector.addSend(msg.payload().readableBytes());
         switch (qos) {
             case AT_MOST_ONCE:
-                return this.qosPublishHandlers.qos0().publish(adapter);
+                return this.qosPublishHandlers.qos0().publish(adapter, connection);
             case AT_LEAST_ONCE:
                 checkServerReceivePubMessageAndIncrementCounterIfNeeded(adapter);
-                return this.qosPublishHandlers.qos1().publish(adapter);
+                return this.qosPublishHandlers.qos1().publish(adapter, connection);
             case EXACTLY_ONCE:
                 checkServerReceivePubMessageAndIncrementCounterIfNeeded(adapter);
-                return this.qosPublishHandlers.qos2().publish(adapter);
+                return this.qosPublishHandlers.qos2().publish(adapter, connection);
             default:
                 log.error("[Publish] Unknown QoS-Type:{}", qos);
                 connection.getChannel().close();

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos0PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos0PublishHandler.java
@@ -16,6 +16,7 @@ package io.streamnative.pulsar.handlers.mqtt.support;
 import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.streamnative.pulsar.handlers.mqtt.AbstractQosPublishHandler;
+import io.streamnative.pulsar.handlers.mqtt.Connection;
 import io.streamnative.pulsar.handlers.mqtt.MQTTServerConfiguration;
 import io.streamnative.pulsar.handlers.mqtt.MQTTService;
 import io.streamnative.pulsar.handlers.mqtt.adapter.MqttAdapterMessage;
@@ -33,7 +34,7 @@ public class Qos0PublishHandler extends AbstractQosPublishHandler {
     }
 
     @Override
-    public CompletableFuture<Void> publish(MqttAdapterMessage adapter) {
+    public CompletableFuture<Void> publish(MqttAdapterMessage adapter, Connection connection) {
         final MqttPublishMessage msg = (MqttPublishMessage) adapter.getMqttMessage();
         if (MqttUtils.isRetainedMessage(msg)) {
             return retainedMessageHandler.addRetainedMessage(msg);

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
@@ -42,9 +42,8 @@ public class Qos1PublishHandler extends AbstractQosPublishHandler {
     }
 
     @Override
-    public CompletableFuture<Void> publish(MqttAdapterMessage adapter) {
+    public CompletableFuture<Void> publish(MqttAdapterMessage adapter, Connection connection) {
         final MqttPublishMessage msg = (MqttPublishMessage) adapter.getMqttMessage();
-        final Connection connection = NettyUtils.getConnection(channel);
         final int protocolVersion = connection.getProtocolVersion();
         final int packetId = msg.variableHeader().packetId();
         final String topic = msg.variableHeader().topicName();

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
@@ -25,7 +25,6 @@ import io.streamnative.pulsar.handlers.mqtt.messages.ack.MqttAck;
 import io.streamnative.pulsar.handlers.mqtt.messages.ack.MqttPubAck;
 import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5PubReasonCode;
 import io.streamnative.pulsar.handlers.mqtt.utils.MqttUtils;
-import io.streamnative.pulsar.handlers.mqtt.utils.NettyUtils;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.service.BrokerServiceException;

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos2PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos2PublishHandler.java
@@ -16,6 +16,7 @@ package io.streamnative.pulsar.handlers.mqtt.support;
 import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.streamnative.pulsar.handlers.mqtt.AbstractQosPublishHandler;
+import io.streamnative.pulsar.handlers.mqtt.Connection;
 import io.streamnative.pulsar.handlers.mqtt.MQTTServerConfiguration;
 import io.streamnative.pulsar.handlers.mqtt.MQTTService;
 import io.streamnative.pulsar.handlers.mqtt.adapter.MqttAdapterMessage;
@@ -33,7 +34,7 @@ public class Qos2PublishHandler extends AbstractQosPublishHandler {
     }
 
     @Override
-    public CompletableFuture<Void> publish(MqttAdapterMessage adapter) {
+    public CompletableFuture<Void> publish(MqttAdapterMessage adapter, Connection connection) {
         final MqttPublishMessage msg = (MqttPublishMessage) adapter.getMqttMessage();
         log.error("[{}] Failed to write data due to QoS2 does not support.", msg.variableHeader().topicName());
         channel.close();


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

when we start two client connections, and the proxy connection pool size is set to 1, Qos1Publisher will get wrong connection.

### Modifications

we can pass the connection from Processor to QosPublisher.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

