### PR TITLE
Support eventtime and  message key

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/AbstractQosPublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/AbstractQosPublishHandler.java
@@ -90,7 +90,7 @@ public abstract class AbstractQosPublishHandler implements QosPublishHandler {
             mqttTopicName = msg.variableHeader().topicName();
         }
         return getTopicReference(mqttTopicName).thenCompose(topicOp -> topicOp.map(topic -> {
-            MessageImpl<byte[]> message = toPulsarMsg(configuration,topic, msg.variableHeader().properties(),
+            MessageImpl<byte[]> message = toPulsarMsg(configuration, topic, msg.variableHeader().properties(),
                     msg.payload().nioBuffer());
             CompletableFuture<PositionImpl> ret = MessagePublishContext.publishMessages(message, topic);
             message.recycle();

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/AbstractQosPublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/AbstractQosPublishHandler.java
@@ -90,7 +90,7 @@ public abstract class AbstractQosPublishHandler implements QosPublishHandler {
             mqttTopicName = msg.variableHeader().topicName();
         }
         return getTopicReference(mqttTopicName).thenCompose(topicOp -> topicOp.map(topic -> {
-            MessageImpl<byte[]> message = toPulsarMsg(topic, msg.variableHeader().properties(),
+            MessageImpl<byte[]> message = toPulsarMsg(configuration,topic, msg.variableHeader().properties(),
                     msg.payload().nioBuffer());
             CompletableFuture<PositionImpl> ret = MessagePublishContext.publishMessages(message, topic);
             message.recycle();

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTServerConfiguration.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTServerConfiguration.java
@@ -30,4 +30,19 @@ public class MQTTServerConfiguration extends MQTTCommonConfiguration {
             doc = "Listener for the MQTT Server."
     )
     private String mqttListeners = "mqtt://127.0.0.1:1883";
+
+    @FieldContext(
+            category = CATEGORY_MQTT,
+            required = false,
+            doc = "Auto Set EventTime for pulsar message."
+    )
+    private boolean mqttAutoEventTime;
+
+    @FieldContext(
+            category = CATEGORY_MQTT,
+            required = false,
+            doc = "Fill eventtime from mqtt user properties."
+    )
+    private String mqttEventTimeFromProp = "";
+
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTServerConfiguration.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTServerConfiguration.java
@@ -45,4 +45,11 @@ public class MQTTServerConfiguration extends MQTTCommonConfiguration {
     )
     private String mqttEventTimeFromProp = "";
 
+    @FieldContext(
+            category = CATEGORY_MQTT,
+            required = false,
+            doc = "Fill message key from mqtt user properties."
+    )
+    private String mqttMessageKeyFromProp = "";
+
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarMessageConverter.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarMessageConverter.java
@@ -72,10 +72,11 @@ public class PulsarMessageConverter {
             };
 
     // Convert MQTT message to Pulsar message.
-    public static MessageImpl<byte[]> toPulsarMsg(MQTTServerConfiguration configuration,Topic topic, MqttProperties properties, ByteBuffer payload) {
+    public static MessageImpl<byte[]> toPulsarMsg(MQTTServerConfiguration configuration, Topic topic,
+                                                  MqttProperties properties, ByteBuffer payload) {
         MessageMetadata metadata = LOCAL_MESSAGE_METADATA.get();
         metadata.clear();
-        if(configuration.isMqttAutoEventTime()){
+        if (configuration.isMqttAutoEventTime()) {
             metadata.setEventTime(System.currentTimeMillis());
         }
         if (properties != null) {
@@ -90,12 +91,12 @@ public class PulsarMessageConverter {
                         ) {
                             try {
                                 metadata.setEventTime(Long.valueOf(pair.value));
-                            }catch (Exception e){
-                                log.error("fill eventtime from prop failed:",e);
+                            } catch (Exception e){
+                                log.error("fill eventtime from prop failed:", e);
                             }
                         }
-                        if(fillMessageKeyFromProp
-                        && pair.key.equals(configuration.getMqttMessageKeyFromProp())){
+                        if (fillMessageKeyFromProp
+                        && pair.key.equals(configuration.getMqttMessageKeyFromProp())) {
                             metadata.setPartitionKey(pair.value);
                             metadata.setPartitionKeyB64Encoded(false);
                         }
@@ -225,7 +226,7 @@ public class PulsarMessageConverter {
         ByteBuf payload = msg.getDataBuffer();
 
         metadata.setEventTime(msg.getEventTime());
-        if(StringUtils.isNotBlank(msg.getKey())){
+        if (StringUtils.isNotBlank(msg.getKey())) {
             metadata.setPartitionKey(msg.getKey());
             metadata.setPartitionKeyB64Encoded(false);
         }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarMessageConverter.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/utils/PulsarMessageConverter.java
@@ -23,6 +23,7 @@ import io.netty.handler.codec.mqtt.MqttProperties;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.util.concurrent.FastThreadLocal;
+import io.streamnative.pulsar.handlers.mqtt.MQTTServerConfiguration;
 import io.streamnative.pulsar.handlers.mqtt.PacketIdGenerator;
 import io.streamnative.pulsar.handlers.mqtt.support.MessageBuilder;
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Entry;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.client.api.Message;
@@ -70,14 +72,27 @@ public class PulsarMessageConverter {
             };
 
     // Convert MQTT message to Pulsar message.
-    public static MessageImpl<byte[]> toPulsarMsg(Topic topic, MqttProperties properties, ByteBuffer payload) {
+    public static MessageImpl<byte[]> toPulsarMsg(MQTTServerConfiguration configuration,Topic topic, MqttProperties properties, ByteBuffer payload) {
         MessageMetadata metadata = LOCAL_MESSAGE_METADATA.get();
         metadata.clear();
+        if(configuration.isMqttAutoEventTime()){
+            metadata.setEventTime(System.currentTimeMillis());
+        }
         if (properties != null) {
             properties.listAll().forEach(prop -> {
                 if (MqttProperties.MqttPropertyType.USER_PROPERTY.value() == prop.propertyId()) {
                     MqttProperties.UserProperties userProperties = (MqttProperties.UserProperties) prop;
+                    boolean fillEventTimeFromProp = StringUtils.isNotBlank(configuration.getMqttEventTimeFromProp());
                     userProperties.value().forEach(pair -> {
+                        if (fillEventTimeFromProp
+                                && pair.key.equals(configuration.getMqttEventTimeFromProp())
+                        ) {
+                            try {
+                                metadata.setEventTime(Long.valueOf(pair.value));
+                            }catch (Exception e){
+                                log.error("fill eventtime from prop failed:",e);
+                            }
+                        }
                         metadata.addProperty().setKey(getPropertiesPrefix(prop.propertyId()) + pair.key)
                                 .setValue(pair.value);
                     });
@@ -203,6 +218,7 @@ public class PulsarMessageConverter {
         metadata.clear();
         ByteBuf payload = msg.getDataBuffer();
 
+        metadata.setEventTime(msg.getEventTime());
         // filled in required fields
         if (!metadata.hasSequenceId()) {
             metadata.setSequenceId(-1);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MessageConverTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MessageConverTest.java
@@ -73,4 +73,19 @@ public class MessageConverTest extends MQTTTestBase{
         Assert.assertEquals(eventtime,message.getEventTime());
     }
 
+    @Test
+    public void testFillMessageKeyFromProp(){
+        String messageKey = "msgKey";
+        serverConfiguration.setMqttMessageKeyFromProp(messageKey);
+
+        List<MqttProperties.StringPair> list = Lists.newArrayList();
+        list.add(new MqttProperties.StringPair(messageKey,messageKey));
+
+        MqttProperties mp = new MqttProperties();
+        mp.add(new MqttProperties.UserProperties(list));
+
+        MessageImpl<byte[]> message = PulsarMessageConverter.toPulsarMsg(serverConfiguration, topic, mp, ByteBuffer.wrap("world".getBytes()));
+        Assert.assertEquals(messageKey,message.getKey());
+    }
+
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MessageConverTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MessageConverTest.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.streamnative.pulsar.handlers.mqtt.base;
 
 import com.google.api.client.util.Lists;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MessageConverTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MessageConverTest.java
@@ -1,0 +1,76 @@
+package io.streamnative.pulsar.handlers.mqtt.base;
+
+import com.google.api.client.util.Lists;
+import io.netty.handler.codec.mqtt.MqttProperties;
+import io.streamnative.pulsar.handlers.mqtt.MQTTServerConfiguration;
+import io.streamnative.pulsar.handlers.mqtt.utils.PulsarMessageConverter;
+import io.streamnative.pulsar.handlers.mqtt.utils.PulsarTopicUtils;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.service.Topic;
+import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.junit.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+public class MessageConverTest extends MQTTTestBase{
+
+    MQTTServerConfiguration serverConfiguration;
+
+    String mqttTopic = "test";
+
+    String mqttEventTimeFromProp = "eventtime";
+
+    PulsarService pulsarService;
+
+    Topic topic;
+
+    @BeforeClass(alwaysRun = true)
+    public void setup() throws Exception {
+        super.setup();
+        serverConfiguration = new MQTTServerConfiguration();
+        serverConfiguration.setMqttAutoEventTime(true);
+
+        List<PulsarService> pulsarServiceList = getPulsarServiceList();
+        pulsarService = pulsarServiceList.get(0);
+
+        String encodedPulsarTopicName = PulsarTopicUtils.getEncodedPulsarTopicName(mqttTopic, serverConfiguration.getDefaultTenant(), serverConfiguration.getDefaultNamespace(), TopicDomain.persistent);
+        pulsarService.getAdminClient().topics().createNonPartitionedTopic(encodedPulsarTopicName);
+
+        CompletableFuture<Optional<Topic>> topicReference = PulsarTopicUtils.getTopicReference(pulsarService, mqttTopic,
+                serverConfiguration.getDefaultTenant(), serverConfiguration.getDefaultNamespace(), true
+                , serverConfiguration.getDefaultTopicDomain());
+
+        topic = topicReference.get().get();
+    }
+
+    @Test
+    public void testAutoEventTime(){
+        MessageImpl<byte[]> message = PulsarMessageConverter.toPulsarMsg(serverConfiguration, topic, new MqttProperties(), ByteBuffer.wrap("world".getBytes()));
+        Assert.assertEquals(true,message.getEventTime()>0);
+        serverConfiguration.setMqttAutoEventTime(false);
+        MessageImpl<byte[]> notEventTimeMessage = PulsarMessageConverter.toPulsarMsg(serverConfiguration, topic, new MqttProperties(), ByteBuffer.wrap("world".getBytes()));
+        Assert.assertEquals(true,notEventTimeMessage.getEventTime()==0);
+    }
+
+    @Test
+    public void testFillEventTimeFromProp(){
+        serverConfiguration.setMqttEventTimeFromProp(mqttEventTimeFromProp);
+
+        List<MqttProperties.StringPair> list = Lists.newArrayList();
+        long eventtime = System.currentTimeMillis();
+        list.add(new MqttProperties.StringPair(mqttEventTimeFromProp,eventtime+""));
+
+        MqttProperties mp = new MqttProperties();
+        mp.add(new MqttProperties.UserProperties(list));
+
+        MessageImpl<byte[]> message = PulsarMessageConverter.toPulsarMsg(serverConfiguration, topic, mp, ByteBuffer.wrap("world".getBytes()));
+        Assert.assertEquals(eventtime,message.getEventTime());
+    }
+
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MessageConverTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MessageConverTest.java
@@ -14,11 +14,15 @@
 
 package io.streamnative.pulsar.handlers.mqtt.base;
 
-import com.google.api.client.util.Lists;
 import io.netty.handler.codec.mqtt.MqttProperties;
 import io.streamnative.pulsar.handlers.mqtt.MQTTServerConfiguration;
 import io.streamnative.pulsar.handlers.mqtt.utils.PulsarMessageConverter;
 import io.streamnative.pulsar.handlers.mqtt.utils.PulsarTopicUtils;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.client.impl.MessageImpl;
@@ -27,10 +31,7 @@ import org.junit.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.nio.ByteBuffer;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
+
 
 public class MessageConverTest extends MQTTTestBase{
 
@@ -53,7 +54,9 @@ public class MessageConverTest extends MQTTTestBase{
         List<PulsarService> pulsarServiceList = getPulsarServiceList();
         pulsarService = pulsarServiceList.get(0);
 
-        String encodedPulsarTopicName = PulsarTopicUtils.getEncodedPulsarTopicName(mqttTopic, serverConfiguration.getDefaultTenant(), serverConfiguration.getDefaultNamespace(), TopicDomain.persistent);
+        String encodedPulsarTopicName = PulsarTopicUtils.getEncodedPulsarTopicName(
+                mqttTopic, serverConfiguration.getDefaultTenant(),
+                serverConfiguration.getDefaultNamespace(), TopicDomain.persistent);
         pulsarService.getAdminClient().topics().createNonPartitionedTopic(encodedPulsarTopicName);
 
         CompletableFuture<Optional<Topic>> topicReference = PulsarTopicUtils.getTopicReference(pulsarService, mqttTopic,
@@ -65,26 +68,29 @@ public class MessageConverTest extends MQTTTestBase{
 
     @Test
     public void testAutoEventTime(){
-        MessageImpl<byte[]> message = PulsarMessageConverter.toPulsarMsg(serverConfiguration, topic, new MqttProperties(), ByteBuffer.wrap("world".getBytes()));
-        Assert.assertEquals(true,message.getEventTime()>0);
+        MessageImpl<byte[]> message = PulsarMessageConverter.toPulsarMsg(
+                serverConfiguration, topic, new MqttProperties(), ByteBuffer.wrap("world".getBytes()));
+        Assert.assertEquals(true, message.getEventTime() > 0);
         serverConfiguration.setMqttAutoEventTime(false);
-        MessageImpl<byte[]> notEventTimeMessage = PulsarMessageConverter.toPulsarMsg(serverConfiguration, topic, new MqttProperties(), ByteBuffer.wrap("world".getBytes()));
-        Assert.assertEquals(true,notEventTimeMessage.getEventTime()==0);
+        MessageImpl<byte[]> notEventTimeMessage = PulsarMessageConverter.toPulsarMsg(
+                serverConfiguration, topic, new MqttProperties(), ByteBuffer.wrap("world".getBytes()));
+        Assert.assertEquals(true, notEventTimeMessage.getEventTime() == 0);
     }
 
     @Test
     public void testFillEventTimeFromProp(){
         serverConfiguration.setMqttEventTimeFromProp(mqttEventTimeFromProp);
 
-        List<MqttProperties.StringPair> list = Lists.newArrayList();
+        List<MqttProperties.StringPair> list = new ArrayList<>();
         long eventtime = System.currentTimeMillis();
-        list.add(new MqttProperties.StringPair(mqttEventTimeFromProp,eventtime+""));
+        list.add(new MqttProperties.StringPair(mqttEventTimeFromProp, eventtime + ""));
 
         MqttProperties mp = new MqttProperties();
         mp.add(new MqttProperties.UserProperties(list));
 
-        MessageImpl<byte[]> message = PulsarMessageConverter.toPulsarMsg(serverConfiguration, topic, mp, ByteBuffer.wrap("world".getBytes()));
-        Assert.assertEquals(eventtime,message.getEventTime());
+        MessageImpl<byte[]> message = PulsarMessageConverter.toPulsarMsg(
+                serverConfiguration, topic, mp, ByteBuffer.wrap("world".getBytes()));
+        Assert.assertEquals(eventtime, message.getEventTime());
     }
 
     @Test
@@ -92,14 +98,15 @@ public class MessageConverTest extends MQTTTestBase{
         String messageKey = "msgKey";
         serverConfiguration.setMqttMessageKeyFromProp(messageKey);
 
-        List<MqttProperties.StringPair> list = Lists.newArrayList();
-        list.add(new MqttProperties.StringPair(messageKey,messageKey));
+        List<MqttProperties.StringPair> list = new ArrayList<>();
+        list.add(new MqttProperties.StringPair(messageKey, messageKey));
 
         MqttProperties mp = new MqttProperties();
         mp.add(new MqttProperties.UserProperties(list));
 
-        MessageImpl<byte[]> message = PulsarMessageConverter.toPulsarMsg(serverConfiguration, topic, mp, ByteBuffer.wrap("world".getBytes()));
-        Assert.assertEquals(messageKey,message.getKey());
+        MessageImpl<byte[]> message = PulsarMessageConverter.toPulsarMsg(
+                serverConfiguration, topic, mp, ByteBuffer.wrap("world".getBytes()));
+        Assert.assertEquals(messageKey, message.getKey());
     }
 
 }


### PR DESCRIPTION
### Motivation

1. Support fill  pulsar message eventtime from mqtt properties or auto fill when convert pulsar message 
2. Support fill pulsar message key from mqtt properties

### Modifications

1. Add configuration for auto fill eventtime, false by default.
2. Add configuration for fill eventtime from properties.
3. Add configguration for fill message key from properties.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
 
  - Added integration tests for message conver 

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required`   

  
- [ ] `no-need-doc` 
  
- [ ] `doc` 
  
