### PR TITLE
Upgrade lombok to 1.18.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <pulsar.version>2.10.0.0-rc4</pulsar.version>
         <mqtt.codec.version>4.1.74.Final</mqtt.codec.version>
         <log4j2.version>2.17.1</log4j2.version>
-        <lombok.version>1.18.4</lombok.version>
+        <lombok.version>1.18.22</lombok.version>
         <fusesource.client.version>1.16</fusesource.client.version>
         <hivemq.mqtt.client.version>1.2.2</hivemq.mqtt.client.version>
         <apache.commons.bean-utils.version>1.9.4</apache.commons.bean-utils.version>


### PR DESCRIPTION


### Motivation  

When i compile on jdk11 and just got the error (Note: pom.xml still configuration for 1.8 )  of `module jdk.compiler does not "opens com.sun.tools.javac.processing" to unnamed module ...` , 

```shell
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0:compile (default-compile) on project pulsar-protocol-handler-mqtt: 
Fatal error compiling: java.lang.ExceptionInInitializerError: Unable to make field private com.sun.tools.javac.processing.JavacProcessingEnvironment$Di
scoveredProcessors com.sun.tools.javac.processing.JavacProcessingEnvironment.discoveredProcs accessible: module jdk.compiler does not "opens com.sun.to
ols.javac.processing" to unnamed module @1d071d30 -> [Help 1]
```

### Modifications 

Upgrade lombok version to 1.18.22

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
- [x] `no-need-doc` 
  
  
- [ ] `doc` 

