### PR TITLE
fix a ClassCastException when scheduling to look up

### DIFF
--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/PulsarServiceLookupHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/PulsarServiceLookupHandler.java
@@ -37,6 +37,7 @@ import org.apache.pulsar.client.impl.BackoffBuilder;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.client.util.ExecutorProvider;
+import org.apache.pulsar.client.util.ScheduledExecutorProvider;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.metadata.api.MetadataCache;
@@ -58,7 +59,7 @@ public class PulsarServiceLookupHandler implements LookupHandler {
     public PulsarServiceLookupHandler(PulsarService pulsarService, MQTTProxyConfiguration proxyConfig) {
         this.pulsarService = pulsarService;
         this.proxyConfig = proxyConfig;
-        this.executorProvider = new ExecutorProvider(proxyConfig.getLookupThreadPoolNum(), "mop-lookup-thread");
+        this.executorProvider = new ScheduledExecutorProvider(proxyConfig.getLookupThreadPoolNum(), "mop-lookup-thread");
         this.localBrokerDataCache = pulsarService
                 .getLocalMetadataStore().getMetadataCache(LocalBrokerData.class);
         this.pulsarClient = getClient(proxyConfig);

--- a/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/PulsarServiceLookupHandler.java
+++ b/mqtt-impl/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/PulsarServiceLookupHandler.java
@@ -59,7 +59,8 @@ public class PulsarServiceLookupHandler implements LookupHandler {
     public PulsarServiceLookupHandler(PulsarService pulsarService, MQTTProxyConfiguration proxyConfig) {
         this.pulsarService = pulsarService;
         this.proxyConfig = proxyConfig;
-        this.executorProvider = new ScheduledExecutorProvider(proxyConfig.getLookupThreadPoolNum(), "mop-lookup-thread");
+        this.executorProvider = new ScheduledExecutorProvider(proxyConfig.getLookupThreadPoolNum(),
+                                                              "mop-lookup-thread");
         this.localBrokerDataCache = pulsarService
                 .getLocalMetadataStore().getMetadataCache(LocalBrokerData.class);
         this.pulsarClient = getClient(proxyConfig);


### PR DESCRIPTION
### Motivation

`new ExecutorProvider(proxyConfig.getLookupThreadPoolNum(), "mop-lookup-thread") ;`
It will create a FinalizableDelegatedExecutorService

`(ScheduledExecutorService) executorProvider.getExecutor();`

It can't be cast to a ScheduledExecutorService, and it will create a RuntimeException without catch, which is also blocking the proxy thread

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

