### PR TITLE
[test] Improve the test EventCenterTest

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/EventCenterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/EventCenterTest.java
@@ -16,8 +16,8 @@ package io.streamnative.pulsar.handlers.mqtt.base;
 import io.streamnative.pulsar.handlers.mqtt.MQTTProtocolHandler;
 import io.streamnative.pulsar.handlers.mqtt.support.event.PulsarEventCenter;
 import io.streamnative.pulsar.handlers.mqtt.support.event.PulsarTopicChangeListener;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.protocol.ProtocolHandler;
@@ -36,24 +36,24 @@ public class EventCenterTest extends MQTTTestBase {
         ProtocolHandler mqtt = pulsarService.getProtocolHandlers().protocol("mqtt");
         MQTTProtocolHandler protocolHandler = (MQTTProtocolHandler) mqtt;
         PulsarEventCenter eventCenter = protocolHandler.getMqttService().getEventCenter();
-        CompletableFuture<String> onLoadEvent = new CompletableFuture<>();
-        CompletableFuture<String> unLoadEvent = new CompletableFuture<>();
+        List<String> onLoadEvents = new ArrayList<>();
+        List<String> unLoadEvents = new ArrayList<>();
         eventCenter.register(new PulsarTopicChangeListener() {
 
             @Override
             public void onTopicLoad(TopicName topicName) {
-                onLoadEvent.complete(topicName.toString());
+                onLoadEvents.add(topicName.toString());
             }
 
             @Override
             public void onTopicUnload(TopicName topicName) {
-                unLoadEvent.complete(topicName.toString());
+                unLoadEvents.add(topicName.toString());
             }
         });
 
         admin.topics().createNonPartitionedTopic(topicName);
-        Assert.assertEquals(onLoadEvent.get(), topicName);
+        Assert.assertTrue(onLoadEvents.contains(topicName));
         admin.topics().delete(topicName);
-        Assert.assertEquals(unLoadEvent.get(), topicName);
+        Assert.assertTrue(unLoadEvents.contains(topicName));
     }
 }


### PR DESCRIPTION
### Motivation

Encounter the error, because the system topic will also be loaded.

```
[INFO] Running io.streamnative.pulsar.handlers.mqtt.base.EventCenterTest
Error:  Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 15.244 s <<< FAILURE! - in io.streamnative.pulsar.handlers.mqtt.base.EventCenterTest
Error:  testReceiveNotification(io.streamnative.pulsar.handlers.mqtt.base.EventCenterTest)  Time elapsed: 0.668 s  <<< FAILURE!
java.lang.AssertionError: expected [persistent://public/default/testEventCenter] but found [persistent://public/default/__change_events]
	at org.testng.Assert.fail(Assert.java:96)
	at org.testng.Assert.failNotEquals(Assert.java:776)
	at org.testng.Assert.assertEqualsImpl(Assert.java:137)
	at org.testng.Assert.assertEquals(Assert.java:118)
	at org.testng.Assert.assertEquals(Assert.java:453)
	at org.testng.Assert.assertEquals(Assert.java:463)
	at io.streamnative.pulsar.handlers.mqtt.base.EventCenterTest.testReceiveNotification(EventCenterTest.java:55)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:124)
	at org.testng.internal.Invoker.invokeMethod(Invoker.java:583)
	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:719)
	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:989)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:125)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:109)
	at org.testng.TestRunner.privateRun(TestRunner.java:648)
	at org.testng.TestRunner.run(TestRunner.java:505)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:455)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:450)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:415)
	at org.testng.SuiteRunner.run(SuiteRunner.java:364)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:84)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1208)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1137)
	at org.testng.TestNG.runSuites(TestNG.java:1049)
	at org.testng.TestNG.run(TestNG.java:1017)
	at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:135)
	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.executeSingleClass(TestNGDirectoryTestSuite.java:112)
	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.execute(TestNGDirectoryTestSuite.java:99)
	at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:146)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)

```

### Modifications

Improve the test EventCenterTest.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

