### PR TITLE
Upgrade mqtt-codec 4.1.94

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,11 +50,12 @@
         <testng.version>6.14.3</testng.version>
         <awaitility.version>4.0.2</awaitility.version>
         <pulsar.version>3.0.0.1-SNAPSHOT</pulsar.version>
-        <mqtt.codec.version>4.1.89.Final</mqtt.codec.version>
+        <mqtt.codec.version>4.1.94.Final</mqtt.codec.version>
         <log4j2.version>2.17.1</log4j2.version>
         <fusesource.client.version>1.16</fusesource.client.version>
         <hivemq.mqtt.client.version>1.2.2</hivemq.mqtt.client.version>
         <apache.commons.bean-utils.version>1.9.4</apache.commons.bean-utils.version>
+        <grpc.version>1.45.1</grpc.version>
         <!-- plugins -->
         <javac.target>1.8</javac.target>
         <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>
@@ -92,7 +93,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-all</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTProtocolHandlerTestBase.java
@@ -400,9 +400,6 @@ public abstract class MQTTProtocolHandlerTestBase {
         setupBrokerMocks(pulsar);
         pulsar.start();
 
-        Compactor spiedCompactor = spy(pulsar.getCompactor());
-        doReturn(spiedCompactor).when(pulsar).getCompactor();
-
         return pulsar;
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTProtocolHandlerTestBase.java
@@ -55,7 +55,6 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.naming.TopicDomain;
-import org.apache.pulsar.compaction.Compactor;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.zookeeper.CreateMode;


### PR DESCRIPTION
### Motivation

1. Upgrade mqtt-codec to 4.1.94 to match the netty version.
2. Remove the useless mock
3. Add grpc dependency to avoid StackOverFlow
```
Exception in thread "main" java.lang.StackOverflowError
	at org.eclipse.aether.util.graph.transformer.ConflictResolver$ConflictContext.isIncluded(ConflictResolver.java:1059)
	at org.eclipse.aether.util.graph.transformer.NearestVersionSelector$1.accept(NearestVersionSelector.java:154)
	at org.eclipse.aether.util.graph.visitor.PathRecordingDependencyVisitor.visitEnter(PathRecordingDependencyVisitor.java:102)
	at org.eclipse.aether.graph.DefaultDependencyNode.accept(DefaultDependencyNode.java:343)
	at org.eclipse.aether.graph.DefaultDependencyNode.accept(DefaultDependencyNode.java:347)
	at org.eclipse.aether.graph.DefaultDependencyNode.accept(DefaultDependencyNode.java:347)
	at org.eclipse.aether.graph.DefaultDependencyNode.accept(DefaultDependencyNode.java:347)
	at org.eclipse.aether.graph.DefaultDependencyNode.accept(DefaultDependencyNode.java:347)
	at org.eclipse.aether.graph.DefaultDependencyNode.accept(DefaultDependencyNode.java:347)
	at org.eclipse.aether.graph.DefaultDependencyNode.accept(DefaultDependencyNode.java:347)
	at org.eclipse.aether.graph.DefaultDependencyNode.accept(DefaultDependencyNode.java:347)
```


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

