### PR TITLE
Fix lookup issue for MQTT-5

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/adapter/MQTTProxyAdapter.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/adapter/MQTTProxyAdapter.java
@@ -51,7 +51,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.common.util.netty.ChannelFutures;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
 
@@ -226,16 +225,14 @@ public class MQTTProxyAdapter {
                                     (MqttPubReplyMessageVariableHeader) variableHeader;
                             byte reasonCode = header.reasonCode();
                             if (Mqtt5PubReasonCode.UNSPECIFIED_ERROR.byteValue() == reasonCode) {
-                                String sourceTopicName = processor.getPacketIdTopic().get(variableHeader.messageId());
-                                if (StringUtils.isEmpty(sourceTopicName)) {
-                                    MqttProperties.UserProperties property =
-                                            (MqttProperties.UserProperties) header.properties()
-                                                    .getProperty(MqttProperties.MqttPropertyType.USER_PROPERTY.value());
-                                    if (property != null) {
-                                        List<MqttProperties.StringPair> pairs = property.value();
-                                        sourceTopicName = pairs.stream().filter(p -> p.key.equals("topicName"))
-                                                .map(p -> p.value).findFirst().orElse("");
-                                    }
+                                String sourceTopicName = null;
+                                MqttProperties.UserProperties property =
+                                        (MqttProperties.UserProperties) header.properties()
+                                                .getProperty(MqttProperties.MqttPropertyType.USER_PROPERTY.value());
+                                if (property != null) {
+                                    List<MqttProperties.StringPair> pairs = property.value();
+                                    sourceTopicName = pairs.stream().filter(p -> p.key.equals("topicName"))
+                                            .map(p -> p.value).findFirst().orElse(null);
                                 }
                                 processor.removeTopicBroker(sourceTopicName);
                             }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/ack/MqttPubAck.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/messages/ack/MqttPubAck.java
@@ -72,12 +72,19 @@ public class MqttPubAck {
         private Mqtt5PubReasonCode reasonCode;
         private String reasonString;
 
+        private MqttProperties.UserProperties userProperties;
+
         public MqttPubErrorAckBuilder(int protocolVersion) {
             this.protocolVersion = protocolVersion;
         }
 
         public MqttPubAck.MqttPubErrorAckBuilder reasonString(String reasonStr) {
             this.reasonString = reasonStr;
+            return this;
+        }
+
+        public MqttPubAck.MqttPubErrorAckBuilder userProperties(MqttProperties.UserProperties userProperties) {
+            this.userProperties = userProperties;
             return this;
         }
 
@@ -111,6 +118,9 @@ public class MqttPubAck {
             MqttProperties properties = new MqttProperties();
             if (reasonString != null) {
                 MqttPropertyUtils.setReasonString(properties, reasonString);
+            }
+            if (userProperties != null) {
+                properties.add(userProperties);
             }
             return properties;
         }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -455,10 +455,11 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
                     TopicDomain.getEnum(proxyConfig.getDefaultTopicDomain()));
             final CompletableFuture<AdapterChannel> brokerChannel = topicBrokers.remove(pulsarTopicName);
             if (brokerChannel != null) {
-                final InetSocketAddress broker = brokerChannel.join().getBroker();
-                if (log.isDebugEnabled()) {
-                    log.debug("remove topic : {} from broker : {}", topic, broker);
-                }
+                brokerChannel.thenAccept(channel -> {
+                    if (log.isDebugEnabled()) {
+                        log.debug("remove topic : {} from broker : {}", topic, channel.getBroker());
+                    }
+                });
             }
         }
     }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -56,6 +56,7 @@ import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
@@ -438,12 +439,28 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
         return topicBrokers.computeIfAbsent(topic,
                 key -> lookupHandler.findBroker(TopicName.get(topic)).thenApply(mqttBroker ->
                         adapterChannels.computeIfAbsent(mqttBroker, key1 -> {
-                    AdapterChannel adapterChannel = proxyAdapter.getAdapterChannel(mqttBroker);
-                    adapterChannel.writeAndFlush(new MqttAdapterMessage(
-                            connection.getClientId(),
-                            connection.getConnectMessage()));
-                    return adapterChannel;
-                })));
+                            AdapterChannel adapterChannel = proxyAdapter.getAdapterChannel(mqttBroker);
+                            adapterChannel.writeAndFlush(new MqttAdapterMessage(connection.getClientId(),
+                                connection.getConnectMessage()));
+                            return adapterChannel;
+                        })
+                )
+        );
+    }
+
+    public void removeTopicBroker(String topic) {
+        if (StringUtils.isNotEmpty(topic)) {
+            String pulsarTopicName = PulsarTopicUtils.getEncodedPulsarTopicName(topic,
+                    proxyConfig.getDefaultTenant(), proxyConfig.getDefaultNamespace(),
+                    TopicDomain.getEnum(proxyConfig.getDefaultTopicDomain()));
+            final CompletableFuture<AdapterChannel> brokerChannel = topicBrokers.remove(pulsarTopicName);
+            if (brokerChannel != null) {
+                final InetSocketAddress broker = brokerChannel.join().getBroker();
+                if (log.isDebugEnabled()) {
+                    log.debug("remove topic : {} from broker : {}", topic, broker);
+                }
+            }
+        }
     }
 
     public AtomicBoolean isDisconnected() {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/PulsarServiceLookupHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/PulsarServiceLookupHandler.java
@@ -151,11 +151,12 @@ public class PulsarServiceLookupHandler implements LookupHandler {
 
     private boolean isLookupMQTTBroker(Pair<InetSocketAddress, InetSocketAddress> pair,
                                        LocalBrokerData localBrokerData) {
-        String pulsar = String.format("pulsar://%s:%d", pair.getLeft().getHostName(), pair.getLeft().getPort());
-        String pulsarSsl = String.format("pulsar+ssl://%s:%d", pair.getLeft().getHostName(), pair.getLeft().getPort());
-        return (localBrokerData.getPulsarServiceUrl().equals(pulsar)
-                || localBrokerData.getPulsarServiceUrlTls().equals(pulsarSsl)
-                && localBrokerData.getProtocol(protocolHandlerName).isPresent());
+
+        String plain = String.format("pulsar://%s:%s", pair.getLeft().getHostName(), pair.getLeft().getPort());
+        String ssl = String.format("pulsar+ssl://%s:%s", pair.getLeft().getHostName(), pair.getLeft().getPort());
+        return localBrokerData.getProtocol(protocolHandlerName).isPresent()
+                && (localBrokerData.getPulsarServiceUrl().equals(plain)
+                    || localBrokerData.getPulsarServiceUrlTls().equals(ssl));
     }
 
     @Override

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MQTTProtocolHandlerTestBase.java
@@ -141,7 +141,7 @@ public abstract class MQTTProtocolHandlerTestBase {
         mqtt.setManagedLedgerCacheSizeMB(8);
         mqtt.setActiveConsumerFailoverDelayTimeMillis(0);
         mqtt.setDefaultRetentionTimeInMinutes(7);
-        mqtt.setDefaultNumberOfNamespaceBundles(1);
+        mqtt.setDefaultNumberOfNamespaceBundles(4);
         mqtt.setZookeeperServers("localhost:2181");
         mqtt.setConfigurationStoreServers("localhost:3181");
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt5/hivemq/proxy/MQTT5ProxyIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt5/hivemq/proxy/MQTT5ProxyIntegrationTest.java
@@ -82,6 +82,7 @@ public class MQTT5ProxyIntegrationTest extends MQTTTestBase {
                 .payload("msg1".getBytes(StandardCharsets.UTF_8))
                 .send();
         Assert.assertFalse(r3.getError().isPresent());
+        client.disconnect();
     }
 
     @Test(invocationCount = 2)

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt5/hivemq/proxy/MQTT5ProxyIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt5/hivemq/proxy/MQTT5ProxyIntegrationTest.java
@@ -47,7 +47,7 @@ public class MQTT5ProxyIntegrationTest extends MQTTTestBase {
         return conf;
     }
 
-    @Test
+    @Test(timeOut = 30_000)
     public void testBrokerThrowServiceNotReadyException() throws Exception {
         Mqtt5BlockingClient client = MQTT5ClientUtils.createMqtt5ProxyClient(
                 getMqttProxyPortList().get(random.nextInt(mqttProxyPortList.size())));

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt5/hivemq/proxy/MQTT5ProxyIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt5/hivemq/proxy/MQTT5ProxyIntegrationTest.java
@@ -17,9 +17,12 @@ import com.google.common.collect.Lists;
 import com.hivemq.client.mqtt.MqttGlobalPublishFilter;
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5BlockingClient;
+import com.hivemq.client.mqtt.mqtt5.exceptions.Mqtt5PubAckException;
 import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish;
+import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5PublishResult;
 import io.streamnative.pulsar.handlers.mqtt.MQTTCommonConfiguration;
 import io.streamnative.pulsar.handlers.mqtt.base.MQTTTestBase;
+import io.streamnative.pulsar.handlers.mqtt.messages.codes.mqtt5.Mqtt5PubReasonCode;
 import io.streamnative.pulsar.handlers.mqtt.mqtt5.hivemq.base.MQTT5ClientUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -42,6 +45,43 @@ public class MQTT5ProxyIntegrationTest extends MQTTTestBase {
         MQTTCommonConfiguration conf = super.initConfig();
         conf.setMqttProxyEnabled(true);
         return conf;
+    }
+
+    @Test
+    public void testBrokerThrowServiceNotReadyException() throws Exception {
+        Mqtt5BlockingClient client = MQTT5ClientUtils.createMqtt5ProxyClient(
+                getMqttProxyPortList().get(random.nextInt(mqttProxyPortList.size())));
+        client.connect();
+        final String topic1 = "topic-1";
+        final String ownedBroker = admin.lookups().lookupTopic(topic1);
+
+        final Mqtt5PublishResult r1 = client.publishWith()
+                .topic(topic1)
+                .qos(MqttQos.AT_LEAST_ONCE)
+                .payload("msg1".getBytes(StandardCharsets.UTF_8))
+                .send();
+        Assert.assertFalse(r1.getError().isPresent());
+        while (ownedBroker.equals(admin.lookups().lookupTopic(topic1))) {
+            admin.namespaces().unload("public/default");
+            Thread.sleep(1000);
+        }
+        try {
+            final Mqtt5PublishResult r2 = client.publishWith()
+                    .topic(topic1)
+                    .qos(MqttQos.AT_LEAST_ONCE)
+                    .payload("msg1".getBytes(StandardCharsets.UTF_8))
+                    .send();
+        } catch (Exception ex) {
+            Assert.assertTrue(ex instanceof Mqtt5PubAckException);
+            Assert.assertEquals(((Mqtt5PubAckException) ex).getMqttMessage().getReasonCode().getCode()
+                    , Mqtt5PubReasonCode.UNSPECIFIED_ERROR.value());
+        }
+        final Mqtt5PublishResult r3 = client.publishWith()
+                .topic(topic1)
+                .qos(MqttQos.AT_LEAST_ONCE)
+                .payload("msg1".getBytes(StandardCharsets.UTF_8))
+                .send();
+        Assert.assertFalse(r3.getError().isPresent());
     }
 
     @Test(invocationCount = 2)


### PR DESCRIPTION
### Motivation

Fix the lookup issue.  this pr only fix this issue for Qos1 under MQTT-5.

```
2023-07-25T08:27:12,754+0000 [pulsar-2-1] ERROR io.streamnative.pulsar.handlers.mqtt.support.MQTTBrokerProtocolMethodProcessor - [Publish] [bench/mqtt/4296] Write MqttPublishMessage[fixedHeader=MqttFixedHeader[messageType=PUBLISH, isDup=false, qosLevel=AT_MOST_ONCE, isRetain=false, remainingLength=274], variableHeader=MqttPublishVariableHeader[topicName=bench/mqtt/4296, packetId=-1], payload=PooledSlicedByteBuf(ridx: 0, widx: 256, cap: 256/256, unwrapped: PooledUnsafeDirectByteBuf(ridx: 277, widx: 277, cap: 277))] to Pulsar topic failed.
org.apache.pulsar.broker.service.BrokerServiceException$ServiceUnitNotReadyException: Namespace bundle for topic (persistent://public/default/bench%2Fmqtt%2F4296) not served by this instance. Please redo the lookup. Request is denied: namespace=public/default
	at org.apache.pulsar.broker.service.BrokerService.lambda$checkTopicNsOwnership$84(BrokerService.java:1925) ~[io.streamnative-pulsar-broker-2.10.3.7.jar:2.10.3.7]
	at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1106) ~[?:?]
	at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2235) ~[?:?]
	at org.apache.pulsar.broker.service.BrokerService.checkTopicNsOwnership(BrokerService.java:1917) ~[io.streamnative-pulsar-broker-2.10.3.7.jar:2.10.3.7]
	at org.apache.pulsar.broker.service.BrokerService.loadOrCreatePersistentTopic(BrokerService.java:1393) ~[io.streamnative-pulsar-broker-2.10.3.7.jar:2.10.3.7]
	at org.apache.pulsar.broker.service.BrokerService.lambda$getTopic$27(BrokerService.java:976) ~[io.streamnative-pulsar-broker-2.10.3.7.jar:2.10.3.7]
	at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.put(ConcurrentOpenHashMap.java:404) ~[io.streamnative-pulsar-common-2.10.3.7.jar:2.10.3.7]
	at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.computeIfAbsent(ConcurrentOpenHashMap.java:238) ~[io.streamnative-pulsar-common-2.10.3.7.jar:2.10.3.7]
	at org.apache.pulsar.broker.service.BrokerService.getTopic(BrokerService.java:975) ~[io.streamnative-pulsar-broker-2.10.3.7.jar:2.10.3.7]
	at org.apache.pulsar.broker.service.BrokerService.getTopic(BrokerService.java:940) ~[io.streamnative-pulsar-broker-2.10.3.7.jar:2.10.3.7]
	at io.streamnative.pulsar.handlers.mqtt.utils.PulsarTopicUtils.lambda$getTopicReference$4(PulsarTopicUtils.java:88) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:1072) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073) ~[?:?]
	at org.apache.pulsar.broker.namespace.NamespaceService.lambda$searchForCandidateBroker$16(NamespaceService.java:605) ~[io.streamnative-pulsar-broker-2.10.3.7.jar:2.10.3.7]
	at java.util.concurrent.CompletableFuture.uniAcceptNow(CompletableFuture.java:753) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniAcceptStage(CompletableFuture.java:731) ~[?:?]
	at java.util.concurrent.CompletableFuture.thenAccept(CompletableFuture.java:2108) ~[?:?]
	at org.apache.pulsar.broker.namespace.NamespaceService.searchForCandidateBroker(NamespaceService.java:605) ~[io.streamnative-pulsar-broker-2.10.3.7.jar:2.10.3.7]
	at org.apache.pulsar.broker.namespace.NamespaceService.lambda$findBrokerServiceUrl$8(NamespaceService.java:408) ~[io.streamnative-pulsar-broker-2.10.3.7.jar:2.10.3.7]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.87.Final.jar:4.1.87.Final]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
2023-07-25T08:27:12,754+0000 [pulsar-2-2] ERROR io.streamnative.pulsar.handlers.mqtt.support.MQTTBrokerProtocolMethodProcessor - [Publish] [bench/mqtt/2116] Write MqttPublishMessage[fixedHeader=MqttFixedHeader[messageType=PUBLISH, isDup=false, qosLevel=AT_MOST_ONCE, isRetain=false, remainingLength=274], variableHeader=MqttPublishVariableHeader[topicName=bench/mqtt/2116, packetId=-1], payload=PooledSlicedByteBuf(ridx: 0, widx: 256, cap: 256/256, unwrapped: PooledUnsafeDirectByteBuf(ridx: 277, widx: 277, cap: 277))] to Pulsar topic failed.
```


### Modifications



### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

