### PR TITLE
Fix MQTT message error handling and improve connection responses

### DIFF
--- a/mqtt-common/src/main/java/io/streamnative/pulsar/handlers/mqtt/common/MQTTCommonInboundHandler.java
+++ b/mqtt-common/src/main/java/io/streamnative/pulsar/handlers/mqtt/common/MQTTCommonInboundHandler.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.mqtt.MqttConnectVariableHeader;
 import io.netty.handler.codec.mqtt.MqttMessage;
 import io.netty.handler.codec.mqtt.MqttMessageType;
+import io.netty.handler.codec.mqtt.MqttVersion;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.ReferenceCountUtil;
@@ -115,7 +116,7 @@ public class MQTTCommonInboundHandler extends ChannelInboundHandlerAdapter {
             ReferenceCountUtil.safeRelease(mqttMessage);
             log.warn("Invalid MQTT message state: {}", ex.getMessage());
 
-            int protocolVersion = 4;
+            int protocolVersion = MqttVersion.MQTT_3_1.protocolLevel();
             try {
                 Connection existingConnection = NettyUtils.getConnection(ctx.channel());
                 if (existingConnection != null) {

--- a/mqtt-common/src/main/java/io/streamnative/pulsar/handlers/mqtt/common/MQTTCommonInboundHandler.java
+++ b/mqtt-common/src/main/java/io/streamnative/pulsar/handlers/mqtt/common/MQTTCommonInboundHandler.java
@@ -114,7 +114,8 @@ public class MQTTCommonInboundHandler extends ChannelInboundHandlerAdapter {
             }
         } catch (IllegalStateException ex) {
             ReferenceCountUtil.safeRelease(mqttMessage);
-            log.warn("Invalid MQTT message state: {}", ex.getMessage());
+            MqttMessageType mqttMessageType = mqttMessage.fixedHeader().messageType();
+            log.warn("Invalid MQTT message state: {}, mqttMessageType:{}", ex.getMessage(), mqttMessageType);
 
             int protocolVersion = MqttVersion.MQTT_3_1.protocolLevel();
             try {
@@ -125,7 +126,6 @@ public class MQTTCommonInboundHandler extends ChannelInboundHandlerAdapter {
             } catch (Exception e) {
             }
 
-            MqttMessageType mqttMessageType = mqttMessage.fixedHeader().messageType();
             if (mqttMessageType == MqttMessageType.CONNECT) {
                 MqttConnectVariableHeader connectVariableHeader =
                     (MqttConnectVariableHeader) mqttMessage.variableHeader();

--- a/mqtt-common/src/main/java/io/streamnative/pulsar/handlers/mqtt/common/MQTTCommonInboundHandler.java
+++ b/mqtt-common/src/main/java/io/streamnative/pulsar/handlers/mqtt/common/MQTTCommonInboundHandler.java
@@ -19,12 +19,17 @@ import static io.streamnative.pulsar.handlers.mqtt.common.utils.MqttMessageUtils
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.mqtt.MqttConnectVariableHeader;
 import io.netty.handler.codec.mqtt.MqttMessage;
 import io.netty.handler.codec.mqtt.MqttMessageType;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.ReferenceCountUtil;
 import io.streamnative.pulsar.handlers.mqtt.common.adapter.MqttAdapterMessage;
+import io.streamnative.pulsar.handlers.mqtt.common.messages.ack.MqttAck;
+import io.streamnative.pulsar.handlers.mqtt.common.messages.ack.MqttConnectAck;
+import io.streamnative.pulsar.handlers.mqtt.common.messages.ack.MqttDisconnectAck;
+import io.streamnative.pulsar.handlers.mqtt.common.messages.codes.mqtt5.Mqtt5DisConnReasonCode;
 import io.streamnative.pulsar.handlers.mqtt.common.utils.NettyUtils;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.extern.slf4j.Slf4j;
@@ -106,6 +111,50 @@ public class MQTTCommonInboundHandler extends ChannelInboundHandlerAdapter {
                 default:
                     throw new UnsupportedOperationException("Unknown MessageType: " + messageType);
             }
+        } catch (IllegalStateException ex) {
+            ReferenceCountUtil.safeRelease(mqttMessage);
+            log.warn("Invalid MQTT message state: {}", ex.getMessage());
+
+            int protocolVersion = 4;
+            try {
+                Connection existingConnection = NettyUtils.getConnection(ctx.channel());
+                if (existingConnection != null) {
+                    protocolVersion = existingConnection.getProtocolVersion();
+                }
+            } catch (Exception e) {
+            }
+
+            MqttMessageType mqttMessageType = mqttMessage.fixedHeader().messageType();
+            if (mqttMessageType == MqttMessageType.CONNECT) {
+                MqttConnectVariableHeader connectVariableHeader =
+                    (MqttConnectVariableHeader) mqttMessage.variableHeader();
+                protocolVersion = connectVariableHeader.version();
+
+                // For CONNECT message errors, send a CONNACK error response.
+                MqttMessage errorResponse = MqttConnectAck.errorBuilder().protocolError(protocolVersion);
+                MqttAdapterMessage errorAdapterMsg = new MqttAdapterMessage(
+                        adapterMsg.getClientId(),
+                        errorResponse,
+                        adapterMsg.fromProxy()
+                );
+                ctx.writeAndFlush(errorAdapterMsg);
+            } else {
+                // For other message errors, send a DISCONNECT error response if supported.
+                MqttAck errorAck = MqttDisconnectAck.errorBuilder(protocolVersion)
+                        .reasonCode(Mqtt5DisConnReasonCode.MALFORMED_PACKET)
+                        .reasonString("Invalid message format: " + ex.getMessage())
+                        .build();
+
+                if (errorAck.isProtocolSupported()) {
+                    MqttAdapterMessage errorAdapterMsg = new MqttAdapterMessage(
+                            adapterMsg.getClientId(),
+                            errorAck.getMqttMessage(),
+                            adapterMsg.fromProxy()
+                    );
+                    ctx.writeAndFlush(errorAdapterMsg);
+                }
+            }
+            ctx.close();
         } catch (Throwable ex) {
             ReferenceCountUtil.safeRelease(mqttMessage);
             log.error("Exception was caught while processing MQTT message, ", ex);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MessageConverTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/base/MessageConverTest.java
@@ -27,7 +27,7 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.common.naming.TopicDomain;
-import org.junit.Assert;
+import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
@@ -91,20 +91,6 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         connection.disconnect();
     }
 
-//    @Test(timeOut = TIMEOUT)
-//    public void testInvalidClientId() throws Exception {
-//        MQTT mqtt = createMQTTClient();
-//        mqtt.setClientId("7e8dae24-33c9-41f7-af10-334c4480348b_mqtt-test-6c8b");
-//        BlockingConnection connection = mqtt.blockingConnection();
-//        try {
-//            connection.connect();
-//            Assert.fail();
-//        } catch (Exception exception) {
-//            log.info("Expected exception: {}", exception.getMessage());
-//        }
-//        connection.disconnect();
-//    }
-
     @Test(dataProvider = "mqttTopicNames", timeOut = TIMEOUT)
     public void testSimpleMqttPubAndSubQos1(String topicName) throws Exception {
         MQTT mqtt = createMQTTClient();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/mqtt/mqtt3/fusesource/base/SimpleIntegrationTest.java
@@ -26,7 +26,6 @@ import io.streamnative.pulsar.handlers.mqtt.common.MQTTCommonConfiguration;
 import io.streamnative.pulsar.handlers.mqtt.common.utils.PulsarTopicUtils;
 import io.streamnative.pulsar.handlers.mqtt.mqtt3.fusesource.psk.PSKClient;
 import java.io.BufferedReader;
-import java.io.EOFException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
@@ -50,6 +49,7 @@ import org.apache.pulsar.common.policies.data.TopicStats;
 import org.awaitility.Awaitility;
 import org.fusesource.mqtt.client.BlockingConnection;
 import org.fusesource.mqtt.client.MQTT;
+import org.fusesource.mqtt.client.MQTTException;
 import org.fusesource.mqtt.client.Message;
 import org.fusesource.mqtt.client.QoS;
 import org.fusesource.mqtt.client.Topic;
@@ -90,6 +90,20 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         received.ack();
         connection.disconnect();
     }
+
+//    @Test(timeOut = TIMEOUT)
+//    public void testInvalidClientId() throws Exception {
+//        MQTT mqtt = createMQTTClient();
+//        mqtt.setClientId("7e8dae24-33c9-41f7-af10-334c4480348b_mqtt-test-6c8b");
+//        BlockingConnection connection = mqtt.blockingConnection();
+//        try {
+//            connection.connect();
+//            Assert.fail();
+//        } catch (Exception exception) {
+//            log.info("Expected exception: {}", exception.getMessage());
+//        }
+//        connection.disconnect();
+//    }
 
     @Test(dataProvider = "mqttTopicNames", timeOut = TIMEOUT)
     public void testSimpleMqttPubAndSubQos1(String topicName) throws Exception {
@@ -374,14 +388,19 @@ public class SimpleIntegrationTest extends MQTTTestBase {
         connection2.disconnect();
     }
 
-    @Test(expectedExceptions = {EOFException.class, IllegalStateException.class})
+    @Test(expectedExceptions = {MQTTException.class},
+        expectedExceptionsMessageRegExp = ".*CONNECTION_REFUSED_SERVER_UNAVAILABLE.*")
     public void testInvalidClientId() throws Exception {
         MQTT mqtt = createMQTTClient();
-        mqtt.setConnectAttemptsMax(1);
         // ClientId is invalid, for max length is 23 in mqtt 3.1
         mqtt.setClientId(UUID.randomUUID().toString().replace("-", ""));
         BlockingConnection connection = Mockito.spy(mqtt.blockingConnection());
-        connection.connect();
+        try {
+            connection.connect();
+        } catch (Exception ex) {
+            log.info("Expected exception: {}", ex.getMessage());
+            throw ex; // rethrow to verify the exception
+        }
         verify(connection, Mockito.times(2)).connect();
     }
 


### PR DESCRIPTION
### Motivation

Currently, when there is an exception in checking the connect message, we directly close the channel. However, the client might keep retrying indefinitely. It's best for us to return a connection error to the client.

### Modifications

For CONNECT message errors, send a CONNACK error response then close channel.
For other message errors, send a DISCONNECT error response if supported then close channel.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

