### PR TITLE
Use Original Authentication data to do Authorization.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
@@ -37,6 +37,7 @@ import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5DisConnRea
 import io.streamnative.pulsar.handlers.mqtt.restrictions.ClientRestrictions;
 import io.streamnative.pulsar.handlers.mqtt.restrictions.ServerRestrictions;
 import io.streamnative.pulsar.handlers.mqtt.utils.FutureUtils;
+import io.streamnative.pulsar.handlers.mqtt.utils.MqttMessageUtils;
 import io.streamnative.pulsar.handlers.mqtt.utils.MqttUtils;
 import io.streamnative.pulsar.handlers.mqtt.utils.WillMessage;
 import java.util.Objects;
@@ -45,6 +46,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 
 /**
  * Value object to maintain the information of single connection, like ClientID, Channel, and clean
@@ -82,6 +84,9 @@ public class Connection {
     private final TopicAliasManager topicAliasManager;
 
     @Getter
+    private AuthenticationDataSource authData;
+
+    @Getter
     private final boolean fromProxy;
     private volatile ConnectionState connectionState = DISCONNECTED;
 
@@ -108,6 +113,7 @@ public class Connection {
         this.addIdleStateHandler();
         this.processor = builder.processor;
         this.fromProxy = builder.fromProxy;
+        this.authData = builder.authData;
         this.manager.addConnection(this);
         this.topicAliasManager = new TopicAliasManager(clientRestrictions.getTopicAliasMaximum());
     }
@@ -148,6 +154,10 @@ public class Connection {
         return mqttAck.isProtocolSupported()
                 ? send(mqttAck.getMqttMessage())
                 : CompletableFuture.completedFuture(null);
+    }
+
+    public void updateAuthData(AuthenticationDataSource authData) {
+        this.authData = authData;
     }
 
     public CompletableFuture<Void> sendAckThenClose(MqttAck mqttAck) {
@@ -249,7 +259,7 @@ public class Connection {
                 .cleanSession(clientRestrictions.isCleanSession())
                 .maximumQos(MqttQoS.AT_LEAST_ONCE.value())
                 .authMethod(getAuthMethod(connectMessage))
-                .authData(getAuthData(connectMessage))
+                .authData(MqttMessageUtils.getAuthData(connectMessage))
                 .maximumPacketSize(getServerRestrictions().getMaximumPacketSize());
         MqttProperties.StringProperty resInformation = (MqttProperties.StringProperty) connectMessage.variableHeader()
                 .properties().getProperty(MqttProperties.MqttPropertyType.RESPONSE_INFORMATION.value());
@@ -285,6 +295,8 @@ public class Connection {
         private ServerRestrictions serverRestrictions;
         private ProtocolMethodProcessor processor;
         private boolean fromProxy;
+
+        private AuthenticationDataSource authData;
 
         public ConnectionBuilder protocolVersion(int protocolVersion) {
             this.protocolVersion = protocolVersion;
@@ -338,6 +350,11 @@ public class Connection {
 
         public ConnectionBuilder fromProxy(boolean fromProxy) {
             this.fromProxy =  fromProxy;
+            return this;
+        }
+
+        public ConnectionBuilder authData(AuthenticationDataSource authData) {
+            this.authData = authData;
             return this;
         }
 

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/Connection.java
@@ -16,7 +16,6 @@ package io.streamnative.pulsar.handlers.mqtt;
 import static io.streamnative.pulsar.handlers.mqtt.Connection.ConnectionState.CONNECT_ACK;
 import static io.streamnative.pulsar.handlers.mqtt.Connection.ConnectionState.DISCONNECTED;
 import static io.streamnative.pulsar.handlers.mqtt.Connection.ConnectionState.ESTABLISHED;
-import static io.streamnative.pulsar.handlers.mqtt.utils.MqttMessageUtils.getAuthData;
 import static io.streamnative.pulsar.handlers.mqtt.utils.MqttMessageUtils.getAuthMethod;
 import static io.streamnative.pulsar.handlers.mqtt.utils.NettyUtils.ATTR_KEY_CONNECTION;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -112,7 +112,8 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
     }
 
     @Override
-    public void doProcessConnect(MqttAdapterMessage adapter, String userRole, AuthenticationDataSource authData, ClientRestrictions clientRestrictions) {
+    public void doProcessConnect(MqttAdapterMessage adapter, String userRole,
+                                 AuthenticationDataSource authData, ClientRestrictions clientRestrictions) {
         final MqttConnectMessage msg = (MqttConnectMessage) adapter.getMqttMessage();
         final ServerRestrictions serverRestrictions = ServerRestrictions.builder()
                 .receiveMaximum(proxyConfig.getReceiveMaximum())

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -57,6 +57,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
@@ -111,7 +112,7 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
     }
 
     @Override
-    public void doProcessConnect(MqttAdapterMessage adapter, String userRole, ClientRestrictions clientRestrictions) {
+    public void doProcessConnect(MqttAdapterMessage adapter, String userRole, AuthenticationDataSource authData, ClientRestrictions clientRestrictions) {
         final MqttConnectMessage msg = (MqttConnectMessage) adapter.getMqttMessage();
         final ServerRestrictions serverRestrictions = ServerRestrictions.builder()
                 .receiveMaximum(proxyConfig.getReceiveMaximum())
@@ -125,6 +126,7 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
                 .clientRestrictions(clientRestrictions)
                 .serverRestrictions(serverRestrictions)
                 .channel(channel)
+                .authData(authData)
                 .connectionManager(connectionManager)
                 .processor(this)
                 .build();

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTBrokerProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTBrokerProtocolMethodProcessor.java
@@ -71,6 +71,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.authentication.AuthenticationDataCommand;
+import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.authorization.AuthorizationService;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.Consumer;
@@ -99,7 +100,6 @@ public class MQTTBrokerProtocolMethodProcessor extends AbstractCommonProtocolMet
     private final WillMessageHandler willMessageHandler;
     private final RetainedMessageHandler retainedMessageHandler;
     private final AutoSubscribeHandler autoSubscribeHandler;
-    private Connection connection;
     @Getter
     private final CompletableFuture<Void> inactiveFuture = new CompletableFuture<>();
 
@@ -123,7 +123,7 @@ public class MQTTBrokerProtocolMethodProcessor extends AbstractCommonProtocolMet
 
     @Override
     public void doProcessConnect(MqttAdapterMessage adapterMsg, String userRole,
-                                 ClientRestrictions clientRestrictions) {
+                                 AuthenticationDataSource authData, ClientRestrictions clientRestrictions) {
         final MqttConnectMessage msg = (MqttConnectMessage) adapterMsg.getMqttMessage();
         ServerRestrictions serverRestrictions = ServerRestrictions.builder()
                 .receiveMaximum(configuration.getReceiveMaximum())
@@ -136,6 +136,7 @@ public class MQTTBrokerProtocolMethodProcessor extends AbstractCommonProtocolMet
                 .willMessage(createWillMessage(msg))
                 .clientRestrictions(clientRestrictions)
                 .serverRestrictions(serverRestrictions)
+                .authData(authData)
                 .channel(channel)
                 .connectMessage(msg)
                 .connectionManager(connectionManager)


### PR DESCRIPTION
### Motivation

When we try to use Oauth2 to verify Authorization, we have to pass the token to
Authorisations Provider, but current, we just passed the role.

### Modifications

- Save the original authentication data to `Connection` and use it for the authorisation check.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 
  

