### PR TITLE
Fix MQTTProxyProtocolMethodProcessor processPingReq not respond bug

### DIFF
--- a/mqtt-proxy/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/impl/MQTTProxyProtocolMethodProcessor.java
+++ b/mqtt-proxy/src/main/java/io/streamnative/pulsar/handlers/mqtt/proxy/impl/MQTTProxyProtocolMethodProcessor.java
@@ -16,6 +16,7 @@ package io.streamnative.pulsar.handlers.mqtt.proxy.impl;
 import static io.streamnative.pulsar.handlers.mqtt.common.utils.MqttMessageUtils.createMqtt5ConnectMessage;
 import static io.streamnative.pulsar.handlers.mqtt.common.utils.MqttMessageUtils.createMqttPublishMessage;
 import static io.streamnative.pulsar.handlers.mqtt.common.utils.MqttMessageUtils.createMqttSubscribeMessage;
+import static io.streamnative.pulsar.handlers.mqtt.common.utils.MqttMessageUtils.pingResp;
 import com.google.common.collect.Lists;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
@@ -62,6 +63,7 @@ import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
@@ -243,6 +245,10 @@ public class MQTTProxyProtocolMethodProcessor extends AbstractCommonProtocolMeth
     @Override
     public void processPingReq(final MqttAdapterMessage msg) {
         String clientId = connection.getClientId();
+        if (MapUtils.isEmpty(topicBrokers)) {
+            connection.send(pingResp());
+            return;
+        }
         topicBrokers.values().forEach(adapterChannel -> {
             adapterChannel.thenAccept(channel -> {
                 msg.setClientId(clientId);


### PR DESCRIPTION
### Motivation

If a mqtt client connects mop without sending any message or subscribing any topic, the mqtt client will get keep-alive timeout error due to Proxy not send any pingResp to the client.

### Modifications

Send a pingResp even when topicBrokers is empty.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

