### PR TITLE
Revert "Change proxy default port"

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ To use the proxy, follow the following steps. For detailed steps, refer to [Depl
     advertisedAddress=127.0.0.1
     
     mqttProxyEnabled=true
-    mqttProxyPort=5678
+    mqttProxyPort=5682
     ```
 
 ### Verify MoP protocol handler
@@ -245,7 +245,7 @@ openssl req -new -x509 -nodes -sha256 -days 365 -key server.key -out server.crt
    ```java
    MQTT mqtt = new MQTT();
    // default proxy tls port
-   mqtt.setHost(URI.create("ssl://127.0.0.1:5679")); 
+   mqtt.setHost(URI.create("ssl://127.0.0.1:5683")); 
    File crtFile = new File("server.crt");
    Certificate certificate = CertificateFactory.getInstance("X.509").generateCertificate(new FileInputStream(crtFile));
    KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
@@ -302,7 +302,7 @@ Please reference [here](https://en.wikipedia.org/wiki/TLS-PSK) to learn more abo
    mqttProxyEnable=true
    mqttProxyTlsPskEnabled=true
    // default tls psk port
-   mqttProxyTlsPskPort=5680
+   mqttProxyTlsPskPort=5684
    // any string can be specified
    mqttTlsPskIdentityHint=alpha
    // identity is semicolon list of string with identity:secret format
@@ -311,7 +311,7 @@ Please reference [here](https://en.wikipedia.org/wiki/TLS-PSK) to learn more abo
 
 2. Test with `mosquitto cli`
    ```
-   mosquitto_pub --psk-identity mqtt --psk 6d717474313233 -p 5680 -t "/a/b/c" -m "hello mqtt"
+   mosquitto_pub --psk-identity mqtt --psk 6d717474313233 -p 5684 -t "/a/b/c" -m "hello mqtt"
    ```
 
 3. Add PSK identities dynamically.

--- a/docs/mop-configuration.md
+++ b/docs/mop-configuration.md
@@ -19,12 +19,12 @@
 ## MoP Proxy
 
 | Property | Default value | Comment
-|----------|---------------| --------
-|mqttProxyEnabled | false         | Enable MoP proxy |
-|mqttProxyPort | 5678          | Default MoP proxy port |
-|mqttProxyTlsEnabled | false         | Enable MoP proxy TLS or not |
-|mqttProxyTlsPort | 5679          | Default mqtt TLS port
-|mqttProxyTlsPskPort | 5680          | Default mqtt proxy tls psk port |
+|----------| --------------| --------
+|mqttProxyEnabled | false | Enable MoP proxy |
+|mqttProxyPort | 5682 | Default MoP proxy port |
+|mqttProxyTlsEnabled | false | Enable MoP proxy TLS or not |
+|mqttProxyTlsPort | 5683 | Default mqtt TLS port
+|mqttProxyTlsPskPort | 5684 | Default mqtt proxy tls psk port |
 
 
 ## TLS

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTCommonConfiguration.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTCommonConfiguration.java
@@ -105,21 +105,21 @@ public class MQTTCommonConfiguration extends ServiceConfiguration {
             required = false,
             doc = "The mqtt proxy port"
     )
-    private int mqttProxyPort = 5678;
+    private int mqttProxyPort = 5682;
 
     @FieldContext(
             category = CATEGORY_MQTT_PROXY,
             required = false,
             doc = "The mqtt proxy tls port"
     )
-    private int mqttProxyTlsPort = 5679;
+    private int mqttProxyTlsPort = 5683;
 
     @FieldContext(
             category = CATEGORY_MQTT_PROXY,
             required = false,
             doc = "The mqtt proxy tls psk port"
     )
-    private int mqttProxyTlsPskPort = 5680;
+    private int mqttProxyTlsPskPort = 5684;
 
     @FieldContext(
             category = CATEGORY_MQTT_PROXY,


### PR DESCRIPTION
### Motivation
As it's the default port, even if it conflicts with AoP, users can change it to other ports.

Reverts streamnative/mop#712