### PR TITLE
change last will to publish to puslar, remove LWT events as they're no

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTService.java
@@ -106,9 +106,9 @@ public class MQTTService {
             this.eventCenter = new PulsarEventCenterImpl(brokerService,
                     serverConfiguration.getEventCenterCallbackPoolThreadNum());
         }
-        this.willMessageHandler = new WillMessageHandler(this);
         this.retainedMessageHandler = new RetainedMessageHandler(this);
         this.qosPublishHandlers = new QosPublishHandlersImpl(this);
+        this.willMessageHandler = new WillMessageHandler(this);
     }
 
     public boolean isSystemTopicEnabled() {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyService.java
@@ -80,7 +80,6 @@ public class MQTTProxyService implements Closeable {
                 ? new SystemTopicBasedSystemEventService(mqttService.getPulsarService())
                 : new DisabledSystemEventService();
         this.eventService.addListener(connectionManager.getEventListener());
-        this.eventService.addListener(mqttService.getWillMessageHandler().getEventListener());
         this.eventService.addListener(mqttService.getRetainedMessageHandler().getEventListener());
         mqttService.setEventService(eventService);
         this.acceptorGroup = EventLoopUtil.newEventLoopGroup(proxyConfig.getMqttProxyNumAcceptorThreads(),

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTBrokerProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTBrokerProtocolMethodProcessor.java
@@ -65,6 +65,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import lombok.Getter;
@@ -308,9 +310,9 @@ public class MQTTBrokerProtocolMethodProcessor extends AbstractCommonProtocolMet
             WillMessage willMessage = connection.getWillMessage();
             if (willMessage != null) {
                 try {
-                    // wait to will message to fire before continuing cleanup
-                    willMessageHandler.fireWillMessage(connection, willMessage).get();
-                } catch (ExecutionException | InterruptedException e) {
+                    // wait to will message to fire before continuing cleanup, timeout at 500ms to avoid blocking
+                    willMessageHandler.fireWillMessage(connection, willMessage).get( 500, TimeUnit.MILLISECONDS );
+                } catch (TimeoutException | ExecutionException | InterruptedException e) {
                     log.error("[Connection Lost] [{}] Failed to fire will message: {}", clientId, e);
                 }
             }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTBrokerProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTBrokerProtocolMethodProcessor.java
@@ -310,7 +310,7 @@ public class MQTTBrokerProtocolMethodProcessor extends AbstractCommonProtocolMet
                 try {
                     // wait to will message to fire before continuing cleanup
                     willMessageHandler.fireWillMessage(connection, willMessage).get();
-                } catch ( ExecutionException | InterruptedException e) {
+                } catch (ExecutionException | InterruptedException e) {
                     log.error("[Connection Lost] [{}] Failed to fire will message: {}", clientId, e);
                 }
             }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTBrokerProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTBrokerProtocolMethodProcessor.java
@@ -311,7 +311,7 @@ public class MQTTBrokerProtocolMethodProcessor extends AbstractCommonProtocolMet
             if (willMessage != null) {
                 try {
                     // wait to will message to fire before continuing cleanup, timeout at 500ms to avoid blocking
-                    willMessageHandler.fireWillMessage(connection, willMessage).get( 500, TimeUnit.MILLISECONDS );
+                    willMessageHandler.fireWillMessage(connection, willMessage).get(500, TimeUnit.MILLISECONDS);
                 } catch (TimeoutException | ExecutionException | InterruptedException e) {
                     log.error("[Connection Lost] [{}] Failed to fire will message: {}", clientId, e);
                 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/WillMessageHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/WillMessageHandler.java
@@ -13,27 +13,25 @@
  */
 package io.streamnative.pulsar.handlers.mqtt.support;
 
-import static io.streamnative.pulsar.handlers.mqtt.support.systemtopic.EventType.LAST_WILL_MESSAGE;
 import static io.streamnative.pulsar.handlers.mqtt.utils.MqttMessageUtils.createMqttWillMessage;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.streamnative.pulsar.handlers.mqtt.Connection;
 import io.streamnative.pulsar.handlers.mqtt.MQTTConnectionManager;
 import io.streamnative.pulsar.handlers.mqtt.MQTTService;
 import io.streamnative.pulsar.handlers.mqtt.MQTTSubscriptionManager;
-import io.streamnative.pulsar.handlers.mqtt.support.systemtopic.EventListener;
-import io.streamnative.pulsar.handlers.mqtt.support.systemtopic.LastWillMessageEvent;
-import io.streamnative.pulsar.handlers.mqtt.support.systemtopic.MqttEvent;
+import io.streamnative.pulsar.handlers.mqtt.QosPublishHandlers;
+import io.streamnative.pulsar.handlers.mqtt.adapter.MqttAdapterMessage;
 import io.streamnative.pulsar.handlers.mqtt.utils.WillMessage;
-import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.common.util.FutureUtil;
 
 @Slf4j
 public class WillMessageHandler {
@@ -42,9 +40,9 @@ public class WillMessageHandler {
     private final MQTTSubscriptionManager mqttSubscriptionManager;
     private final MQTTConnectionManager connectionManager;
     private final String advertisedAddress;
-    @Getter
-    private final EventListener eventListener;
     private final MQTTService mqttService;
+    private final QosPublishHandlers qosPublishHandlers;
+    private final MQTTMetricsCollector metricsCollector;
 
     private final ScheduledExecutorService executor;
 
@@ -54,58 +52,44 @@ public class WillMessageHandler {
         this.mqttSubscriptionManager = mqttService.getSubscriptionManager();
         this.connectionManager = mqttService.getConnectionManager();
         this.advertisedAddress = mqttService.getPulsarService().getAdvertisedAddress();
-        this.eventListener = new LastWillMessageEventListener();
+        this.qosPublishHandlers = mqttService.getQosPublishHandlers();
+        this.metricsCollector = mqttService.getMetricsCollector();
         this.executor = Executors.newSingleThreadScheduledExecutor(
                 new DefaultThreadFactory("will-message-executor"));
     }
 
-    public void fireWillMessage(String clientId, WillMessage willMessage) {
-        if (StringUtils.isNotBlank(clientId) && mqttService.isSystemTopicEnabled()) {
-            LastWillMessageEvent lwt = LastWillMessageEvent
-                    .builder()
-                    .clientId(clientId)
-                    .willMessage(willMessage)
-                    .address(pulsarService.getAdvertisedAddress())
-                    .build();
-            mqttService.getEventService().sendLWTEvent(lwt);
-        }
-        if (willMessage.getDelayInterval() > 0) {
-            executor.schedule(() -> sendWillMessage(willMessage), willMessage.getDelayInterval(), TimeUnit.SECONDS);
-        } else {
-            sendWillMessage(willMessage);
-        }
+    private Executor delayedExecutor(long delay, TimeUnit unit) {
+        // this allows CompleteableFuture to be executed with a specified delay into a scheduled executor service
+        return r -> executor.schedule( r, delay, unit );
     }
 
-    private void sendWillMessage(WillMessage willMessage) {
-        List<Pair<String, String>> subscriptions = mqttSubscriptionManager.findMatchedTopic(willMessage.getTopic());
-        MqttPublishMessage msg = createMqttWillMessage(willMessage);
-        for (Pair<String, String> entry : subscriptions) {
-            Connection connection = connectionManager.getConnection(entry.getLeft());
-            if (connection != null) {
-                connection.send(msg);
-            } else {
-                log.warn("Not find connection for empty : {}", entry.getLeft());
-            }
+    public CompletableFuture<Void> fireWillMessage(Connection connection, WillMessage willMessage) {
+        if (willMessage.getDelayInterval() > 0) {
+            final Executor delayed = delayedExecutor(willMessage.getDelayInterval(), TimeUnit.SECONDS);
+            return CompletableFuture.supplyAsync(() -> sendWillMessageToPulsarTopic(connection, willMessage).join(), delayed);
+        }
+        return sendWillMessageToPulsarTopic(connection, willMessage);
+    }
+
+    private CompletableFuture<Void> sendWillMessageToPulsarTopic(Connection connection, WillMessage willMessage) {
+        final MqttPublishMessage msg = createMqttWillMessage(willMessage);
+        final MqttAdapterMessage adapter = new MqttAdapterMessage(connection.getClientId(), msg, connection.isFromProxy());
+        final MqttQoS qos = msg.fixedHeader().qosLevel();
+        metricsCollector.addSend(msg.payload().readableBytes());
+        switch (qos) {
+            case AT_MOST_ONCE:
+                return this.qosPublishHandlers.qos0().publish(connection, adapter);
+            case AT_LEAST_ONCE:
+                return this.qosPublishHandlers.qos1().publish(connection, adapter);
+            case EXACTLY_ONCE:
+                return this.qosPublishHandlers.qos2().publish(connection, adapter);
+            default:
+                log.error("[Publish] Unknown QoS-Type:{}", qos);
+                return FutureUtil.failedFuture(new IllegalArgumentException("Unknown QoS-Type:" + qos));
         }
     }
 
     public void close() {
         this.executor.shutdown();
-    }
-
-    class LastWillMessageEventListener implements EventListener {
-
-        @Override
-        public void onChange(MqttEvent event) {
-            if (event.getEventType() == LAST_WILL_MESSAGE) {
-                LastWillMessageEvent lwtEvent = (LastWillMessageEvent) event.getSourceEvent();
-                if (!lwtEvent.getAddress().equals(advertisedAddress)) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("fire will message : {}", lwtEvent.getWillMessage());
-                    }
-                    fireWillMessage("", lwtEvent.getWillMessage());
-                }
-            }
-        }
     }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/WillMessageHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/WillMessageHandler.java
@@ -60,20 +60,22 @@ public class WillMessageHandler {
 
     private Executor delayedExecutor(long delay, TimeUnit unit) {
         // this allows CompleteableFuture to be executed with a specified delay into a scheduled executor service
-        return r -> executor.schedule( r, delay, unit );
+        return r -> executor.schedule(r, delay, unit);
     }
 
     public CompletableFuture<Void> fireWillMessage(Connection connection, WillMessage willMessage) {
         if (willMessage.getDelayInterval() > 0) {
             final Executor delayed = delayedExecutor(willMessage.getDelayInterval(), TimeUnit.SECONDS);
-            return CompletableFuture.supplyAsync(() -> sendWillMessageToPulsarTopic(connection, willMessage).join(), delayed);
+            return CompletableFuture.supplyAsync(() -> sendWillMessageToPulsarTopic(connection, willMessage).join(),
+                                                 delayed);
         }
         return sendWillMessageToPulsarTopic(connection, willMessage);
     }
 
     private CompletableFuture<Void> sendWillMessageToPulsarTopic(Connection connection, WillMessage willMessage) {
         final MqttPublishMessage msg = createMqttWillMessage(willMessage);
-        final MqttAdapterMessage adapter = new MqttAdapterMessage(connection.getClientId(), msg, connection.isFromProxy());
+        final MqttAdapterMessage adapter = new MqttAdapterMessage(connection.getClientId(),
+                                                                  msg, connection.isFromProxy());
         final MqttQoS qos = msg.fixedHeader().qosLevel();
         metricsCollector.addSend(msg.payload().readableBytes());
         switch (qos) {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/WillMessageHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/WillMessageHandler.java
@@ -66,8 +66,7 @@ public class WillMessageHandler {
     public CompletableFuture<Void> fireWillMessage(Connection connection, WillMessage willMessage) {
         if (willMessage.getDelayInterval() > 0) {
             final Executor delayed = delayedExecutor(willMessage.getDelayInterval(), TimeUnit.SECONDS);
-            return CompletableFuture.supplyAsync(() -> sendWillMessageToPulsarTopic(connection, willMessage).join(),
-                                                 delayed);
+            return CompletableFuture.runAsync(() -> sendWillMessageToPulsarTopic(connection, willMessage), delayed);
         }
         return sendWillMessageToPulsarTopic(connection, willMessage);
     }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/DisabledSystemEventService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/DisabledSystemEventService.java
@@ -38,11 +38,6 @@ public class DisabledSystemEventService implements SystemEventService{
     }
 
     @Override
-    public CompletableFuture<Void> sendLWTEvent(LastWillMessageEvent event) {
-        return CompletableFuture.completedFuture(null);
-    }
-
-    @Override
     public CompletableFuture<Void> sendRetainedEvent(RetainedMessageEvent event) {
         return CompletableFuture.completedFuture(null);
     }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/SystemEventService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/SystemEventService.java
@@ -25,8 +25,6 @@ public interface SystemEventService {
 
     CompletableFuture<Void> sendConnectEvent(ConnectEvent event);
 
-    CompletableFuture<Void> sendLWTEvent(LastWillMessageEvent event);
-
     CompletableFuture<Void> sendRetainedEvent(RetainedMessageEvent event);
 
     CompletableFuture<Void> sendPSKEvent(PSKEvent event);

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/SystemTopicBasedSystemEventService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/SystemTopicBasedSystemEventService.java
@@ -78,17 +78,6 @@ public class SystemTopicBasedSystemEventService implements SystemEventService {
     }
 
     @Override
-    public CompletableFuture<Void> sendLWTEvent(LastWillMessageEvent event) {
-        checkReader();
-        return sendEvent(getMqttEvent(event, ActionType.INSERT))
-                .thenRun(() -> {
-                    if (log.isDebugEnabled()) {
-                        log.debug("send LWT event : {}", event);
-                    }
-                });
-    }
-
-    @Override
     public CompletableFuture<Void> sendRetainedEvent(RetainedMessageEvent event) {
         checkReader();
         return sendEvent(getMqttEvent(event, ActionType.INSERT))


### PR DESCRIPTION
Fixes #937


### Motivation

LWT did not function as expected. LWTs mechanism would utilize the system topic to propagate fireWillMessage events, and then each MoP instance would look at each of it's subscriptions on the topic the LWT should be published on, it would then send the LWT to all these susbcriptions directly. This meant LWT did NOT reach Pulsar topics, nor did QoSPublishHandlers come into play at all for LWT which means that retained LWTs did not work.

### Modifications

Instead of using the system topic I changed WillMessageHandler to publish the messages to their destination pulsar topic. This means that both Pulsar and MQTT clients can receive these messages, as MoP already subscribes on the pulsar topic on behalf of the MQTT MoP connection. WillMessageHandler now acquires the QoSPublishHandlers from MQTTService to properly publish messages with the appropriate QoS and retain functionality.

Since sendLWT events are no longer used I removed that from the interface and implementing classes, no uses or implementations should continue to exist. LWTs should NOT need to reach the system topic any longer, as the destination topic is already read by every MoP instance that's concerned with that topic. This is obviously excluding the case where the LWT is retained and that LWT message is send into the system topic as a retained message.

I tried to remain styled as closely to the rest of the codebase as possible. In many cases code is directly copied from other areas. The sendWillMessageToPulsarTopic was named to be very explicit about the behavior, and this code is largely taken from the `doPublish` method with some modifcations. In this case I'm relying on the `Connection` object, and therefore `fireWillMessage` was adapted to return a CompleteableFuture, so we can block till the will message is sent so we don't cleanup the `Connection` prematurely. I'm not sure if it would make sense to add a timeout on that to prevent deadlocking, but opted for the simpler solution. Additionally to support returning a CompleteableFuture, I changed the delay logic to wrap the SchedulerExecutorService in a way that could be used by a CompleteableFuture.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *(please describe tests)*.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
This change only adapts existing components to behave as expected.
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

