### PR TITLE
Move `QosPublishHandlers` into `MQTTService`

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/AbstractQosPublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/AbstractQosPublishHandler.java
@@ -14,7 +14,6 @@
 package io.streamnative.pulsar.handlers.mqtt;
 
 import static io.streamnative.pulsar.handlers.mqtt.utils.PulsarMessageConverter.toPulsarMsg;
-import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.streamnative.pulsar.handlers.mqtt.exception.MQTTNoMatchingSubscriberException;
 import io.streamnative.pulsar.handlers.mqtt.support.RetainedMessageHandler;
@@ -37,14 +36,11 @@ public abstract class AbstractQosPublishHandler implements QosPublishHandler {
     protected final PulsarService pulsarService;
     protected final RetainedMessageHandler retainedMessageHandler;
     protected final MQTTServerConfiguration configuration;
-    protected final Channel channel;
 
-    protected AbstractQosPublishHandler(MQTTService mqttService, MQTTServerConfiguration configuration,
-                                        Channel channel) {
+    protected AbstractQosPublishHandler(MQTTService mqttService) {
         this.pulsarService = mqttService.getPulsarService();
         this.retainedMessageHandler = mqttService.getRetainedMessageHandler();
-        this.configuration = configuration;
-        this.channel = channel;
+        this.configuration = mqttService.getServerConfiguration();
     }
 
     protected CompletableFuture<Optional<Topic>> getTopicReference(MqttPublishMessage msg) {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTService.java
@@ -15,6 +15,7 @@ package io.streamnative.pulsar.handlers.mqtt;
 
 import io.streamnative.pulsar.handlers.mqtt.support.MQTTMetricsCollector;
 import io.streamnative.pulsar.handlers.mqtt.support.MQTTMetricsProvider;
+import io.streamnative.pulsar.handlers.mqtt.support.QosPublishHandlersImpl;
 import io.streamnative.pulsar.handlers.mqtt.support.RetainedMessageHandler;
 import io.streamnative.pulsar.handlers.mqtt.support.WillMessageHandler;
 import io.streamnative.pulsar.handlers.mqtt.support.event.DisableEventCenter;
@@ -78,6 +79,9 @@ public class MQTTService {
     private final RetainedMessageHandler retainedMessageHandler;
 
     @Getter
+    private final QosPublishHandlers qosPublishHandlers;
+
+    @Getter
     @Setter
     private SystemEventService eventService;
 
@@ -104,7 +108,7 @@ public class MQTTService {
         }
         this.willMessageHandler = new WillMessageHandler(this);
         this.retainedMessageHandler = new RetainedMessageHandler(this);
-
+        this.qosPublishHandlers = new QosPublishHandlersImpl(this);
     }
 
     public boolean isSystemTopicEnabled() {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/QosPublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/QosPublishHandler.java
@@ -21,5 +21,5 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface QosPublishHandler {
 
-    CompletableFuture<Void> publish(MqttAdapterMessage msg, Connection connection);
+    CompletableFuture<Void> publish(Connection connection, MqttAdapterMessage msg);
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTBrokerProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTBrokerProtocolMethodProcessor.java
@@ -108,7 +108,7 @@ public class MQTTBrokerProtocolMethodProcessor extends AbstractCommonProtocolMet
                 mqttService.getServerConfiguration().isMqttAuthenticationEnabled(), ctx);
         this.pulsarService = mqttService.getPulsarService();
         this.configuration = mqttService.getServerConfiguration();
-        this.qosPublishHandlers = new QosPublishHandlersImpl(mqttService, configuration, ctx.channel());
+        this.qosPublishHandlers = mqttService.getQosPublishHandlers();
         this.packetIdGenerator = PacketIdGenerator.newNonZeroGenerator();
         this.outstandingPacketContainer = new OutstandingPacketContainerImpl();
         this.authorizationService = mqttService.getAuthorizationService();
@@ -222,13 +222,13 @@ public class MQTTBrokerProtocolMethodProcessor extends AbstractCommonProtocolMet
         metricsCollector.addSend(msg.payload().readableBytes());
         switch (qos) {
             case AT_MOST_ONCE:
-                return this.qosPublishHandlers.qos0().publish(adapter, connection);
+                return this.qosPublishHandlers.qos0().publish(connection, adapter);
             case AT_LEAST_ONCE:
                 checkServerReceivePubMessageAndIncrementCounterIfNeeded(adapter);
-                return this.qosPublishHandlers.qos1().publish(adapter, connection);
+                return this.qosPublishHandlers.qos1().publish(connection, adapter);
             case EXACTLY_ONCE:
                 checkServerReceivePubMessageAndIncrementCounterIfNeeded(adapter);
-                return this.qosPublishHandlers.qos2().publish(adapter, connection);
+                return this.qosPublishHandlers.qos2().publish(connection, adapter);
             default:
                 log.error("[Publish] Unknown QoS-Type:{}", qos);
                 connection.getChannel().close();

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos0PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos0PublishHandler.java
@@ -13,11 +13,9 @@
  */
 package io.streamnative.pulsar.handlers.mqtt.support;
 
-import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.streamnative.pulsar.handlers.mqtt.AbstractQosPublishHandler;
 import io.streamnative.pulsar.handlers.mqtt.Connection;
-import io.streamnative.pulsar.handlers.mqtt.MQTTServerConfiguration;
 import io.streamnative.pulsar.handlers.mqtt.MQTTService;
 import io.streamnative.pulsar.handlers.mqtt.adapter.MqttAdapterMessage;
 import io.streamnative.pulsar.handlers.mqtt.utils.MqttUtils;
@@ -29,12 +27,12 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class Qos0PublishHandler extends AbstractQosPublishHandler {
 
-    public Qos0PublishHandler(MQTTService mqttService, MQTTServerConfiguration configuration, Channel channel) {
-        super(mqttService, configuration, channel);
+    public Qos0PublishHandler(MQTTService mqttService) {
+        super(mqttService);
     }
 
     @Override
-    public CompletableFuture<Void> publish(MqttAdapterMessage adapter, Connection connection) {
+    public CompletableFuture<Void> publish(Connection connection, MqttAdapterMessage adapter) {
         final MqttPublishMessage msg = (MqttPublishMessage) adapter.getMqttMessage();
         if (MqttUtils.isRetainedMessage(msg)) {
             return retainedMessageHandler.addRetainedMessage(msg);

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
@@ -13,11 +13,9 @@
  */
 package io.streamnative.pulsar.handlers.mqtt.support;
 
-import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.streamnative.pulsar.handlers.mqtt.AbstractQosPublishHandler;
 import io.streamnative.pulsar.handlers.mqtt.Connection;
-import io.streamnative.pulsar.handlers.mqtt.MQTTServerConfiguration;
 import io.streamnative.pulsar.handlers.mqtt.MQTTService;
 import io.streamnative.pulsar.handlers.mqtt.adapter.MqttAdapterMessage;
 import io.streamnative.pulsar.handlers.mqtt.exception.MQTTNoMatchingSubscriberException;
@@ -36,12 +34,12 @@ import org.apache.pulsar.common.util.FutureUtil;
 @Slf4j
 public class Qos1PublishHandler extends AbstractQosPublishHandler {
 
-    public Qos1PublishHandler(MQTTService mqttService, MQTTServerConfiguration configuration, Channel channel) {
-        super(mqttService, configuration, channel);
+    public Qos1PublishHandler(MQTTService mqttService) {
+        super(mqttService);
     }
 
     @Override
-    public CompletableFuture<Void> publish(MqttAdapterMessage adapter, Connection connection) {
+    public CompletableFuture<Void> publish(Connection connection, MqttAdapterMessage adapter) {
         final MqttPublishMessage msg = (MqttPublishMessage) adapter.getMqttMessage();
         final int protocolVersion = connection.getProtocolVersion();
         final int packetId = msg.variableHeader().packetId();

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos2PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos2PublishHandler.java
@@ -13,11 +13,9 @@
  */
 package io.streamnative.pulsar.handlers.mqtt.support;
 
-import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.streamnative.pulsar.handlers.mqtt.AbstractQosPublishHandler;
 import io.streamnative.pulsar.handlers.mqtt.Connection;
-import io.streamnative.pulsar.handlers.mqtt.MQTTServerConfiguration;
 import io.streamnative.pulsar.handlers.mqtt.MQTTService;
 import io.streamnative.pulsar.handlers.mqtt.adapter.MqttAdapterMessage;
 import java.util.concurrent.CompletableFuture;
@@ -29,15 +27,15 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class Qos2PublishHandler extends AbstractQosPublishHandler {
 
-    public Qos2PublishHandler(MQTTService mqttService, MQTTServerConfiguration configuration, Channel channel) {
-        super(mqttService, configuration, channel);
+    public Qos2PublishHandler(MQTTService mqttService) {
+        super(mqttService);
     }
 
     @Override
-    public CompletableFuture<Void> publish(MqttAdapterMessage adapter, Connection connection) {
+    public CompletableFuture<Void> publish(Connection connection, MqttAdapterMessage adapter) {
         final MqttPublishMessage msg = (MqttPublishMessage) adapter.getMqttMessage();
         log.error("[{}] Failed to write data due to QoS2 does not support.", msg.variableHeader().topicName());
-        channel.close();
+        connection.disconnect();
         return CompletableFuture.completedFuture(null);
     }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/QosPublishHandlersImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/QosPublishHandlersImpl.java
@@ -13,8 +13,6 @@
  */
 package io.streamnative.pulsar.handlers.mqtt.support;
 
-import io.netty.channel.Channel;
-import io.streamnative.pulsar.handlers.mqtt.MQTTServerConfiguration;
 import io.streamnative.pulsar.handlers.mqtt.MQTTService;
 import io.streamnative.pulsar.handlers.mqtt.QosPublishHandler;
 import io.streamnative.pulsar.handlers.mqtt.QosPublishHandlers;
@@ -28,10 +26,10 @@ public class QosPublishHandlersImpl implements QosPublishHandlers {
     private final QosPublishHandler qos1Handler;
     private final QosPublishHandler qos2Handler;
 
-    public QosPublishHandlersImpl(MQTTService mqttService, MQTTServerConfiguration configuration, Channel channel) {
-        this.qos0Handler = new Qos0PublishHandler(mqttService, configuration, channel);
-        this.qos1Handler = new Qos1PublishHandler(mqttService, configuration, channel);
-        this.qos2Handler = new Qos2PublishHandler(mqttService, configuration, channel);
+    public QosPublishHandlersImpl(MQTTService mqttService) {
+        this.qos0Handler = new Qos0PublishHandler(mqttService);
+        this.qos1Handler = new Qos1PublishHandler(mqttService);
+        this.qos2Handler = new Qos2PublishHandler(mqttService);
     }
 
     @Override


### PR DESCRIPTION
### Motivation

Moved `QosPublishHandlers` to `MQTTService` to avoid creating handlers on each handler.

### Modifications

- Move `QosPublishHandlers` into `MQTTService`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

