### PR TITLE
Support MQTT-5 topic alias.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/AbstractQosPublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/AbstractQosPublishHandler.java
@@ -14,14 +14,18 @@
 package io.streamnative.pulsar.handlers.mqtt;
 
 import static io.streamnative.pulsar.handlers.mqtt.utils.PulsarMessageConverter.toPulsarMsg;
+import io.netty.handler.codec.mqtt.MqttProperties;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.streamnative.pulsar.handlers.mqtt.exception.MQTTNoMatchingSubscriberException;
+import io.streamnative.pulsar.handlers.mqtt.exception.MQTTTopicAliasNotFoundException;
+import io.streamnative.pulsar.handlers.mqtt.messages.MqttPropertyUtils;
 import io.streamnative.pulsar.handlers.mqtt.support.RetainedMessageHandler;
 import io.streamnative.pulsar.handlers.mqtt.utils.MessagePublishContext;
 import io.streamnative.pulsar.handlers.mqtt.utils.PulsarTopicUtils;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.Topic;
@@ -49,8 +53,9 @@ public abstract class AbstractQosPublishHandler implements QosPublishHandler {
                 , configuration.getDefaultTopicDomain());
     }
 
-    protected CompletableFuture<PositionImpl> writeToPulsarTopic(Connection connection, MqttPublishMessage msg) {
-        return writeToPulsarTopic(connection, msg, false);
+    protected CompletableFuture<PositionImpl> writeToPulsarTopic(TopicAliasManager topicAliasManager,
+                                                                 MqttPublishMessage msg) {
+        return writeToPulsarTopic(topicAliasManager, msg, false);
     }
 
     /**
@@ -59,11 +64,27 @@ public abstract class AbstractQosPublishHandler implements QosPublishHandler {
      * @param checkSubscription Check if the subscription exists, throw #{MQTTNoMatchingSubscriberException}
      *                              if the subscription does not exist;
      */
-    protected CompletableFuture<PositionImpl> writeToPulsarTopic(Connection connection, MqttPublishMessage msg,
-                                                                 boolean checkSubscription) {
-        String maybeTopicAlias = msg.variableHeader().topicName();
-        String mqttTopicName = connection.findTopicIfAlias(maybeTopicAlias);
-        return getTopicReference(maybeTopicAlias).thenCompose(topicOp -> topicOp.map(topic -> {
+    protected CompletableFuture<PositionImpl> writeToPulsarTopic(TopicAliasManager topicAliasManager,
+                                                                 MqttPublishMessage msg, boolean checkSubscription) {
+        Optional<Integer> topicAlias = MqttPropertyUtils.getProperty(msg.variableHeader().properties(),
+                MqttProperties.MqttPropertyType.TOPIC_ALIAS);
+        String mqttTopicName;
+        if (topicAlias.isPresent()) {
+            int alias = topicAlias.get();
+            String tpName = msg.variableHeader().topicName();
+            if (StringUtils.isNoneBlank(tpName)) {
+                // update alias
+                topicAliasManager.updateTopicAlias(tpName, alias);
+            }
+            Optional<String> realName = topicAliasManager.getTopicByAlias(alias);
+            if (!realName.isPresent()) {
+                throw new MQTTTopicAliasNotFoundException(alias);
+            }
+            mqttTopicName = realName.get();
+        } else {
+            mqttTopicName = msg.variableHeader().topicName();
+        }
+        return getTopicReference(mqttTopicName).thenCompose(topicOp -> topicOp.map(topic -> {
             MessageImpl<byte[]> message = toPulsarMsg(topic, msg.variableHeader().properties(),
                     msg.payload().nioBuffer());
             CompletableFuture<PositionImpl> ret = MessagePublishContext.publishMessages(message, topic);

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
@@ -37,11 +37,8 @@ import io.streamnative.pulsar.handlers.mqtt.restrictions.ServerRestrictions;
 import io.streamnative.pulsar.handlers.mqtt.utils.FutureUtils;
 import io.streamnative.pulsar.handlers.mqtt.utils.MqttUtils;
 import io.streamnative.pulsar.handlers.mqtt.utils.WillMessage;
-
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import lombok.Getter;
@@ -79,7 +76,9 @@ public class Connection {
     @Getter
     private final ProtocolMethodProcessor processor;
 
-    private final Map<String, String> topicAlias;
+    @Getter
+    private final TopicAliasManager topicAliasManager;
+
     @Getter
     private final boolean fromProxy;
     private volatile ConnectionState connectionState = DISCONNECTED;
@@ -108,7 +107,7 @@ public class Connection {
         this.processor = builder.processor;
         this.fromProxy = builder.fromProxy;
         this.manager.addConnection(this);
-        this.topicAlias = new ConcurrentHashMap<>();
+        this.topicAliasManager = new TopicAliasManager(clientRestrictions.getTopicAliasMaximum());
     }
 
     private void addIdleStateHandler() {
@@ -342,14 +341,6 @@ public class Connection {
         public Connection build() {
             return new Connection(this);
         }
-    }
-
-    public void addTopicAlias(String topic, String alias) {
-        topicAlias.put(topic, alias);
-    }
-
-    public String findTopicIfAlias(String maybeAlias) {
-        return topicAlias.getOrDefault(maybeAlias, maybeAlias);
     }
 
     @Override

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
@@ -37,8 +37,11 @@ import io.streamnative.pulsar.handlers.mqtt.restrictions.ServerRestrictions;
 import io.streamnative.pulsar.handlers.mqtt.utils.FutureUtils;
 import io.streamnative.pulsar.handlers.mqtt.utils.MqttUtils;
 import io.streamnative.pulsar.handlers.mqtt.utils.WillMessage;
+
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import lombok.Getter;
@@ -75,6 +78,8 @@ public class Connection {
     private volatile int serverCurrentReceiveCounter = 0;
     @Getter
     private final ProtocolMethodProcessor processor;
+
+    private final Map<String, String> topicAlias;
     @Getter
     private final boolean fromProxy;
     private volatile ConnectionState connectionState = DISCONNECTED;
@@ -103,6 +108,7 @@ public class Connection {
         this.processor = builder.processor;
         this.fromProxy = builder.fromProxy;
         this.manager.addConnection(this);
+        this.topicAlias = new ConcurrentHashMap<>();
     }
 
     private void addIdleStateHandler() {
@@ -336,6 +342,14 @@ public class Connection {
         public Connection build() {
             return new Connection(this);
         }
+    }
+
+    public void addTopicAlias(String topic, String alias) {
+        topicAlias.put(topic, alias);
+    }
+
+    public String findTopicIfAlias(String maybeAlias) {
+        return topicAlias.getOrDefault(maybeAlias, maybeAlias);
     }
 
     @Override

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/TopicAliasManager.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/TopicAliasManager.java
@@ -30,6 +30,7 @@ public class TopicAliasManager {
     private final Map<String, TopicAliasInfo> brokerSideAlias;
 
     private final PacketIdGenerator idGenerator;
+    @Getter
     private final int topicMaximumAlias;
 
     public TopicAliasManager(int topicMaximumAlias) {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/TopicAliasManager.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/TopicAliasManager.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+
+public class TopicAliasManager {
+
+    public static final int NO_ALIAS = -1;
+    private final Map<Integer, String> clientSideAlias;
+    private final Map<String, TopicAliasInfo> brokerSideAlias;
+
+    private final PacketIdGenerator idGenerator;
+    private final int topicMaximumAlias;
+
+    public TopicAliasManager(int topicMaximumAlias) {
+        this.topicMaximumAlias = topicMaximumAlias;
+        this.idGenerator = PacketIdGenerator.newNonZeroGenerator();
+        this.clientSideAlias = new ConcurrentHashMap<>(topicMaximumAlias);
+        this.brokerSideAlias = new ConcurrentHashMap<>(topicMaximumAlias);
+    }
+
+    public Optional<String> getTopicByAlias(int alias) {
+        return Optional.ofNullable(clientSideAlias.get(alias));
+    }
+
+    public boolean updateTopicAlias(String topic, int alias) {
+        return clientSideAlias.compute(alias, (k, v) -> {
+            if (v == null && clientSideAlias.size() >= topicMaximumAlias) {
+                return null;
+            }
+            return topic;
+        }) != null;
+    }
+
+    public Optional<Integer> getOrCreateAlias(String topic) {
+        TopicAliasInfo topicAliasInfo = brokerSideAlias.computeIfAbsent(topic, (k) -> {
+            if (brokerSideAlias.size() >= topicMaximumAlias) {
+                return null;
+            }
+            return TopicAliasInfo.builder()
+                    .alias(idGenerator.nextPacketId())
+                    .syncToClient(false)
+                    .build();
+        });
+        if (topicAliasInfo == null) {
+            // Exceeds topic alias maximum
+            return Optional.empty();
+        }
+        return Optional.of(topicAliasInfo.getAlias());
+    }
+
+    public boolean isSyncAliasToClient(String topicName) {
+        TopicAliasInfo topicAliasInfo = brokerSideAlias.get(topicName);
+        if (topicAliasInfo == null) {
+            return false;
+        }
+        return topicAliasInfo.isSyncToClient();
+    }
+
+    public void syncAlias(String topic) {
+        brokerSideAlias.computeIfPresent(topic, (key, info) -> {
+            info.setSyncToClient(true);
+            return info;
+        });
+    }
+
+    @Getter
+    @ToString
+    @EqualsAndHashCode
+    @Builder
+    static class TopicAliasInfo {
+        private int alias;
+        @Setter
+        private boolean syncToClient;
+    }
+}

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/exception/MQTTTopicAliasExceedsLimitException.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/exception/MQTTTopicAliasExceedsLimitException.java
@@ -15,12 +15,15 @@ package io.streamnative.pulsar.handlers.mqtt.exception;
 
 import lombok.Getter;
 
-public class MQTTTopicAliasNotFoundException extends RuntimeException {
-   @Getter
-   private final int alias;
+public class MQTTTopicAliasExceedsLimitException extends RuntimeException {
+    @Getter
+    private final int alias;
+    @Getter
+    private final int topicAliasMaximum;
 
-   public MQTTTopicAliasNotFoundException(int alias) {
-      super(String.format("The topic alias %s is not found.", alias));
-      this.alias = alias;
-   }
+    public MQTTTopicAliasExceedsLimitException(int alias, int topicAliasMaximum) {
+        super(String.format("The topic alias %s is exceed topic alias maximum %s.", alias, topicAliasMaximum));
+        this.alias = alias;
+        this.topicAliasMaximum = topicAliasMaximum;
+    }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/exception/MQTTTopicAliasNotFoundException.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/exception/MQTTTopicAliasNotFoundException.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.exception;
+
+import lombok.Getter;
+
+public class MQTTTopicAliasNotFoundException extends RuntimeException{
+   @Getter
+   private final int alias;
+
+   public MQTTTopicAliasNotFoundException(int alias) {
+      super(String.format("The topic alias %s is not found.", alias));
+      this.alias = alias;
+   }
+}

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/MqttPropertyUtils.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/MqttPropertyUtils.java
@@ -49,8 +49,8 @@ public class MqttPropertyUtils {
     }
 
     @SuppressWarnings("unchecked")
-    public static Optional<Integer> getIntProperty(MqttProperties properties, MqttProperties.MqttPropertyType type) {
-        MqttProperties.MqttProperty<Integer> property = properties.getProperty(type.value());
+    public static <T> Optional<T> getProperty(MqttProperties properties, MqttProperties.MqttPropertyType type) {
+        MqttProperties.MqttProperty<T> property = properties.getProperty(type.value());
         if (property == null) {
             return Optional.empty();
         }
@@ -66,23 +66,23 @@ public class MqttPropertyUtils {
         getExpireInterval(properties)
                 .ifPresent(clientRestrictionsBuilder::sessionExpireInterval);
         // parse receive maximum
-        Optional<Integer> receiveMaximum = getIntProperty(properties, MqttProperties.MqttPropertyType.RECEIVE_MAXIMUM);
+        Optional<Integer> receiveMaximum = getProperty(properties, MqttProperties.MqttPropertyType.RECEIVE_MAXIMUM);
         if (receiveMaximum.isPresent() && receiveMaximum.get() == 0) {
             throw new InvalidReceiveMaximumException("Not Allow Receive maximum property value zero");
         } else {
             receiveMaximum.ifPresent(clientRestrictionsBuilder::receiveMaximum);
         }
         // parse maximum packet size
-        Optional<Integer> maximumPacketSize = getIntProperty(properties, MqttProperties
+        Optional<Integer> maximumPacketSize = getProperty(properties, MqttProperties
                 .MqttPropertyType.MAXIMUM_PACKET_SIZE);
         maximumPacketSize.ifPresent(clientRestrictionsBuilder::maximumPacketSize);
         // parse request problem information
         Optional<Integer> requestProblemInformation =
-                getIntProperty(properties, MqttProperties.MqttPropertyType.REQUEST_PROBLEM_INFORMATION);
+                getProperty(properties, MqttProperties.MqttPropertyType.REQUEST_PROBLEM_INFORMATION);
         // the empty option means allowing reason string or user property
         clientRestrictionsBuilder.allowReasonStrOrUserProperty(!requestProblemInformation.isPresent());
         Optional<Integer> topicAliasMaximum =
-                getIntProperty(properties, MqttProperties.MqttPropertyType.TOPIC_ALIAS_MAXIMUM);
+                getProperty(properties, MqttProperties.MqttPropertyType.TOPIC_ALIAS_MAXIMUM);
         topicAliasMaximum.ifPresent(clientRestrictionsBuilder::topicAliasMaximum);
     }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos0PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos0PublishHandler.java
@@ -37,6 +37,6 @@ public class Qos0PublishHandler extends AbstractQosPublishHandler {
         if (MqttUtils.isRetainedMessage(msg)) {
             return retainedMessageHandler.addRetainedMessage(msg);
         }
-        return writeToPulsarTopic(connection, msg).thenAccept(__ -> {});
+        return writeToPulsarTopic(connection.getTopicAliasManager(), msg).thenAccept(__ -> {});
     }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos0PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos0PublishHandler.java
@@ -37,6 +37,6 @@ public class Qos0PublishHandler extends AbstractQosPublishHandler {
         if (MqttUtils.isRetainedMessage(msg)) {
             return retainedMessageHandler.addRetainedMessage(msg);
         }
-        return writeToPulsarTopic(msg).thenAccept(__ -> {});
+        return writeToPulsarTopic(connection, msg).thenAccept(__ -> {});
     }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
@@ -48,7 +48,7 @@ public class Qos1PublishHandler extends AbstractQosPublishHandler {
         if (MqttUtils.isRetainedMessage(msg)) {
             ret = retainedMessageHandler.addRetainedMessage(msg);
         } else {
-            ret = writeToPulsarTopic(msg, !MqttUtils.isMqtt3(protocolVersion)).thenApply(__ -> null);
+            ret = writeToPulsarTopic(connection, msg, !MqttUtils.isMqtt3(protocolVersion)).thenApply(__ -> null);
         }
         // we need to check if subscription exist when protocol version is mqtt 5.x
         return ret

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
@@ -48,7 +48,8 @@ public class Qos1PublishHandler extends AbstractQosPublishHandler {
         if (MqttUtils.isRetainedMessage(msg)) {
             ret = retainedMessageHandler.addRetainedMessage(msg);
         } else {
-            ret = writeToPulsarTopic(connection, msg, !MqttUtils.isMqtt3(protocolVersion)).thenApply(__ -> null);
+            ret = writeToPulsarTopic(connection.getTopicAliasManager()
+                    , msg, !MqttUtils.isMqtt3(protocolVersion)).thenApply(__ -> null);
         }
         // we need to check if subscription exist when protocol version is mqtt 5.x
         return ret

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarMessageConverter.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarMessageConverter.java
@@ -26,6 +26,7 @@ import io.netty.util.concurrent.FastThreadLocal;
 import io.streamnative.pulsar.handlers.mqtt.PacketIdGenerator;
 import io.streamnative.pulsar.handlers.mqtt.support.MessageBuilder;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -69,10 +70,9 @@ public class PulsarMessageConverter {
             };
 
     // Convert MQTT message to Pulsar message.
-    public static MessageImpl<byte[]> toPulsarMsg(Topic topic, MqttPublishMessage mqttMsg) {
+    public static MessageImpl<byte[]> toPulsarMsg(Topic topic, MqttProperties properties, ByteBuffer payload) {
         MessageMetadata metadata = LOCAL_MESSAGE_METADATA.get();
         metadata.clear();
-        MqttProperties properties = mqttMsg.variableHeader().properties();
         if (properties != null) {
             properties.listAll().forEach(prop -> {
                 if (MqttProperties.MqttPropertyType.USER_PROPERTY.value() == prop.propertyId()) {
@@ -104,7 +104,7 @@ public class PulsarMessageConverter {
                 }
             });
         }
-        return MessageImpl.create(metadata, mqttMsg.payload().nioBuffer(), SCHEMA, topic.getName());
+        return MessageImpl.create(metadata, payload, SCHEMA, topic.getName());
     }
 
     private static String getPropertiesPrefix(int propertyId) {


### PR DESCRIPTION
### Motivation

Support MQTT-5 topic alias. See specification https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html

### Modifications

- Support topic alias.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
