### PR TITLE
Lazy init listener and avoid use metadata-thread run task.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/event/PulsarEventCenterImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/event/PulsarEventCenterImpl.java
@@ -15,22 +15,25 @@ package io.streamnative.pulsar.handlers.mqtt.support.event;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.common.util.OrderedExecutor;
+import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.metadata.api.Notification;
 
+@Slf4j
 public class PulsarEventCenterImpl implements Consumer<Notification>, PulsarEventCenter {
     private final List<PulsarEventListener> listeners;
-    private final ExecutorService callbackExecutor;
+    private final OrderedExecutor callbackExecutor;
 
     @SuppressWarnings("UnstableApiUsage")
     public PulsarEventCenterImpl(BrokerService brokerService, int poolThreadNum) {
         this.listeners = new CopyOnWriteArrayList<>();
-        this.callbackExecutor =
-                Executors.newFixedThreadPool(poolThreadNum);
+        this.callbackExecutor = OrderedScheduler.newSchedulerBuilder()
+                .numThreads(poolThreadNum)
+                .name("mqtt-notification-workers").build();
         brokerService.getPulsar()
                 .getConfigurationMetadataStore().registerListener(this);
     }
@@ -53,11 +56,15 @@ public class PulsarEventCenterImpl implements Consumer<Notification>, PulsarEven
 
     @Override
     public void accept(Notification notification) {
-        String path = notification.getPath();
-        List<PulsarEventListener> needNotifyListener =
-                listeners.stream().filter(listeners -> listeners.matchPath(path)).collect(Collectors.toList());
-        callbackExecutor.execute(() -> needNotifyListener.parallelStream()
-                .forEach(listener -> {
+        if (listeners.isEmpty()) {
+            return;
+        }
+        final String path = notification.getPath();
+        // give the task to another thread to avoid blocking metadata
+        callbackExecutor.executeOrdered(path, () -> {
+            for (PulsarEventListener listener : listeners.stream().filter(listeners ->
+                    listeners.matchPath(path)).collect(Collectors.toList())) {
+                try {
                     switch (notification.getType()) {
                         case Created:
                             listener.onNodeCreated(path);
@@ -68,6 +75,10 @@ public class PulsarEventCenterImpl implements Consumer<Notification>, PulsarEven
                         default:
                             break;
                     }
-                }));
+                } catch (Throwable ex) {
+                    log.warn("notify change {} {} failed.", notification.getType(), notification.getPath(), ex);
+                }
+            }
+        });
     }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/event/PulsarEventCenterImpl.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/event/PulsarEventCenterImpl.java
@@ -19,7 +19,6 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.util.OrderedExecutor;
-import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.metadata.api.Notification;
 
@@ -31,7 +30,7 @@ public class PulsarEventCenterImpl implements Consumer<Notification>, PulsarEven
     @SuppressWarnings("UnstableApiUsage")
     public PulsarEventCenterImpl(BrokerService brokerService, int poolThreadNum) {
         this.listeners = new CopyOnWriteArrayList<>();
-        this.callbackExecutor = OrderedScheduler.newSchedulerBuilder()
+        this.callbackExecutor = OrderedExecutor.newBuilder()
                 .numThreads(poolThreadNum)
                 .name("mqtt-notification-workers").build();
         brokerService.getPulsar()


### PR DESCRIPTION
### Motivation

1. When subscribing to MoP, we will create too many unused `AutoSubscribeHandler` listeners to the event store, for the performance problem, We can change this behaviour to being lazy.
2.  Avoid using metadata-thread to invoke logical operations.

### Modifications

 - Lazy register `AutoSubscribeHandler`
 - Use `OrderedExecutor` to avoid the concurrent problem.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

