### PR TITLE
Rework proxy keep alive mechanism

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/adapter/AdapterChannel.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/adapter/AdapterChannel.java
@@ -31,10 +31,13 @@ public class AdapterChannel {
     private final InetSocketAddress broker;
     private CompletableFuture<Channel> channelFuture;
 
-    public AdapterChannel(MQTTProxyAdapter adapter,
-                          InetSocketAddress broker, CompletableFuture<Channel> channelFuture) {
+    private final int keepAliveTimeSeconds;
+
+    public AdapterChannel(MQTTProxyAdapter adapter, InetSocketAddress broker,
+                          int keepAliveTimeSeconds, CompletableFuture<Channel> channelFuture) {
         this.adapter = adapter;
         this.broker = broker;
+        this.keepAliveTimeSeconds = keepAliveTimeSeconds;
         this.channelFuture = channelFuture;
     }
 
@@ -44,7 +47,7 @@ public class AdapterChannel {
         adapterMsg.setEncodeType(MqttAdapterMessage.EncodeType.ADAPTER_MESSAGE);
         CompletableFuture<Void> future = channelFuture.thenCompose(channel -> {
             if (!channel.isActive()) {
-                channelFuture = adapter.getChannel(broker);
+                channelFuture = adapter.getChannel(broker, keepAliveTimeSeconds);
                 return writeAndFlush(adapterMsg);
             }
             return FutureUtils.completableFuture(channel.writeAndFlush(adapterMsg));

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/adapter/AdapterChannel.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/adapter/AdapterChannel.java
@@ -15,6 +15,7 @@ package io.streamnative.pulsar.handlers.mqtt.adapter;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import io.netty.channel.Channel;
+import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.streamnative.pulsar.handlers.mqtt.Connection;
 import io.streamnative.pulsar.handlers.mqtt.exception.MQTTServerException;
 import io.streamnative.pulsar.handlers.mqtt.utils.FutureUtils;
@@ -32,15 +33,15 @@ public class AdapterChannel {
     private final MQTTProxyAdapter adapter;
     @Getter
     private final InetSocketAddress broker;
+    private final Connection connection;
     private CompletableFuture<Channel> channelFuture;
 
-    private final int keepAliveTimeSeconds;
 
     public AdapterChannel(MQTTProxyAdapter adapter, InetSocketAddress broker,
-                          int keepAliveTimeSeconds, CompletableFuture<Channel> channelFuture) {
+                          Connection connection, CompletableFuture<Channel> channelFuture) {
         this.adapter = adapter;
         this.broker = broker;
-        this.keepAliveTimeSeconds = keepAliveTimeSeconds;
+        this.connection = connection;
         this.channelFuture = channelFuture;
     }
 
@@ -57,7 +58,7 @@ public class AdapterChannel {
                 if (attempts > 5) {
                     throw new CompletionException(new MQTTServerException("Failed to reconnect adapter channel."));
                 }
-                channelFuture = adapter.getChannel(broker, keepAliveTimeSeconds);
+                channelFuture = adapter.getChannel(broker, connection);
                 return writeAndFlush(adapterMsg, attempts + 1);
             }
             return FutureUtils.completableFuture(channel.writeAndFlush(adapterMsg));


### PR DESCRIPTION
Fixes #1212


### Motivation

The keep alive had a few major flaws and would frequently cause the connection to drop. This also caused every PINGREQ to get many PINGRESP back if the proxy was forwarding the ping to many brokers. 

### Modifications

Now the keep alive is managed between the client and the proxy, and the proxy and the brokers separately using a scheduled task. This reduces the PINGRESP to 1 regardless of how many brokers are being forwarded to.


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

