### PR TITLE
Support lookup broker retriable

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyConfiguration.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyConfiguration.java
@@ -74,4 +74,21 @@ public class MQTTProxyConfiguration extends MQTTCommonConfiguration {
     )
     private int connectTimeoutMs = 10;
 
+    @FieldContext(
+            category = CATEGORY_MQTT_PROXY,
+            doc = "The number of schedule thread pools for Proxy lookup topic owner broker"
+    )
+    private int lookupThreadPoolNum = 1;
+
+    @FieldContext(
+            category = CATEGORY_MQTT_PROXY,
+            doc = "The max operation time for looking up"
+    )
+    private int lookupOperationTimeoutMs = 20000;
+
+    @FieldContext(
+            category = CATEGORY_MQTT_PROXY,
+            doc = "The maximum interval for performing lookup"
+    )
+    private int maxLookupIntervalMs = 5000;
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/PulsarServiceLookupHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/PulsarServiceLookupHandler.java
@@ -21,6 +21,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
@@ -29,8 +32,11 @@ import org.apache.pulsar.broker.loadbalance.LoadManager;
 import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.Backoff;
+import org.apache.pulsar.client.impl.BackoffBuilder;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.client.util.ExecutorProvider;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataCache;
@@ -47,71 +53,101 @@ public class PulsarServiceLookupHandler implements LookupHandler {
     private final PulsarClientImpl pulsarClient;
     private final MetadataCache<LocalBrokerData> localBrokerDataCache;
     private final PulsarService pulsarService;
+    private final MQTTProxyConfiguration proxyConfig;
+    private final ExecutorProvider executorProvider;
 
     public PulsarServiceLookupHandler(PulsarService pulsarService, MQTTProxyConfiguration proxyConfig) {
         this.pulsarService = pulsarService;
+        this.proxyConfig = proxyConfig;
+        this.executorProvider = new ExecutorProvider(proxyConfig.getLookupThreadPoolNum(), "pulsar-lookup-thread");
         this.localBrokerDataCache = pulsarService
                 .getLocalMetadataStore().getMetadataCache(LocalBrokerData.class);
         this.pulsarClient = getClient(proxyConfig);
     }
 
+    private void findBroker(TopicName topicName, Backoff backoff, AtomicLong remainingTime, CompletableFuture<InetSocketAddress> future) {
+        pulsarClient.getLookup().getBroker(topicName)
+                .thenCompose(lookupPair ->
+                        localBrokerDataCache.getChildren(LoadManager.LOADBALANCE_BROKERS_ROOT).thenCompose(brokers -> {
+                            // Get all broker data by metadata
+                            List<CompletableFuture<Optional<LocalBrokerData>>> brokerDataFutures =
+                                    Collections.unmodifiableList(brokers.stream()
+                                            .map(brokerPath -> String.format("%s/%s",
+                                                    LoadManager.LOADBALANCE_BROKERS_ROOT, brokerPath))
+                                            .map(localBrokerDataCache::get)
+                                            .collect(Collectors.toList()));
+                            return FutureUtil.waitForAll(brokerDataFutures)
+                                    .thenCompose(__ -> {
+                                        // Find specific broker same to lookup
+                                        Optional<LocalBrokerData> specificBrokerData =
+                                                brokerDataFutures.stream().map(CompletableFuture::join)
+                                                        .filter(brokerData -> brokerData.isPresent()
+                                                                && isLookupMQTTBroker(lookupPair, brokerData.get()))
+                                                        .map(Optional::get)
+                                                        .findAny();
+                                        if (!specificBrokerData.isPresent()) {
+                                            return FutureUtil.failedFuture(new BrokerServiceException(
+                                                    "The broker does not enabled the mqtt protocol handler."));
+                                        }
+                                        // Get MQTT protocol listeners
+                                        Optional<String> protocol = specificBrokerData.get().getProtocol(protocolHandlerName);
+                                        assert protocol.isPresent();
+                                        String mqttBrokerUrls = protocol.get();
+                                        String[] brokerUrls = mqttBrokerUrls.split(ConfigurationUtils.LISTENER_DEL);
+                                        // Get url random
+                                        Optional<String> brokerUrl = Arrays.stream(brokerUrls)
+                                                .filter(url -> url.startsWith(ConfigurationUtils.PLAINTEXT_PREFIX))
+                                                .findAny();
+                                        if (!brokerUrl.isPresent()) {
+                                            return FutureUtil.failedFuture(new BrokerServiceException(
+                                                    "The broker does not enabled the mqtt protocol handler."));
+                                        }
+                                        String[] splits = brokerUrl.get().split(ConfigurationUtils.COLON);
+                                        String port = splits[splits.length - 1];
+                                        int mqttBrokerPort = Integer.parseInt(port);
+                                        return CompletableFuture.completedFuture(new InetSocketAddress(
+                                                lookupPair.getLeft().getHostName(), mqttBrokerPort));
+                                    });
+                        }))
+                .thenAccept(future::complete)
+                .exceptionally(e -> {
+                    long nextDelay = Math.min(backoff.next(), remainingTime.get());
+                    // skip retry scheduler when set lookup throttle in client or server side which will lead to `TooManyRequestsException`
+                    boolean isLookupThrottling = !PulsarClientException.isRetriableError(e.getCause())
+                            || e.getCause() instanceof PulsarClientException.TooManyRequestsException
+                            || e.getCause() instanceof PulsarClientException.AuthenticationException;
+                    if (nextDelay <= 0 || isLookupThrottling) {
+                        future.completeExceptionally(e);
+                        return null;
+                    }
+
+                    ((ScheduledExecutorService) executorProvider.getExecutor()).schedule(() -> {
+                        log.warn("[topic: {}] Could not get topic lookup result -- Will try again in {} ms", topicName, nextDelay);
+                        remainingTime.addAndGet(-nextDelay);
+                        findBroker(topicName, backoff, remainingTime, future);
+                    }, nextDelay, TimeUnit.MILLISECONDS);
+                    return null;
+                });
+    }
+
     @Override
     public CompletableFuture<InetSocketAddress> findBroker(TopicName topicName) {
-        CompletableFuture<InetSocketAddress> lookupResult =  pulsarClient.getLookup().getBroker(topicName)
-                .thenCompose(lookupPair ->
-                    localBrokerDataCache.getChildren(LoadManager.LOADBALANCE_BROKERS_ROOT).thenCompose(brokers -> {
-                        // Get all broker data by metadata
-                        List<CompletableFuture<Optional<LocalBrokerData>>> brokerDataFutures =
-                                Collections.unmodifiableList(brokers.stream()
-                                        .map(brokerPath -> String.format("%s/%s",
-                                                        LoadManager.LOADBALANCE_BROKERS_ROOT, brokerPath))
-                                        .map(localBrokerDataCache::get)
-                                        .collect(Collectors.toList()));
-                    return FutureUtil.waitForAll(brokerDataFutures)
-                            .thenCompose(__ -> {
-                                // Find specific broker same to lookup
-                                Optional<LocalBrokerData> specificBrokerData =
-                                    brokerDataFutures.stream().map(CompletableFuture::join)
-                                        .filter(brokerData -> brokerData.isPresent()
-                                                && isLookupMQTTBroker(lookupPair, brokerData.get()))
-                                        .map(Optional::get)
-                                        .findAny();
-                                if (!specificBrokerData.isPresent()) {
-                                    return FutureUtil.failedFuture(new BrokerServiceException(
-                                            "The broker does not enabled the mqtt protocol handler."));
-                                }
-                                // Get MQTT protocol listeners
-                                Optional<String> protocol = specificBrokerData.get().getProtocol(protocolHandlerName);
-                                assert protocol.isPresent();
-                                String mqttBrokerUrls = protocol.get();
-                                String[] brokerUrls = mqttBrokerUrls.split(ConfigurationUtils.LISTENER_DEL);
-                                // Get url random
-                                Optional<String> brokerUrl = Arrays.stream(brokerUrls)
-                                        .filter(url -> url.startsWith(ConfigurationUtils.PLAINTEXT_PREFIX))
-                                        .findAny();
-                                if (!brokerUrl.isPresent()) {
-                                    return FutureUtil.failedFuture(new BrokerServiceException(
-                                            "The broker does not enabled the mqtt protocol handler."));
-                                }
-                                String[] splits = brokerUrl.get().split(ConfigurationUtils.COLON);
-                                String port = splits[splits.length - 1];
-                                int mqttBrokerPort = Integer.parseInt(port);
-                                return CompletableFuture.completedFuture(new InetSocketAddress(
-                                        lookupPair.getLeft().getHostName(), mqttBrokerPort));
-                                });
-                        })
-                );
-        lookupResult.exceptionally(ex -> {
-            log.error("Failed to perform lookup request for topic {}", topicName, ex);
-            return null;
-        });
+        CompletableFuture<InetSocketAddress> lookupResult = new CompletableFuture<>();
+        AtomicLong opTimeoutMs = new AtomicLong(proxyConfig.getLookupOperationTimeoutMs());
+        Backoff backoff = new BackoffBuilder()
+                .setInitialTime(100, TimeUnit.MILLISECONDS)
+                .setMandatoryStop(opTimeoutMs.get() * 2, TimeUnit.MILLISECONDS)
+                .setMax(proxyConfig.getMaxLookupIntervalMs(), TimeUnit.MILLISECONDS)
+                .create();
+
+        findBroker(topicName, backoff, opTimeoutMs, lookupResult);
         return lookupResult;
     }
 
     private boolean isLookupMQTTBroker(Pair<InetSocketAddress, InetSocketAddress> pair,
                                        LocalBrokerData localBrokerData) {
         return (localBrokerData.getPulsarServiceUrl().equals("pulsar://" + pair.getLeft().toString())
-                    || localBrokerData.getPulsarServiceUrlTls().equals("pulsar+ssl://" + pair.getLeft().toString()))
+                || localBrokerData.getPulsarServiceUrlTls().equals("pulsar+ssl://" + pair.getLeft().toString()))
                 && localBrokerData.getProtocol(protocolHandlerName).isPresent();
     }
 
@@ -119,6 +155,7 @@ public class PulsarServiceLookupHandler implements LookupHandler {
     public void close() {
         try {
             pulsarClient.close();
+            executorProvider.shutdownNow();
         } catch (PulsarClientException ignore) {
         }
     }


### PR DESCRIPTION
### Motivation

When the broker hangs or closes, if the client just executes the lookup request, the client will fail, so adding retriable topic lookup.


### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 


