### PR TITLE
Fix broker enable dedup cause client publish msg NPE

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos0PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos0PublishHandler.java
@@ -36,8 +36,8 @@ public class Qos0PublishHandler extends AbstractQosPublishHandler {
         final MqttPublishMessage msg = (MqttPublishMessage) adapter.getMqttMessage();
         if (MqttUtils.isRetainedMessage(msg)) {
             return retainedMessageHandler.addRetainedMessage(msg)
-                .thenCompose(__ -> writeToPulsarTopic(connection.getTopicAliasManager(), msg).thenAccept(___ -> {}));
+                .thenCompose(__ -> writeToPulsarTopic(connection, msg).thenAccept(___ -> {}));
         }
-        return writeToPulsarTopic(connection.getTopicAliasManager(), msg).thenAccept(__ -> {});
+        return writeToPulsarTopic(connection, msg).thenAccept(__ -> {});
     }
 }

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/support/Qos1PublishHandler.java
@@ -50,11 +50,10 @@ public class Qos1PublishHandler extends AbstractQosPublishHandler {
         final CompletableFuture<Void> ret;
         if (MqttUtils.isRetainedMessage(msg)) {
             ret = retainedMessageHandler.addRetainedMessage(msg)
-                .thenCompose(__ -> writeToPulsarTopic(connection.getTopicAliasManager()
-                    , msg, !MqttUtils.isMqtt3(protocolVersion)).thenApply(___ -> null));
+                .thenCompose(__ -> writeToPulsarTopic(connection,
+                        msg, !MqttUtils.isMqtt3(protocolVersion)).thenApply(___ -> null));
         } else {
-            ret = writeToPulsarTopic(connection.getTopicAliasManager()
-                    , msg, !MqttUtils.isMqtt3(protocolVersion)).thenApply(__ -> null);
+            ret = writeToPulsarTopic(connection, msg, !MqttUtils.isMqtt3(protocolVersion)).thenApply(__ -> null);
         }
         // we need to check if subscription exist when protocol version is mqtt 5.x
         return ret

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleBrokerEnableDedupTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleBrokerEnableDedupTest.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.mqtt.mqtt3.fusesource.base;
+
+import io.streamnative.pulsar.handlers.mqtt.MQTTCommonConfiguration;
+import io.streamnative.pulsar.handlers.mqtt.base.MQTTTestBase;
+import lombok.extern.slf4j.Slf4j;
+import org.fusesource.mqtt.client.BlockingConnection;
+import org.fusesource.mqtt.client.MQTT;
+import org.fusesource.mqtt.client.Message;
+import org.fusesource.mqtt.client.QoS;
+import org.fusesource.mqtt.client.Topic;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Simple integration tests for broker enable dedup.
+ */
+@Slf4j
+public class SimpleBrokerEnableDedupTest extends MQTTTestBase {
+
+    @Override
+    protected MQTTCommonConfiguration initConfig() throws Exception {
+        MQTTCommonConfiguration mqtt = super.initConfig();
+        mqtt.setBrokerDeduplicationEnabled(true);
+        return mqtt;
+    }
+
+    @Test
+    public void testSendAndConsume() throws Exception {
+        MQTT mqtt = createMQTTClient();
+        String topicName = "testSendAndConsume";
+        BlockingConnection connection = mqtt.blockingConnection();
+        connection.connect();
+        Topic[] topics = { new Topic(topicName, QoS.AT_MOST_ONCE) };
+        connection.subscribe(topics);
+        String message = "Hello MQTT";
+        connection.publish(topicName, message.getBytes(), QoS.AT_MOST_ONCE, false);
+        Message received = connection.receive();
+        Assert.assertEquals(received.getTopic(), topicName);
+        Assert.assertEquals(new String(received.getPayload()), message);
+        received.ack();
+        connection.disconnect();
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
@@ -72,6 +72,7 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         mqtt.setMqttTlsPskEnabled(true);
         mqtt.setMqttTlsPskIdentityHint("alpha");
         mqtt.setMqttTlsPskIdentity("mqtt:mqtt123");
+        mqtt.setBrokerDeduplicationEnabled(true);
         return mqtt;
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
@@ -72,7 +72,6 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         mqtt.setMqttTlsPskEnabled(true);
         mqtt.setMqttTlsPskIdentityHint("alpha");
         mqtt.setMqttTlsPskIdentity("mqtt:mqtt123");
-        mqtt.setBrokerDeduplicationEnabled(true);
         return mqtt;
     }
 


### PR DESCRIPTION
### Motivation

When the broker enable dedup, the client will publish msg failed due to not set producerName.
```
20:18:21.791 [pulsar-ph-mqtt-36-1:io.streamnative.pulsar.handlers.mqtt.support.MQTTBrokerProtocolMethodProcessor@199] ERROR io.streamnative.pulsar.handlers.mqtt.support.MQTTBrokerProtocolMethodProcessor - [Publish] [a/b/c] Write MqttPublishMessage[fixedHeader=MqttFixedHeader[messageType=PUBLISH, isDup=false, qosLevel=AT_MOST_ONCE, isRetain=false, remainingLength=17], variableHeader=MqttPublishVariableHeader[topicName=a/b/c, packetId=-1], payload=UnpooledSlicedByteBuf(ridx: 0, widx: 10, cap: 10/10, unwrapped: UnpooledByteBufAllocator$InstrumentedUnpooledUnsafeDirectByteBuf(ridx: 19, widx: 19, cap: 8192))] to Pulsar topic failed.
java.lang.NullPointerException: Cannot invoke "String.startsWith(String)" because "producerName" is null
	at org.apache.pulsar.broker.service.persistent.MessageDeduplication.isDuplicate(MessageDeduplication.java:334) ~[pulsar-broker-3.2.0-20240122.091046-19.jar:3.2.0-SNAPSHOT]
	at org.apache.pulsar.broker.service.persistent.PersistentTopic.publishMessage(PersistentTopic.java:537) ~[pulsar-broker-3.2.0-20240122.091046-19.jar:3.2.0-SNAPSHOT]
	at io.streamnative.pulsar.handlers.mqtt.utils.MessagePublishContext.publishMessages(MessagePublishContext.java:100) ~[classes/:?]
	at io.streamnative.pulsar.handlers.mqtt.AbstractQosPublishHandler.lambda$writeToPulsarTopic$2(AbstractQosPublishHandler.java:105) ~[classes/:?]
	at java.util.Optional.map(Optional.java:260) ~[?:?]
```



### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

