### PR TITLE
Bump MoP version to 2.9.5.1

### DIFF
--- a/mqtt-impl/pom.xml
+++ b/mqtt-impl/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>pulsar-protocol-handler-mqtt-parent</artifactId>
         <groupId>io.streamnative.pulsar.handlers</groupId>
-        <version>2.9.2.14</version>
+        <version>2.9.5.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pulsar-protocol-handler-mqtt</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <groupId>io.streamnative.pulsar.handlers</groupId>
     <artifactId>pulsar-protocol-handler-mqtt-parent</artifactId>
-    <version>2.9.2.14</version>
+    <version>2.9.5.1</version>
     <name>StreamNative :: Pulsar Protocol Handler :: MoP Parent</name>
     <description>Parent for MQTT on Pulsar implemented using Pulsar Protocol Handler.</description>
 
@@ -49,8 +49,8 @@
         <mockito.version>2.22.0</mockito.version>
         <testng.version>6.14.3</testng.version>
         <awaitility.version>4.0.2</awaitility.version>
-        <pulsar.version>2.9.2.14</pulsar.version>
-        <mqtt.codec.version>4.1.74.Final</mqtt.codec.version>
+        <pulsar.version>2.9.5.1</pulsar.version>
+        <mqtt.codec.version>4.1.89.Final</mqtt.codec.version>
         <log4j2.version>2.17.1</log4j2.version>
         <lombok.version>1.18.4</lombok.version>
         <fusesource.client.version>1.16</fusesource.client.version>
@@ -350,6 +350,10 @@
     </build>
 
     <repositories>
+        <repository>
+            <id>ossrh1</id>
+            <url>https://s01.oss.sonatype.org/service/local/repositories/iostreamnative-2201/content</url>
+        </repository>
         <repository>
             <id>central</id>
             <layout>default</layout>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>pulsar-protocol-handler-mqtt-parent</artifactId>
         <groupId>io.streamnative.pulsar.handlers</groupId>
-        <version>2.9.2.14</version>
+        <version>2.9.5.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pulsar-protocol-handler-mqtt-tests</artifactId>


### PR DESCRIPTION


### Motivation

Bump MoP version to 2.9.5.1

### Modifications

- Bump MoP version to 2.9.5.1

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

