### PR TITLE
Support MQTT-5 Conn-ACK with `subscriptionIdentifiersAvailable` and `maximumPacketSize`

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
@@ -239,7 +239,8 @@ public class Connection {
         MqttConnectAck.MqttConnectSuccessAckBuilder builder = MqttConnectAck.successBuilder(protocolVersion)
                 .receiveMaximum(getServerRestrictions().getReceiveMaximum())
                 .cleanSession(clientRestrictions.isCleanSession())
-                .maximumQos(MqttQoS.AT_LEAST_ONCE.value());
+                .maximumQos(MqttQoS.AT_LEAST_ONCE.value())
+                .maximumPacketSize(getServerRestrictions().getMaximumPacketSize());
         MqttProperties.StringProperty resInformation = (MqttProperties.StringProperty) connectMessage.variableHeader()
                 .properties().getProperty(MqttProperties.MqttPropertyType.RESPONSE_INFORMATION.value());
         if (resInformation != null) {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/ack/MqttConnectAck.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/ack/MqttConnectAck.java
@@ -49,6 +49,8 @@ public class MqttConnectAck {
 
         private String responseInformation;
 
+        private int maximumPacketSize;
+
         public MqttConnectSuccessAckBuilder(int protocolVersion) {
             this.protocolVersion = protocolVersion;
         }
@@ -73,6 +75,11 @@ public class MqttConnectAck {
             return this;
         }
 
+        public MqttConnectSuccessAckBuilder maximumPacketSize(int maximumPacketSize) {
+            this.maximumPacketSize = maximumPacketSize;
+            return this;
+        }
+
         public MqttAck build() {
             MqttMessageBuilders.ConnAckBuilder commonBuilder = MqttMessageBuilders.connAck()
                     .sessionPresent(!cleanSession);
@@ -88,8 +95,17 @@ public class MqttConnectAck {
             MqttProperties.IntegerProperty maximumQosProperty =
                     new MqttProperties.IntegerProperty(MqttProperties.MqttPropertyType.MAXIMUM_QOS.value(),
                             maximumQos);
+            // Set Subscription Identifiers Available = 0 now.
+            MqttProperties.IntegerProperty subscriptionIdentifiersAvailableProperty =
+                    new MqttProperties.IntegerProperty(
+                            MqttProperties.MqttPropertyType.SUBSCRIPTION_IDENTIFIER_AVAILABLE.value(), 0);
+            MqttProperties.IntegerProperty maximumPacketSizeProperty =
+                    new MqttProperties.IntegerProperty(
+                            MqttProperties.MqttPropertyType.MAXIMUM_PACKET_SIZE.value(), maximumPacketSize);
             properties.add(receiveMaximumProperty);
             properties.add(maximumQosProperty);
+            properties.add(subscriptionIdentifiersAvailableProperty);
+            properties.add(maximumPacketSizeProperty);
             if (StringUtils.isNotEmpty(responseInformation)) {
                 MqttProperties.StringProperty responseInformationProperty =
                         new MqttProperties.StringProperty(MqttProperties.MqttPropertyType.RESPONSE_INFORMATION.value(),

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -115,6 +115,7 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
         final MqttConnectMessage msg = (MqttConnectMessage) adapter.getMqttMessage();
         final ServerRestrictions serverRestrictions = ServerRestrictions.builder()
                 .receiveMaximum(proxyConfig.getReceiveMaximum())
+                .maximumPacketSize(proxyConfig.getMqttMessageMaxLength())
                 .build();
         connection = Connection.builder()
                 .protocolVersion(msg.variableHeader().version())

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/restrictions/ServerRestrictions.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/restrictions/ServerRestrictions.java
@@ -24,4 +24,7 @@ import lombok.ToString;
 public class ServerRestrictions {
     @Getter
     private int receiveMaximum;
+
+    @Getter
+    private int maximumPacketSize;
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTBrokerProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTBrokerProtocolMethodProcessor.java
@@ -127,6 +127,7 @@ public class MQTTBrokerProtocolMethodProcessor extends AbstractCommonProtocolMet
         final MqttConnectMessage msg = (MqttConnectMessage) adapterMsg.getMqttMessage();
         ServerRestrictions serverRestrictions = ServerRestrictions.builder()
                 .receiveMaximum(configuration.getReceiveMaximum())
+                .maximumPacketSize(configuration.getMqttMessageMaxLength())
                 .build();
         connection = Connection.builder()
                 .protocolVersion(msg.variableHeader().version())


### PR DESCRIPTION
Master Issue: #369 

### Motivation

Support MQTT-5 Conn-ACK with `subscriptionIdentifiersAvailable` and `maximumPacketSize`

- [x] `no-need-doc` 
  

