### PR TITLE
Fix connection event error

### DIFF
--- a/mqtt-common/src/main/java/io/streamnative/pulsar/handlers/mqtt/common/MQTTConnectionManager.java
+++ b/mqtt-common/src/main/java/io/streamnative/pulsar/handlers/mqtt/common/MQTTConnectionManager.java
@@ -21,8 +21,9 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 import io.streamnative.pulsar.handlers.mqtt.common.systemtopic.ConnectEvent;
 import io.streamnative.pulsar.handlers.mqtt.common.systemtopic.EventListener;
 import io.streamnative.pulsar.handlers.mqtt.common.systemtopic.MqttEvent;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -35,6 +36,8 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class MQTTConnectionManager {
+
+    private static final Connection REMOTE_CONNECTION_SOLT = Connection.builder().build();
 
     private final ConcurrentMap<String, Connection> localConnections;
 
@@ -102,11 +105,11 @@ public class MQTTConnectionManager {
         return this.localConnections.values();
     }
 
-    public Collection<Connection> getAllConnections() {
-        Collection<Connection> connections = new ArrayList<>(this.localConnections.values().size()
-                    + this.eventConnections.values().size());
-        connections.addAll(this.localConnections.values());
-        connections.addAll(eventConnections.values());
+    public Collection<String> getAllConnectionsId() {
+        Set<String> connections = new LinkedHashSet<>(this.localConnections.keySet().size()
+                    + this.eventConnections.keySet().size());
+        connections.addAll(this.localConnections.keySet());
+        connections.addAll(eventConnections.keySet());
         return connections;
     }
 
@@ -126,7 +129,7 @@ public class MQTTConnectionManager {
                         log.warn("[ConnectEvent] close existing connection : {}", connection);
                         connection.disconnect();
                     } else {
-                        eventConnections.put(connectEvent.getClientId(), connection);
+                        eventConnections.put(connectEvent.getClientId(), REMOTE_CONNECTION_SOLT);
                     }
                 }
             }

--- a/mqtt-common/src/main/java/io/streamnative/pulsar/handlers/mqtt/common/systemtopic/SystemTopicBasedSystemEventService.java
+++ b/mqtt-common/src/main/java/io/streamnative/pulsar/handlers/mqtt/common/systemtopic/SystemTopicBasedSystemEventService.java
@@ -237,7 +237,13 @@ public class SystemTopicBasedSystemEventService implements SystemEventService {
                 default:
                     break;
             }
-            listeners.forEach(listener -> listener.onChange(value));
+            listeners.forEach(listener -> {
+                try {
+                    listener.onChange(value);
+                } catch (Throwable e) {
+                    log.error("Failed to process event : {}", value.getKey(), e);
+                }
+            });
         } catch (Throwable ex) {
             log.error("refresh cache error", ex);
         }

--- a/mqtt-proxy/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/web/admin/Devices.java
+++ b/mqtt-proxy/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/web/admin/Devices.java
@@ -45,9 +45,8 @@ public class Devices extends WebResource {
             @ApiResponse(code = 500, message = "Internal server error")})
     public void getList(@Suspended final AsyncResponse asyncResponse) {
         try {
-            final Collection<Connection> allConnections = service().getConnectionManager().getAllConnections();
-            asyncResponse.resume(allConnections.stream().map(e ->
-                    e.getClientId()).collect(Collectors.toList()));
+            final Collection<String> allConnections = service().getConnectionManager().getAllConnectionsId();
+            asyncResponse.resume(allConnections);
         } catch (Exception e) {
             log.error("[{}] Failed to list devices {}", clientAppId(), e);
             asyncResponse.resume(new RestException(e));

--- a/mqtt-proxy/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/web/admin/Devices.java
+++ b/mqtt-proxy/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/web/admin/Devices.java
@@ -13,13 +13,11 @@
  */
 package io.streamnative.pulsar.handlers.mqtt.proxy.web.admin;
 
-import io.streamnative.pulsar.handlers.mqtt.common.Connection;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import java.util.Collection;
-import java.util.stream.Collectors;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

```java
2025-04-29T14:35:42,091+0000 [broker-client-shared-internal-executor-5-1] ERROR io.streamnative.pulsar.handlers.mqtt.common.systemtopic.SystemTopicBasedSystemEventService - refresh cache error
java.lang.NullPointerException: null
	at java.base/java.util.concurrent.ConcurrentHashMap.putVal(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.ConcurrentHashMap.put(Unknown Source) ~[?:?]
	at io.streamnative.pulsar.handlers.mqtt.common.MQTTConnectionManager$ConnectEventListener.onChange(MQTTConnectionManager.java:129) ~[?:?]
	at io.streamnative.pulsar.handlers.mqtt.common.systemtopic.SystemTopicBasedSystemEventService.lambda$refreshCache$14(SystemTopicBasedSystemEventService.java:240) ~[?:?]
	at java.base/java.util.ArrayList.forEach(Unknown Source) ~[?:?]
	at io.streamnative.pulsar.handlers.mqtt.common.systemtopic.SystemTopicBasedSystemEventService.refreshCache(SystemTopicBasedSystemEventService.java:240) ~[?:?]
	at io.streamnative.pulsar.handlers.mqtt.common.systemtopic.SystemTopicBasedSystemEventService.lambda$readEvent$13(SystemTopicBasedSystemEventService.java:196) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.complete(Unknown Source) ~[?:?]
	at org.apache.pulsar.client.impl.ConsumerBase.lambda$completePendingReceive$0(ConsumerBase.java:330) ~[io.streamnative-pulsar-client-original-3.3.5.5.jar:3.3.5.5]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) ~[?:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[io.netty-netty-common-4.1.119.Final.jar:4.1.119.Final]
	at java.base/java.lang.Thread.run(Unknown Source) [?:?]
```

Master Issue: #<xyz>

### Motivation

Using `REMOTE_CONNECTION_SOLT` instead of  nll value， since ConcurrentMap can't allow null value

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

