### PR TITLE
call equals on formatted strings since they will never be null

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/PulsarServiceLookupHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/PulsarServiceLookupHandler.java
@@ -158,8 +158,8 @@ public class PulsarServiceLookupHandler implements LookupHandler {
         String plain = String.format("pulsar://%s:%s", pair.getLeft().getHostName(), pair.getLeft().getPort());
         String ssl = String.format("pulsar+ssl://%s:%s", pair.getLeft().getHostName(), pair.getLeft().getPort());
         return localBrokerData.getProtocol(protocolHandlerName).isPresent()
-                && (localBrokerData.getPulsarServiceUrl().equals(plain)
-                    || localBrokerData.getPulsarServiceUrlTls().equals(ssl));
+                && (plain.equals(localBrokerData.getPulsarServiceUrl())
+                    || ssl.equals(localBrokerData.getPulsarServiceUrlTls()));
     }
 
     @Override


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #1210

### Motivation

When running with TLS disabled `PulsarServiceLookupHandler::isLookupMQTTBroker` is calling `localBrokerData.getPulsarServiceUrlTls()` which returns `null` if TLS is disabled. This method then tried to call `equals(..)` on the returned value which is `null` causing a `NullPointerException`. This prevents MoP proxy from working properly, as it will never resolve the host and this loop will simply crash.

### Modifications

Instead of calling `equals` on the values returned from `localBrokerData`, which can be `null` if missing in the metadata store, I instead call `equals` on the strings created which are compared against since those will never be null, but it's safe to pass null as an argument to `String::equals`. This prevents the `NullPointerException` with minimal change.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

