### PR TITLE
Revert "Add ping request for adapter channel (#1047)"

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/MQTTProxyProtocolMethodProcessor.java
@@ -13,7 +13,6 @@
  */
 package io.streamnative.pulsar.handlers.mqtt.proxy;
 
-import static io.streamnative.pulsar.handlers.mqtt.utils.MqttMessageUtils.pingResp;
 import com.google.common.collect.Lists;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
@@ -65,7 +64,6 @@ import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.common.util.FutureUtil;
-
 /**
  * Proxy inbound handler is the bridge between proxy and MoP.
  */
@@ -222,7 +220,13 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
 
     @Override
     public void processPingReq(final MqttAdapterMessage msg) {
-        connection.send(pingResp());
+        String clientId = connection.getClientId();
+        topicBrokers.values().forEach(adapterChannel -> {
+            adapterChannel.thenAccept(channel -> {
+                msg.setClientId(clientId);
+                channel.writeAndFlush(msg);
+            });
+        });
     }
 
     @Override


### PR DESCRIPTION
### Motivation

Revert #1047, as it breaks the original logic in the broker .
The broker will add `addIdleStateHandler` according to user configed keepalive-time dynamically.
If #1047 doesn't send a ping request to the broker, the broker will close the client connection due to idle handler.

The ProxyTest#testProxyProcessPingReq will help cover this case.


### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

