### PR TITLE
Fix close reader NPE.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/SystemTopicBasedSystemEventService.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/systemtopic/SystemTopicBasedSystemEventService.java
@@ -196,7 +196,9 @@ public class SystemTopicBasedSystemEventService implements SystemEventService {
 
     private void closeReader() {
         if (initReader.compareAndSet(true, false)) {
-            reader.closeAsync();
+            if (reader != null) {
+                reader.closeAsync();
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation

```
org.apache.pulsar.broker.PulsarServerException: java.lang.NullPointerException: Cannot invoke "org.apache.pulsar.broker.systopic.SystemTopicClient$Reader.closeAsync()" because "this.reader" is null

	at org.apache.pulsar.broker.PulsarService.closeAsync(PulsarService.java:583)
	at org.apache.pulsar.broker.PulsarService.close(PulsarService.java:373)
	at io.streamnative.pulsar.handlers.mqtt.mqtt5.hivemq.proxy.MQTT5ProxyIntegrationTest.testBrokerThrowServiceNotReadyException(MQTT5ProxyIntegrationTest.java:68)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:124)
	at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:54)
	at org.testng.internal.InvokeMethodRunnable.run(InvokeMethodRunnable.java:44)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:264)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.pulsar.broker.systopic.SystemTopicClient$Reader.closeAsync()" because "this.reader" is null
```


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

