### PR TITLE
Add jackson dependency to avoid compile issue.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <hivemq.mqtt.client.version>1.2.2</hivemq.mqtt.client.version>
         <apache.commons.bean-utils.version>1.9.4</apache.commons.bean-utils.version>
         <grpc.version>1.45.1</grpc.version>
+        <jackson.version>2.14.2</jackson.version>
         <!-- plugins -->
         <javac.target>1.8</javac.target>
         <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>
@@ -91,6 +92,10 @@
                     <groupId>io.grpc</groupId>
                     <artifactId>grpc-auth</artifactId>
                 </exclusion>
+                <exclusion>
+                  <artifactId>jersey-media-json-jackson</artifactId>
+                  <groupId>org.glassfish.jersey.media</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -99,6 +104,14 @@
             <artifactId>grpc-all</artifactId>
             <version>${grpc.version}</version>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>com.fasterxml.jackson</groupId>
+          <artifactId>jackson-bom</artifactId>
+          <version>${jackson.version}</version>
+          <type>pom</type>
+          <scope>import</scope>
         </dependency>
 
         <dependency>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -41,6 +41,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.streamnative</groupId>
             <artifactId>pulsar-broker</artifactId>
             <version>${pulsar.version}</version>


### PR DESCRIPTION

### Motivation

https://github.com/streamnative/mop/actions/runs/10384444156/job/28751852979?pr=1404

![image](https://github.com/user-attachments/assets/0fcff682-cebc-47e9-a77f-8140c34ee74e)

The root cause is that, MoP  relied on jackson from Pulsar, but `jersey-media-json-jackson` upgrade to a high version and cause the `jackson-databind` to 2.16.2. so there throw `NoSuchMethodError `. 
`EnumResolver.constructUsingToString` should be under 2.14

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

