### PR TITLE
Fix bundle is being unload IllegalState exception

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/AbstractQosPublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/AbstractQosPublishHandler.java
@@ -25,8 +25,6 @@ import io.streamnative.pulsar.handlers.mqtt.utils.MessagePublishContext;
 import io.streamnative.pulsar.handlers.mqtt.utils.PulsarTopicUtils;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;


### PR DESCRIPTION
### Motivation

```
2023-07-27T09:04:27,927+0000 [pulsar-ph-mqtt-51-1] ERROR io.streamnative.pulsar.handlers.mqtt.support.Qos1PublishHandler - [bench/mqtt/3482] Publish msg MqttPublishMessage[fixedHeader=MqttFixedHeader[messageType=PUBLISH, isDup=false, qosLevel=AT_LEAST_ONCE, isRetain=false, remainingLength=276], variableHeader=MqttPublishVariableHeader[topicName=bench/mqtt/3482, packetId=65], payload=PooledSlicedByteBuf(ridx: 0, widx: 256, cap: 256/256, unwrapped: PooledUnsafeDirectByteBuf(ridx: 279, widx: 279, cap: 279))] fail.
java.util.concurrent.CompletionException: java.lang.IllegalStateException: Namespace bundle public/default/0x203b5d0d_0x40000000 is being unloaded
	at java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:367) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1108) ~[?:?]
	at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2235) ~[?:?]
	at org.apache.pulsar.broker.namespace.NamespaceService.getBrokerServiceUrlAsync(NamespaceService.java:191) ~[io.streamnative-pulsar-broker-2.10.4.6.jar:2.10.4.6]
	at io.streamnative.pulsar.handlers.mqtt.utils.PulsarTopicUtils.getTopicReference(PulsarTopicUtils.java:86) ~[?:?]
	at io.streamnative.pulsar.handlers.mqtt.utils.PulsarTopicUtils.lambda$getTopicReference$1(PulsarTopicUtils.java:72) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1106) ~[?:?]
	at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2235) ~[?:?]
	at io.streamnative.pulsar.handlers.mqtt.utils.PulsarTopicUtils.lambda$getTopicReference$2(PulsarTopicUtils.java:71) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1106) ~[?:?]
	at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2235) ~[?:?]
	at io.streamnative.pulsar.handlers.mqtt.utils.PulsarTopicUtils.getTopicReference(PulsarTopicUtils.java:58) ~[?:?]
	at io.streamnative.pulsar.handlers.mqtt.AbstractQosPublishHandler.getTopicReference(AbstractQosPublishHandler.java:52) ~[?:?]
	at io.streamnative.pulsar.handlers.mqtt.AbstractQosPublishHandler.writeToPulsarTopic(AbstractQosPublishHandler.java:92) ~[?:?]
```

### Modifications

- Convert `IllegalStateException` to `ServiceUnitNotReadyException` 
### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

