### PR TITLE
Write retained messages to pulsar topic

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos0PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos0PublishHandler.java
@@ -35,7 +35,8 @@ public class Qos0PublishHandler extends AbstractQosPublishHandler {
     public CompletableFuture<Void> publish(Connection connection, MqttAdapterMessage adapter) {
         final MqttPublishMessage msg = (MqttPublishMessage) adapter.getMqttMessage();
         if (MqttUtils.isRetainedMessage(msg)) {
-            return retainedMessageHandler.addRetainedMessage(msg);
+            return retainedMessageHandler.addRetainedMessage(msg)
+                .thenCompose(__ -> writeToPulsarTopic(connection.getTopicAliasManager(), msg).thenAccept(___ -> {}));
         }
         return writeToPulsarTopic(connection.getTopicAliasManager(), msg).thenAccept(__ -> {});
     }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
@@ -49,8 +49,8 @@ public class Qos1PublishHandler extends AbstractQosPublishHandler {
         final CompletableFuture<Void> ret;
         if (MqttUtils.isRetainedMessage(msg)) {
             ret = retainedMessageHandler.addRetainedMessage(msg)
-                .thenCompose(__ -> writeToPulsarTopic( connection.getTopicAliasManager()
-                    , msg, !MqttUtils.isMqtt3(protocolVersion) ).thenApply(___ -> null));
+                .thenCompose(__ -> writeToPulsarTopic(connection.getTopicAliasManager()
+                    , msg, !MqttUtils.isMqtt3(protocolVersion)).thenApply(___ -> null));
         } else {
             ret = writeToPulsarTopic(connection.getTopicAliasManager()
                     , msg, !MqttUtils.isMqtt3(protocolVersion)).thenApply(__ -> null);

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
@@ -48,7 +48,9 @@ public class Qos1PublishHandler extends AbstractQosPublishHandler {
         final String topic = msg.variableHeader().topicName();
         final CompletableFuture<Void> ret;
         if (MqttUtils.isRetainedMessage(msg)) {
-            ret = retainedMessageHandler.addRetainedMessage(msg);
+            ret = retainedMessageHandler.addRetainedMessage(msg)
+                .thenCompose(__ -> writeToPulsarTopic( connection.getTopicAliasManager()
+                    , msg, !MqttUtils.isMqtt3(protocolVersion) ).thenApply(___ -> null));
         } else {
             ret = writeToPulsarTopic(connection.getTopicAliasManager()
                     , msg, !MqttUtils.isMqtt3(protocolVersion)).thenApply(__ -> null);


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes  #924

### Motivation

This fixes the issue of retain messages never making it to the destination pulsar topic. The issue seems to originate from the fact that adding a retain message seemed to completely evade the `writeToPulsarTopic` method, which effectively breaks retained MQTT messages from ever getting sent through as expected.

### Modifications

All retained messages are now also written into their respective pulsar topics per the expected behavior, which should now mimic every other MQTT broker's behavior.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*


This change is already covered by existing tests, such as *(please describe tests)*.


This change added tests and can be verified as follows:

 - Run MoP
 - Subscribe to topic
 - Publish retained message, should see message on subscription
 - Unsubscribe and resubscribe and you should see the retained message

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  This implements the implied and expected behavior for an existing feature.
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

