### PR TITLE
Fix mqtt disconnect due to appId permission bug when namespace policies update

### DIFF
--- a/mqtt-broker/src/main/java/io/streamnative/pulsar/handlers/mqtt/broker/impl/consumer/MQTTConsumer.java
+++ b/mqtt-broker/src/main/java/io/streamnative/pulsar/handlers/mqtt/broker/impl/consumer/MQTTConsumer.java
@@ -72,7 +72,7 @@ public class MQTTConsumer extends Consumer {
                         MQTTServerCnx cnx, MqttQoS qos, PacketIdGenerator packetIdGenerator,
                         OutstandingPacketContainer outstandingPacketContainer, MQTTMetricsCollector metricsCollector) {
         super(subscription, CommandSubscribe.SubType.Shared, pulsarTopicName, 0, 0,
-                connection.getClientId(), true, cnx, "", null, false,
+                connection.getClientId(), true, cnx, connection.getUserRole(), null, false,
                 null, MessageId.latest, Commands.DEFAULT_CONSUMER_EPOCH);
         this.pulsarTopicName = pulsarTopicName;
         this.mqttTopicName = mqttTopicName;


### PR DESCRIPTION
### Motivation

MQTTConsumer appId field is equivalent to the userRole in Authentication. The appId field will be used to do checkPermissionsAsync when namespace policies update.
https://github.com/apache/pulsar/blob/0a949de4bfa3734194be87a8655763a4411be1b6/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java#L1042-L1044

### Modifications

Before: appId is set to ""
After: appId is set to connection.getUserRole()

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

