### PR TITLE
Fix unsubscribe topic cause the test failed.

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTSubscriptionManager.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/MQTTSubscriptionManager.java
@@ -80,11 +80,11 @@ public class MQTTSubscriptionManager {
         subscriptions.remove(clientId);
     }
 
-    public boolean removeSubscriptionForTopic(String clientId, String topic) {
+    public void removeSubscriptionForTopic(String clientId, String topic) {
         List<MqttTopicSubscription> subscriptionsList = this.subscriptions.get(clientId);
         if (subscriptionsList == null) {
             // return false if no subscriptions are found for this client
-            return false;
+            return;
         }
         synchronized (clientId.intern()) {
             List<MqttTopicSubscription> withSubscriptionRemoved = subscriptionsList.stream()
@@ -92,11 +92,10 @@ public class MQTTSubscriptionManager {
                 .collect(Collectors.toList());
             if (withSubscriptionRemoved.size() == subscriptionsList.size()) {
                 // if no subscription is removed, return false
-                return false;
+                return;
             }
             this.subscriptions.put(clientId, withSubscriptionRemoved);
         }
-        return true;
     }
 
     private static boolean matchSubscription(String topic1, String topic2) {

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTBrokerProtocolMethodProcessor.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/MQTTBrokerProtocolMethodProcessor.java
@@ -513,11 +513,7 @@ public class MQTTBrokerProtocolMethodProcessor extends AbstractCommonProtocolMet
         final List<String> topicFilters = msg.payload().topics();
         final List<CompletableFuture<Void>> futureList = new ArrayList<>(topicFilters.size());
         for (String topicFilter : topicFilters) {
-            final boolean removed = mqttSubscriptionManager.removeSubscriptionForTopic(clientId, topicFilter);
-            if (!removed) {
-                throw new MQTTTopicNotExistedException(
-                    String.format("Can not found topic when %s unsubscribe.", clientId));
-            }
+            mqttSubscriptionManager.removeSubscriptionForTopic(clientId, topicFilter);
             metricsCollector.removeSub(topicFilter);
             CompletableFuture<List<String>> topicListFuture = PulsarTopicUtils.asyncGetTopicListFromTopicSubscription(
                     topicFilter, configuration.getDefaultTenant(), configuration.getDefaultNamespace(), pulsarService,


### PR DESCRIPTION

### Motivation

The fix of #957 cause `MQTT5ReasonCodeOnAllACKTest` fails
https://github.com/streamnative/mop/actions/runs/7357019768/job/20027990799


### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

