### PR TITLE
remove subs from subscription manager on unsubscribe

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTBrokerProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTBrokerProtocolMethodProcessor.java
@@ -500,6 +500,11 @@ public class MQTTBrokerProtocolMethodProcessor extends AbstractCommonProtocolMet
         final List<String> topicFilters = msg.payload().topics();
         final List<CompletableFuture<Void>> futureList = new ArrayList<>(topicFilters.size());
         for (String topicFilter : topicFilters) {
+            final boolean removed = mqttSubscriptionManager.removeSubscriptionForTopic(clientId, topicFilter);
+            if (!removed) {
+                throw new MQTTTopicNotExistedException(
+                    String.format("Can not found topic when %s unsubscribe.", clientId));
+            }
             metricsCollector.removeSub(topicFilter);
             CompletableFuture<List<String>> topicListFuture = PulsarTopicUtils.asyncGetTopicListFromTopicSubscription(
                     topicFilter, configuration.getDefaultTenant(), configuration.getDefaultNamespace(), pulsarService,


### PR DESCRIPTION

Fixes #954

### Motivation

Resubscribing was causing clients to be disconnected for duplicate subscription even though the subscription had been unsubscribed. The MQTTSubscriptionManager never removed subscriptions for a client, thus if you resubscribed on a topic it would always be a duplicate even if you unsubscribed previously.

### Modifications

MQTTSubscriptionManager now implements a way to remove a subscription by topic for a given client. The `processUnsubscribe` method now invokes that to appropriately remove the subscriptions on unsubscribe.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change is already covered by existing tests

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

