### PR TITLE
Upgrade artifact github action version

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -105,7 +105,7 @@ jobs:
         run: ./scripts/retry.sh mvn -B -ntp test -Dtest=${{ matrix.test }} -DfailIfNoTests=false
 
       - name: Upload jacoco artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.test }}-jacoco-artifact
           path: '**/*.exec'
@@ -118,7 +118,7 @@ jobs:
           mkdir artifacts
           find . -type d -name "*surefire*" -exec cp --parents -R {} artifacts/ \;
           zip -r ${{ matrix.test }}-artifacts.zip artifacts
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         name: upload surefire-artifacts
         if: failure()
         with:
@@ -149,7 +149,7 @@ jobs:
         run: mvn clean install -DskipTests
 
       - name: Download jacoco artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: mqtt-broker/target
 


### PR DESCRIPTION

### Motivation

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

```
### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

