### PR TITLE
Upgrade to depend on 3.0.0.1-SNAPSHOT

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/MQTTEventSystemTopicClient.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/MQTTEventSystemTopicClient.java
@@ -75,25 +75,25 @@ public class MQTTEventSystemTopicClient extends SystemTopicClientBase<MqttEvent>
         }
 
         @Override
-        public MessageId write(MqttEvent event) throws PulsarClientException {
+        public MessageId write(String key, MqttEvent event) throws PulsarClientException {
             TypedMessageBuilder<MqttEvent> builder = producer.newMessage().key(event.getKey()).value(event);
             return builder.send();
         }
 
         @Override
-        public CompletableFuture<MessageId> writeAsync(MqttEvent event) {
+        public CompletableFuture<MessageId> writeAsync(String key, MqttEvent event) {
             TypedMessageBuilder<MqttEvent> builder = producer.newMessage().key(event.getKey()).value(event);
             return builder.sendAsync();
         }
 
         @Override
-        public MessageId delete(MqttEvent event) throws PulsarClientException {
+        public MessageId delete(String key, MqttEvent event) throws PulsarClientException {
             TypedMessageBuilder<MqttEvent> builder = producer.newMessage().key(event.getKey()).value(event);
             return builder.send();
         }
 
         @Override
-        public CompletableFuture<MessageId> deleteAsync(MqttEvent event) {
+        public CompletableFuture<MessageId> deleteAsync(String key, MqttEvent event) {
             TypedMessageBuilder<MqttEvent> builder = producer.newMessage().key(event.getKey()).value(event);
             return builder.sendAsync();
         }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/SystemTopicBasedSystemEventService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/SystemTopicBasedSystemEventService.java
@@ -115,7 +115,7 @@ public class SystemTopicBasedSystemEventService implements SystemEventService {
         CompletableFuture<SystemTopicClient.Writer<MqttEvent>> writerFuture = systemTopicClient.newWriterAsync();
         return writerFuture.thenCompose(writer -> {
             CompletableFuture<MessageId> writeFuture = ActionType.DELETE.equals(event.getActionType())
-                    ? writer.deleteAsync(event) : writer.writeAsync(event);
+                    ? writer.deleteAsync(event.getKey(), event) : writer.writeAsync(event.getKey(), event);
             writeFuture.whenComplete((__, ex) -> {
                 if (ex != null) {
                     log.error("[{}] send event error.", SYSTEM_EVENT_TOPIC, ex);

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <mockito.version>2.22.0</mockito.version>
         <testng.version>6.14.3</testng.version>
         <awaitility.version>4.0.2</awaitility.version>
-        <pulsar.version>2.11.0.0-rc3</pulsar.version>
+        <pulsar.version>3.0.0.1-SNAPSHOT</pulsar.version>
         <mqtt.codec.version>4.1.77.Final</mqtt.codec.version>
         <log4j2.version>2.17.1</log4j2.version>
         <fusesource.client.version>1.16</fusesource.client.version>
@@ -362,6 +362,11 @@
             <id>central</id>
             <layout>default</layout>
             <url>https://repo1.maven.org/maven2</url>
+        </repository>
+
+        <repository>
+            <id>snapshot</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
 
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <testng.version>6.14.3</testng.version>
         <awaitility.version>4.0.2</awaitility.version>
         <pulsar.version>3.0.0.1-SNAPSHOT</pulsar.version>
-        <mqtt.codec.version>4.1.77.Final</mqtt.codec.version>
+        <mqtt.codec.version>4.1.89.Final</mqtt.codec.version>
         <log4j2.version>2.17.1</log4j2.version>
         <fusesource.client.version>1.16</fusesource.client.version>
         <hivemq.mqtt.client.version>1.2.2</hivemq.mqtt.client.version>


### PR DESCRIPTION
### Motivation

Upgrade to depend on 3.0.0.1-SNAPSHOT

### Modifications

* Upgrade pulsar version to 3.0.0.1-SNAPSHOT
* Upgrade netty version to 4.1.89.Final

### Verifying this change 

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

